### PR TITLE
Fix fork PR builder workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -252,40 +252,8 @@ jobs:
       - name: Clean up after Tests
         if: always()
         run: |
-          hz=$(kubectl get hazelcast -o name); [[ "$hz" != "" ]] && kubectl delete $hz --wait=false \
-            || echo "no hazelcast resources"
-          mc=$(kubectl get managementcenter -o name); [[ "$mc" != "" ]] && kubectl delete $mc --wait=false \
-            || echo "no managementcenter resources"
-          if [[ ${{ steps.e2e-test.outcome }} != 'success' ]]; then
-            i=0
-            while ! kubectl rollout status deployment $DEPLOY_NAME; do
-              kubectl rollout restart deployment $DEPLOY_NAME
-              if [[ $i == 2 ]]; then
-                echo "Failure testing the operator, namespace $NAMESPACE requires manual clean up"
-                exit 1
-              fi
-              ((i++))
-            done
-          fi
-          sleep 10
+          make clean-up-namespace NAMESPACE=${NAMESPACE}
 
-          hz=$(kubectl get hazelcast -o name)
-          mc=$(kubectl get managementcenter -o name)
-          if [[ $hz != "" ]] || [[ $mc != "" ]]; then
-            echo -n "Failure deleting hazelcast and managementcenter resources, "
-            echo "namespace $NAMESPACE requires manual clean up"
-            exit 1
-          fi
-
-          if [[ ${{ matrix.edition }} == 'ee' ]]; then
-            kubectl delete secret hazelcast-license-key --wait=false
-          fi
-          make undeploy-keep-crd
-
-          kubectl delete pvc -l app.kubernetes.io/managed-by=hazelcast-platform-operator --wait=true --timeout=1m
-          kubectl delete svc -l app.kubernetes.io/managed-by=hazelcast-platform-operator --wait=true --timeout=4m
-
-          kubectl delete namespace $NAMESPACE --wait=true --timeout=1m
 
   delete-cluster:
     name: Delete Cluster

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,6 @@ jobs:
     name: Run unit and integration tests
     runs-on: ubuntu-20.04
     needs: linter
-    if: github.event_name == 'pull_request' && needs.linter.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -90,6 +89,7 @@ jobs:
     name: Create GKE cluster and push image
     runs-on: ubuntu-20.04
     if: >-
+      always() && (
       (github.event_name == 'pull_request_target'
         && github.event.action == 'labeled'
         && github.event.label.name == 'safe-to-test'
@@ -97,7 +97,7 @@ jobs:
       ||
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && needs.unit-tests.result == 'success')
+        && needs.unit-tests.result == 'success') )
     needs: unit-tests
     outputs:
       CLUSTER_NAME: ${{ steps.set-cluster-name.outputs.CLUSTER_NAME }}
@@ -163,6 +163,7 @@ jobs:
     name: Run E2E tests
     runs-on: ubuntu-20.04
     needs: create-gke-cluster
+    if: always() && needs.create-gke-cluster.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -289,7 +290,7 @@ jobs:
   delete-cluster:
     name: Delete Cluster
     runs-on: ubuntu-20.04
-    if: always()
+    if: always() && needs.create-gke-cluster.result != 'skipped'
     needs: [ create-gke-cluster, gke-e2e-tests ]
     env:
       CLUSTER_NAME: ${{ needs.create-gke-cluster.outputs.CLUSTER_NAME }}


### PR DESCRIPTION
Our PR builders were working correctly for PRs created in the main repository. However, the `safe-to-test` trigger was not working correctly for fork PRs. The reason is that E2E test jobs are in the middle of the job prerequisite graph and in the default settings jobs expect all the prerequisite jobs to be completed successfully. For label event trigger, the E2E jobs don't get triggered because we are skipping `linter` and `unit & integration test` jobs. To fix this, we need to ad `always()` function together with the correct conditions