### PR TITLE
[CN-262] Add Kubernetes provider info into platform struct

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,10 +70,10 @@ jobs:
         run: make test-unit
 
       - name: Run integration tests (OS)
-        run: make GO_TEST_TAGS=os test-it
+        run: make GO_TEST_FLAGS="-ee=false" test-it
 
       - name: Run integration tests (EE)
-        run: make GO_TEST_TAGS=ee test-it
+        run: make GO_TEST_FLAGS="-ee=true" test-it
 
       - name: Check if bundle.yaml is updated
         run: |

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -123,11 +123,7 @@ func (r *HazelcastReconciler) reconcileClusterRole(ctx context.Context, h *hazel
 		},
 	}
 
-	pt, err := platform.GetType()
-	if err != nil {
-		return err
-	}
-	if pt == platform.OpenShift {
+	if platform.GetType() == platform.OpenShift {
 		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"security.openshift.io"},
 			Resources: []string{"securitycontextconstraints"},

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -29,12 +29,7 @@ const (
 )
 
 func (r *ManagementCenterReconciler) reconcileRole(ctx context.Context, mc *hazelcastv1alpha1.ManagementCenter, logger logr.Logger) error {
-	pt, err := platform.GetType()
-	if err != nil {
-		return err
-	}
-
-	if pt == platform.Kubernetes {
+	if platform.GetType() == platform.Kubernetes {
 		return nil
 	}
 
@@ -49,7 +44,7 @@ func (r *ManagementCenterReconciler) reconcileRole(ctx context.Context, mc *haze
 		},
 	}
 
-	err = controllerutil.SetControllerReference(mc, role, r.Scheme)
+	err := controllerutil.SetControllerReference(mc, role, r.Scheme)
 	if err != nil {
 		logger.Error(err, "Failed to set owner reference on Role")
 		return err
@@ -65,10 +60,7 @@ func (r *ManagementCenterReconciler) reconcileRole(ctx context.Context, mc *haze
 }
 
 func (r *ManagementCenterReconciler) reconcileServiceAccount(ctx context.Context, mc *hazelcastv1alpha1.ManagementCenter, logger logr.Logger) error {
-	pt, err := platform.GetType()
-	if err != nil {
-		return err
-	}
+	pt := platform.GetType()
 
 	if pt == platform.Kubernetes {
 		return nil
@@ -78,7 +70,7 @@ func (r *ManagementCenterReconciler) reconcileServiceAccount(ctx context.Context
 		ObjectMeta: metadata(mc),
 	}
 
-	err = controllerutil.SetControllerReference(mc, serviceAccount, r.Scheme)
+	err := controllerutil.SetControllerReference(mc, serviceAccount, r.Scheme)
 	if err != nil {
 		logger.Error(err, "Failed to set owner reference on ServiceAccount")
 		return err
@@ -94,12 +86,7 @@ func (r *ManagementCenterReconciler) reconcileServiceAccount(ctx context.Context
 }
 
 func (r *ManagementCenterReconciler) reconcileRoleBinding(ctx context.Context, mc *hazelcastv1alpha1.ManagementCenter, logger logr.Logger) error {
-	pt, err := platform.GetType()
-	if err != nil {
-		return err
-	}
-
-	if pt == platform.Kubernetes {
+	if platform.GetType() == platform.Kubernetes {
 		return nil
 	}
 
@@ -118,7 +105,7 @@ func (r *ManagementCenterReconciler) reconcileRoleBinding(ctx context.Context, m
 			Name:     mc.Name,
 		},
 	}
-	err = controllerutil.SetControllerReference(mc, rb, r.Scheme)
+	err := controllerutil.SetControllerReference(mc, rb, r.Scheme)
 	if err != nil {
 		logger.Error(err, "Failed to set owner reference on RoleBinding")
 		return err
@@ -261,16 +248,11 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 		},
 	}
 
-	pt, err := platform.GetType()
-	if err != nil {
-		return err
-	}
-
-	if pt == platform.OpenShift {
+	if platform.GetType() == platform.OpenShift {
 		sts.Spec.Template.Spec.ServiceAccountName = mc.Name
 	}
 
-	err = controllerutil.SetControllerReference(mc, sts, r.Scheme)
+	err := controllerutil.SetControllerReference(mc, sts, r.Scheme)
 	if err != nil {
 		logger.Error(err, "Failed to set owner reference on Statefulset")
 		return err

--- a/controllers/platform/platform.go
+++ b/controllers/platform/platform.go
@@ -22,7 +22,7 @@ const (
 type ProviderType string
 
 const (
-	AWS ProviderType = "AWS"
+	EKS ProviderType = "EKS"
 	AKS ProviderType = "AKS"
 	GKE ProviderType = "GKE"
 )
@@ -133,7 +133,7 @@ func getInfo() (Platform, error) {
 	for _, v := range apiList.Groups {
 		switch v.Name {
 		case "crd.k8s.amazonaws.com":
-			info.Provider = AWS
+			info.Provider = EKS
 			return info, nil
 		case "networking.gke.io":
 			info.Provider = GKE

--- a/controllers/platform/platform.go
+++ b/controllers/platform/platform.go
@@ -29,84 +29,37 @@ const (
 
 var (
 	plt Platform
-	cfg *rest.Config
 )
 
-func SetClientConfig(c *rest.Config) {
-	cfg = c
+func GetPlatform() Platform {
+	return plt
 }
 
-func GetPlatform() (Platform, error) {
-	if plt != (Platform{}) {
-		return plt, nil
-	}
+func GetType() PlatformType {
+	return plt.Type
+}
 
-	var err error
-	plt, err = getInfo()
+func GetProvider() ProviderType {
+	return plt.Provider
+}
+
+func GetVersion() string {
+	return plt.Version
+}
+
+func FindAndSetPlatform(cfg *rest.Config) error {
+	info, err := GetPlatformInfo(cfg)
 	if err != nil {
-		return Platform{}, err
+		return err
 	}
-	return plt, nil
+	plt = info
+	return nil
 }
 
-func GetProvider() (ProviderType, error) {
-	if plt != (Platform{}) {
-		return plt.Provider, nil
-	}
-
-	var err error
-	plt, err = getInfo()
-	if err != nil {
-		return "", err
-	}
-	return plt.Provider, nil
-}
-
-func GetType() (PlatformType, error) {
-	if plt.Type != "" {
-		return plt.Type, nil
-	}
-
-	var err error
-	plt, err = getInfo()
-	if err != nil {
-		return "", err
-	}
-	return plt.Type, nil
-}
-
-func GetVersion() (string, error) {
-	if plt.Version != "" {
-		return plt.Version, nil
-	}
-
-	var err error
-	plt, err = getInfo()
-	if err != nil {
-		return "", err
-	}
-	return plt.Version, nil
-}
-
-func newClient() (*discovery.DiscoveryClient, error) {
-
-	if cfg != nil {
-		return discovery.NewDiscoveryClientForConfig(cfg)
-	}
-
-	config, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	return discovery.NewDiscoveryClientForConfig(config)
-
-}
-
-func getInfo() (Platform, error) {
+func GetPlatformInfo(cfg *rest.Config) (Platform, error) {
 	info := Platform{Type: Kubernetes}
 
-	client, err := newClient()
+	client, err := newClient(cfg)
 	if err != nil {
 		return Platform{}, err
 	}
@@ -145,4 +98,17 @@ func getInfo() (Platform, error) {
 	}
 
 	return info, nil
+}
+
+func newClient(cfg *rest.Config) (*discovery.DiscoveryClient, error) {
+	if cfg != nil {
+		return discovery.NewDiscoveryClientForConfig(cfg)
+	}
+
+	config, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return discovery.NewDiscoveryClientForConfig(config)
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast"
 	"github.com/hazelcast/hazelcast-platform-operator/controllers/managementcenter"
+	"github.com/hazelcast/hazelcast-platform-operator/controllers/platform"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -66,7 +67,8 @@ func main() {
 		setupLog.Info("Watching namespace: " + namespace)
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	cfg := ctrl.GetConfigOrDie()
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
@@ -79,6 +81,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	platform.SetClientConfig(cfg)
 
 	if err = hazelcast.NewHazelcastReconciler(
 		mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -82,7 +82,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	platform.SetClientConfig(cfg)
+	err = platform.FindAndSetPlatform(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to get platform info")
+		os.Exit(1)
+	}
 
 	if err = hazelcast.NewHazelcastReconciler(
 		mgr.GetClient(),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	"github.com/hazelcast/hazelcast-platform-operator/controllers/platform"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -43,6 +44,8 @@ var _ = BeforeSuite(func() {
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
+
+	platform.SetClientConfig(cfg)
 
 	err = hazelcastcomv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -45,7 +45,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	platform.SetClientConfig(cfg)
+	err = platform.FindAndSetPlatform(cfg)
+	Expect(err).NotTo(HaveOccurred())
 
 	err = hazelcastcomv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -52,7 +52,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	platform.SetClientConfig(cfg)
+	err = platform.FindAndSetPlatform(cfg)
+	Expect(err).NotTo(HaveOccurred())
 
 	err = hazelcastcomv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast"
 	"github.com/hazelcast/hazelcast-platform-operator/controllers/managementcenter"
+	"github.com/hazelcast/hazelcast-platform-operator/controllers/platform"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -50,6 +51,8 @@ var _ = BeforeSuite(func() {
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
+
+	platform.SetClientConfig(cfg)
 
 	err = hazelcastcomv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Changes:
- Added provider info to Platform struct, providers are `EKS`, `GKE` and `AKS`.
- Added config to the Platform resolver client. It used to use Kubeconfig as default one, I set its config to the Manager's one.