### PR TITLE
Change repository default in CRD

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -29,7 +29,7 @@ type HazelcastSpec struct {
 	ClusterSize int32 `json:"clusterSize"`
 
 	// Repository to pull the Hazelcast Platform image from.
-	// +kubebuilder:default:="docker.io/hazelcast/hazelcast-enterprise"
+	// +kubebuilder:default:="docker.io/hazelcast/hazelcast"
 	// +optional
 	Repository string `json:"repository"`
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -77,7 +77,7 @@ spec:
                 description: Name of the secret with Hazelcast Enterprise License Key.
                 type: string
               repository:
-                default: docker.io/hazelcast/hazelcast-enterprise
+                default: docker.io/hazelcast/hazelcast
                 description: Repository to pull the Hazelcast Platform image from.
                 type: string
               scheduling:

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -93,7 +93,7 @@ spec:
                   Key.
                 type: string
               repository:
-                default: docker.io/hazelcast/hazelcast-enterprise
+                default: docker.io/hazelcast/hazelcast
                 description: Repository to pull the Hazelcast Platform image from.
                 type: string
               scheduling:


### PR DESCRIPTION
Changes the default value of the repository field in OpenAPI spec to OS Hazelcast