### PR TITLE
[CN-303] Fix Bundle Release Pipelines for Red Hat Release

### DIFF
--- a/.github/workflows/redhat-connect-release.yaml
+++ b/.github/workflows/redhat-connect-release.yaml
@@ -14,6 +14,7 @@ jobs:
         shell: bash
     outputs:
       RELEASE_VERSION: ${{ steps.set-outputs.outputs.RELEASE_VERSION }}
+      DIGEST: ${{ steps.set-digest.outputs.DIGEST }}
     env:
       SCAN_REGISTRY: "scan.connect.redhat.com"
       TIMEOUT_IN_MINS: "60"
@@ -40,9 +41,13 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::${RELEASE_VERSION}"
 
       - name: Generate Operator and Operator Image
+        id: set-digest
         run: |
           echo "Building the operator image"
           make docker-build IMG=${RHEL_IMAGE} VERSION="${RELEASE_VERSION}" PARDOT_ID="redhat"
+
+          DIGEST=$(docker images --no-trunc --quiet $RHEL_IMAGE)
+          echo "::set-output name=DIGEST::${DIGEST}"
 
       - name: Push Hazelcast-Platform-Operator image to RHEL scan registry
         run: |
@@ -82,7 +87,6 @@ jobs:
           oc rollout status deployment hazelcast-platform-controller-manager
 
       - name: Test the Operator
-        id: e2e-test
         run: |
           oc create secret generic hazelcast-license-key --from-literal=license-key=${HZ_LICENSE_KEY}
           make test-e2e NAMESPACE=$NAMESPACE
@@ -90,38 +94,7 @@ jobs:
       - name: Clean up after Tests
         if: always()
         run: |
-          DEPLOY_NAME=hazelcast-platform-controller-manager
-
-          hz=$(oc get hazelcast -o name)
-          [[ "$hz" != "" ]] && oc delete $hz --wait=false || echo "no hazelcast resources"
-
-          mc=$(oc get managementcenter -o name)
-          [[ "$mc" != "" ]] && oc delete $mc --wait=false || echo "no managementcenter resources"
-          if [[ ${{ steps.e2e-test.outcome }} != 'success' ]]; then
-            i=0
-            while ! oc rollout status deployment $DEPLOY_NAME; do
-              oc rollout restart deployment $DEPLOY_NAME
-              if [[ $i == 2 ]]; then
-                echo "Failure testing the operator, namespace $NAMESPACE requires manual clean up"
-                exit 1
-              fi
-              ((i++))
-            done
-          fi
-          sleep 10
-
-          hz=$(oc get hazelcast -o name)
-          mc=$(oc get managementcenter -o name)
-          if [[ $hz != "" ]] || [[ $mc != "" ]]; then
-            echo -n "Failure deleting hazelcast and managementcenter resources,"
-            echo "namespace $NAMESPACE requires manual clean up"
-            exit 1
-          fi
-
-          make undeploy
-          oc delete secret hazelcast-license-key --wait=false
-          oc delete secret pull-secret --wait=false
-          oc delete project $NAMESPACE --wait=false
+          make clean-up-namespace NAMESPACE=$NAMESPACE
 
       - name: Publish the Hazelcast-Platform-Operator image
         run: |
@@ -149,20 +122,44 @@ jobs:
       REPO_NAME: ${{ matrix.repo-name }}
       REPO_OWNER: ${{ matrix.repo-owner }}
       RELEASE_VERSION: ${{ needs.publish_image.outputs.RELEASE_VERSION }}
+      DIGEST: ${{ needs.publish_image.outputs.DIGEST }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Add Annotation for redhat-marketplace-operators
+        if: env.REPO_NAME == 'redhat-marketplace-operators'
+        run: |
+          OPERATOR_NAME_RHPM=${OPERATOR_NAME}-rhmp
+          echo "OPERATOR_NAME_RHPM=${OPERATOR_NAME_RHPM}" >> $GITHUB_ENV
+
+          curl -sSLo ./bin/yq https://github.com/mikefarah/yq/releases/download/v4.18.1/yq_linux_amd64 --create-dirs
+          chmod +x ./bin/yq
+
+          ./bin/yq -i e ".metadata.annotations += \
+          {\"marketplace.openshift.io/remote-workflow\": \"https://marketplace.redhat.com/en-us/operators/${OPERATOR_NAME_RHPM}/pricing?utm_source=openshift_console\", \
+           \"marketplace.openshift.io/support-workflow\": \"https://marketplace.redhat.com/en-us/operators/${OPERATOR_NAME_RHPM}/support?utm_source=openshift_console\" }" \
+          config/manifests/bases/${OPERATOR_NAME}.clusterserviceversion.yaml
+
       - name: Build Bundle
         run: |
           RED_HAT_OPERATOR_REPOSITORY=registry.connect.redhat.com/hazelcast/${OPERATOR_NAME}
-          RED_HAT_OPERATOR_IMG=${RED_HAT_OPERATOR_REPOSITORY}:${RELEASE_VERSION}
+          RED_HAT_OPERATOR_IMG=${RED_HAT_OPERATOR_REPOSITORY}@${DIGEST}
 
           make bundle IMG=${RED_HAT_OPERATOR_IMG} VERSION=${RELEASE_VERSION}
           cat >> ./bundle/metadata/annotations.yaml <<EOF
             # OpenShift annotations.
             com.redhat.openshift.versions: "v4.6"
+            operators.operatorframework.io.bundle.channel.default.v1: alpha
           EOF
+
+      - name: Change package name for redhat-marketplace-operators
+        if: env.REPO_NAME == 'redhat-marketplace-operators'
+        run: |
+          sed -i "s|operators.operatorframework.io.bundle.package.v1: ${OPERATOR_NAME}|operators.operatorframework.io.bundle.package.v1: ${OPERATOR_NAME_RHPM}|" bundle/metadata/annotations.yaml
+          mv bundle/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml bundle/manifests/${OPERATOR_NAME_RHPM}.clusterserviceversion.yaml
+
+          echo "OPERATOR_NAME=${OPERATOR_NAME_RHPM}" >> $GITHUB_ENV
 
       - name: Validate Bundle for OCP
         run: |

--- a/.github/workflows/redhat-connect-release.yaml
+++ b/.github/workflows/redhat-connect-release.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Clean up after Tests
         if: always()
         run: |
-          make clean-up-namespace NAMESPACE=$NAMESPACE
+          make clean-up-namespace KUBECTL=oc NAMESPACE=${NAMESPACE}
 
       - name: Publish the Hazelcast-Platform-Operator image
         run: |

--- a/config/manifests/bases/hazelcast-platform-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/hazelcast-platform-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ spec:
 
     Easily deploy Hazelcast clusters and Management Center into Kubernetes environments and manage their lifecycles.
 
-    ## Before You Start 
+    ## Before You Start
 
     If you are planning to create Hazelcast Platform Enterprise clusters, you need to [create a secret](https://docs.hazelcast.com/operator/latest/get-started#step-2-start-the-hazelcast-cluster) for the license. You can request a trial license key from [here](https://trialrequest.hazelcast.com).
 
@@ -51,6 +51,7 @@ spec:
     * Scale up and down Hazelcast clusters
     * Expose Hazelcast cluster to external
       clients ([Smart & Unisocket](https://docs.hazelcast.com/hazelcast/latest/clients/java#java-client-operation-modes))
+  displayName: Hazelcast Platform Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAACXBIWXMAABCcAAAQnAEmzTo0AAAHQ0lEQVR4nO3dgXHbRhAFUDiTAtSBnA6SDuwK0kLcQVxBJhUkHdguwRVYHVgdJOzAHSQjQpQEmqQE7AFY3L03owlHkukNd88kyAN+V9Ru92X/BWuYYf5+LPy/8brw/cEYxefPAqEmxefvh2L3tNv9fPI2LGGm+Su3QLruzZnbsIRZ5q/kAvn1zG1Ywizz96rIvex2d6/9/jn67k/d9fW/Re4fVpq/Us8gf7zwezCH2eYv/gxyevUeeBZhXjPPX4lnkA8TfwYlzDp/sQWy2/3+zDsGb+5/B8pbYP6mv8Tq32v++sLf/qW7vr6d/HfBSvM37RmkL27MnpcvPjykmAXnb/wzyGNxVyP/5Leu6956JiFk4fkbt0CmF3dgkTDdCvP38pdY/cHO10Bx3f2f/erAndFWmr/nn0H695k/lNzfcu+m67p3PifhopXn7/wC6Qu7+zTyt8KFHfvYdd2fFgoDSeZvuED613hv7jd7Lb0j925Ff97/1zFKmxLO36v7UxRfJzzZ6d/91/X12wS1MJfk81dyuztUx0ss8kj5EuscB+msKeVB+ine5mVNad/mPdZ/uPJXoeLed9fXfxe6L1qw0vzZasJ2rDB/NiuyLak3Kx6ML9LioJwF588JU2xT6hOm7vR/4fsX/OZ7i4PiFpq/Elc1+XLhLbgbW0WY1czzV2KrybuJP4MSZp2/+ALpP2j5eOInH30IyOxmnj+XHmX70l96tC/k5sl3biwOFjPj/JXc7v75zG1YwizzV3KB3Jy5DUvYwPztdv/tv6CS+SudUei4gzUVnz8LhJoUn7+2zkmX4x7T4OPXWgy0mOqY5vprgVDT4ycnfTI57jGN9relnHQ57jFN9relnHQ57jFN9reNzYo2U8Y03N9WctLluMc029/6c9LluMc03t8WctLluMc03d+6c9LluMfob8WX/XFZohj93aszJ12Oe4z+Pqjv0qMujRqjvwN1XbzaxbVj9Pc79eSky3GP0d+Tth+gI+AnRn8rzUkXERejvwcV5aQLGY3R39H15c9J78lxn0p/p5KTDs/xEqtkfdnp7+j6HKQ/z0F6TEUH6ad4G9DbvNNU/jbvsew56XLcY/T3JFtNhmw10d8BmxUf2azY6e+xOnPS5bjH6O8DJ0z1nDB1TH/36s1Jl+Meo7979eeky3GPaby/LeSky3GPabq/9eeky3GPaby/Lj3K9h8/OelBctxjttffWznp48lxj9lSfz+VutOWctLluMfob1j2nHQ57jEN9re1GGjHHTG3wcvuzE1OepAFEvPt/isrOelVk+OejhjoXF4n/xdaTnqQBRKjvhg56ZOpL0ZOepic9Bj1xchJD1JfjJz0yWxWjFFfjJz0MPXFyEmfTE56jPpi5KSHqS9GTvpkcrRj1BcjJz1AfTHq25OT3lPfU+p74NKjj9TXqe+Yi1cPqU99A3LSh9SnvgEBOuepL0ZOeiF1RrCp70BOeiHbD/FUX3X1yUmfTn0xctJh67zEUp/6LtTnIP156ouRkz6Rtylj1BcjJz1AfTFy0icWZquE+qaTk16A+mLUNyAnvae+p9T3wAlTPfUdU9+enHT1naa+PTnp6rtMTnqYnPQY9cXISQ9RX4yc9AJcOjNGfTFy0oPUF9NwfXLS81BfzCz1yUnPQ30xctLD1BcjJz1MDHRM9vrkpAcZwJjs9TWXk156gRDzkq0TLEgMdCZr7Lka5yr5Syw56UHZ68suX/zzkJz0ybLXl52c9DA533WTkx4k57tuctIns9mubjYrhsn5rpuc9MnkfNdNTnqYnO+6yUmfTI523fTXZX/uLV9fdvq7Jye9t2x92envA5cefbTs1Quz0t8BF68eanuR6O935KQPzVdfdvp7kgCd88rUl53+ykkPmlZfdvp7ICd9sfqy09/R9R1y0q8Sngxz++T857z1rX3x5ufo71T7+g4H6RlPo7w6czuLzKeeHtPf8fY1eYlVsr7s9Hd0fQ7Sn+cgPUZO+kTe5s1Af+WkT1C+vuz09yRbTYZsNdHfAZsVH9ms2OnvMTnpPYvjKf194ISpnhOmjunvnpz0terLTn/35KRn3yqyNjnpYXK+6yYnPUTOd93kpBfg0qN1c+nRIDnfddtef2/lpI+Xvb7sttTfT6XuVE46tTx+ctLDsteXnZz0MDHLdZOTHmSB1E1OeuXkkMc09/i1FQNtz1VM/sdPTjpcICcdlpy/lnLSqZucdFh6/trYrEjd5KTDOvNXf046dZOTDuvNX9056dRNTjqsO3915qRTNznpkGP+6rp4NXWTkw655m/7ATrUTU56pRFnxMhJ/872QzKJkZM+yjZyyIlJPn9byUmnbnLSX8BLrNbJST/JQTrfk5PubV5eQE465J0/W03YDjnpkGv+6sxJp25y0iHH/NWbk07d5KTD+vPXQk46dZOTDmvNn0uPsn1y0mHU/MlJhwvzJycdtjd/cshZk5x0uEhOOlxQdv66rvsfiJAAx8qfoToAAAAASUVORK5CYII=
     mediatype: image/png
@@ -82,7 +83,7 @@ spec:
   - email: cloudnative@hazelcast.com
     name: Hazelcast Cloud Native Team
   maturity: alpha
-  minKubeVersion: "1.16"
+  minKubeVersion: 1.16.0
   provider:
     name: Hazelcast, Inc
   version: 5.0.0


### PR DESCRIPTION
Changes:
- Add required fields into CSV file and fix `minKubeVersion`.
- Use image digest instead of tag in bundle CSV file.
- Use makefile to clean up after E2E tests.
- Change bundle package name for marketplace, new one has `rhmp` suffix.
- Add required annotations to CSV for marketplace.
- Add default channel annotations to annotation.yaml.