### PR TITLE
Repeat conflicted updates in test

### DIFF
--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -101,8 +101,8 @@ var _ = Describe("Hazelcast controller", func() {
 					types.NamespacedName{Name: hz.Name, Namespace: hz.Namespace},
 					cr),
 				).Should(Succeed())
-				for i := range fns {
-					cr = fns[i](cr)
+				for _, fn := range fns {
+					cr = fn(cr)
 				}
 				err := k8sClient.Update(context.Background(), cr)
 				if err == nil {


### PR DESCRIPTION
Update() method in tests observers Conflicted Update error in some cases.

This PR adds functionality to repeat updates in case of such event (repeatedly calling Get() and Update()).