### PR TITLE
Fix Readiness probe for MC container

### DIFF
--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -243,10 +243,8 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 						},
 						ReadinessProbe: &v1.Probe{
 							Handler: v1.Handler{
-								HTTPGet: &v1.HTTPGetAction{
-									Path:   "/health",
-									Port:   intstr.FromInt(8081),
-									Scheme: corev1.URISchemeHTTP,
+								TCPSocket: &v1.TCPSocketAction{
+									Port: intstr.FromInt(8080),
 								},
 							},
 							InitialDelaySeconds: 10,


### PR DESCRIPTION
The Readiness probe using `HTTPGet` for endpoint `/health` does not prove the Spring web started it shows that Jetty is started listening on port 8081.  This PR changes readiness probe into `TCPSocket` for port `8080`.