### PR TITLE
Fix create release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
       - name: Convert latest-snapshot to release version
         run: |

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -147,6 +147,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: 'main'
 
       - name: Convert changes to latest-snapshot
         run: |

--- a/.github/workflows/redhat-connect-release.yaml
+++ b/.github/workflows/redhat-connect-release.yaml
@@ -206,8 +206,8 @@ jobs:
         working-directory: ${{ env.REPO_NAME }}
         run: |
           echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --title "operator ${OPERATOR_NAME} \
-            (${BUNDLE_RELEASE_VERSION})" --body "" --repo ${REPO_OWNER}/${REPO_NAME}
+          gh pr create --title \
+          "operator ${OPERATOR_NAME} (${BUNDLE_RELEASE_VERSION})" --body "" --repo ${REPO_OWNER}/${REPO_NAME}
 
   slack_notify:
     name: Slack Notify


### PR DESCRIPTION
1. I just added DEVOPS_GITHUB_TOKEN to trigger dockerhub and redhat publish workflows.
2. Added ref: 'main' to updated versions to the latest snapshot and fix this error: 
```
error: src refspec main does not match any
error: failed to push some refs to 'https://github.com/hazelcast/hazelcast-platform-operator'
Error: Process completed with exit code 1.
```

