### PR TITLE
Use make clean-up-namespace job for CI pipelines

### DIFF
--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -1,6 +1,5 @@
 name: Nightly E2E tests on GKE
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -1,5 +1,6 @@
 name: Nightly E2E tests on GKE
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"
@@ -119,40 +120,7 @@ jobs:
       - name: Clean up after Tests
         if: always()
         run: |
-          hz=$(kubectl get hazelcast -o name); [[ "$hz" != "" ]] && kubectl delete $hz --wait=false \
-            || echo "no hazelcast resources"
-          mc=$(kubectl get managementcenter -o name); [[ "$mc" != "" ]] && kubectl delete $mc --wait=false \
-            || echo "no managementcenter resources"
-          if [[ ${{ steps.e2e-test.outcome }} != 'success' ]]; then
-            i=0
-            while ! kubectl rollout status deployment $DEPLOY_NAME; do
-              kubectl rollout restart deployment $DEPLOY_NAME
-              if [[ $i == 2 ]]; then
-                echo "Failure testing the operator, namespace $NAMESPACE requires manual clean up"
-                exit 1
-              fi
-              ((i++))
-            done
-          fi
-          sleep 10
-
-          hz=$(kubectl get hazelcast -o name)
-          mc=$(kubectl get managementcenter -o name)
-          if [[ $hz != "" ]] || [[ $mc != "" ]]; then
-            echo -n "Failure deleting hazelcast and managementcenter resources, "
-            echo "namespace $NAMESPACE requires manual clean up"
-            exit 1
-          fi
-
-          if [[ ${{ matrix.edition }} == 'ee' ]]; then
-            kubectl delete secret hazelcast-license-key --wait=false
-          fi
-          make undeploy-keep-crd
-
-          kubectl delete pvc -l app.kubernetes.io/managed-by=hazelcast-platform-operator --wait=true --timeout=1m
-          kubectl delete svc -l app.kubernetes.io/managed-by=hazelcast-platform-operator --wait=true --timeout=4m
-
-          kubectl delete namespace $NAMESPACE --wait=true --timeout=1m
+          make clean-up-namespace NAMESPACE=${NAMESPACE}
 
   delete-cluster:
     name: Run E2E tests

--- a/.github/workflows/nightly-e2e-ocp.yaml
+++ b/.github/workflows/nightly-e2e-ocp.yaml
@@ -1,6 +1,5 @@
 name: Nightly E2E tests on OCP
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"

--- a/.github/workflows/nightly-e2e-ocp.yaml
+++ b/.github/workflows/nightly-e2e-ocp.yaml
@@ -67,4 +67,4 @@ jobs:
       - name: Clean up after Tests
         if: always()
         run: |
-          make clean-up-namespace NAMESPACE=${NAMESPACE}
+          make clean-up-namespace KUBECTL=oc NAMESPACE=${NAMESPACE}

--- a/.github/workflows/nightly-e2e-ocp.yaml
+++ b/.github/workflows/nightly-e2e-ocp.yaml
@@ -1,5 +1,6 @@
 name: Nightly E2E tests on OCP
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"
@@ -66,36 +67,4 @@ jobs:
       - name: Clean up after Tests
         if: always()
         run: |
-          DEPLOY_NAME=${NAME_PREFIX}controller-manager
-
-          hz=$(oc get hazelcast -o name)
-          [[ "$hz" != "" ]] && oc delete $hz --wait=false || echo "no hazelcast resources"
-
-          mc=$(oc get managementcenter -o name)
-          [[ "$mc" != "" ]] && oc delete $mc --wait=false || echo "no managementcenter resources"
-
-          if [[ ${{ steps.e2e-test.outcome }} != 'success' ]]; then
-            i=0
-            while ! oc rollout status deployment $DEPLOY_NAME; do
-              oc rollout restart deployment $DEPLOY_NAME
-              if [[ $i == 2 ]]; then
-                echo "Failure testing the operator, namespace $NAMESPACE requires manual clean up"
-                exit 1
-              fi
-              ((i++))
-            done
-          fi
-          sleep 10
-
-          hz=$(oc get hazelcast -o name)
-          mc=$(oc get managementcenter -o name)
-          if [[ $hz != "" ]] || [[ $mc != "" ]]; then
-            echo "Failure deleting hazelcast and managementcenter resources, \
-              namespace $NAMESPACE requires manual clean up"; exit 1
-          fi
-
-          if [[ ${{ matrix.edition }} == 'ee' ]]; then
-            oc delete secret hazelcast-license-key --wait=false
-          fi
-          make undeploy-keep-crd
-          oc delete project $NAMESPACE --wait=false
+          make clean-up-namespace NAMESPACE=${NAMESPACE}


### PR DESCRIPTION
Example of run job on OCP: https://github.com/hazelcast/hazelcast-platform-operator/actions/runs/1605940365
Example of run job on GKE: https://github.com/hazelcast/hazelcast-platform-operator/actions/runs/1605940364