### PR TITLE
E2E tests: remove storage class to use the default one

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -101,6 +101,7 @@ type PersistencePvcConfiguration struct {
 
 	// Name of StorageClass which this persistent volume belongs to.
 	// +optional
+	// +nullable
 	StorageClassName *string `json:"storageClassName,omitempty"`
 }
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -120,6 +120,7 @@ spec:
                         x-kubernetes-int-or-string: true
                       storageClassName:
                         description: Name of StorageClass which this persistent volume belongs to.
+                        nullable: true
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -140,6 +140,7 @@ spec:
                       storageClassName:
                         description: Name of StorageClass which this persistent volume
                           belongs to.
+                        nullable: true
                         type: string
                     type: object
                 required:

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -135,9 +135,8 @@ var (
 					BaseDir:                   "/data/hot-restart",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: hazelcastv1alpha1.PersistencePvcConfiguration{
-						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-						RequestStorage:   resource.MustParse("8Gi"),
-						StorageClassName: &[]string{"standard"}[0],
+						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						RequestStorage: resource.MustParse("8Gi"),
 					},
 				},
 			},


### PR DESCRIPTION
The tests contained the hardcoded name of `standard` ClassName which is the default one for GKE but is not present for EKS and AKS