### PR TITLE
[CN-273] Add API reference doc generation code

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -44,6 +44,11 @@ jobs:
           ref: ${{ steps.set-version.outputs.OPERATOR_DOCS_BRANCH }}
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
+      - name: Checkout to operator repo
+        uses: actions/checkout@v2
+        with:
+          path: operator-repo
+
       - name: Update versions
         run: |
           sed -i "0,/version: 'latest-snapshot'/s//version: '${MAJOR_MINOR_VERSION}'/" docs/antora.yml
@@ -52,6 +57,14 @@ jobs:
           sed -i '/prerelease/d' docs/antora.yml
           sed -i "s/page-latest-supported-hazelcast:.*/page-latest-supported-hazelcast: '${{ github.event.inputs.LATEST_SUPPORTED_HAZELCAST }}'/" docs/antora.yml
           sed -i "s/page-latest-supported-mc:.*/page-latest-supported-mc: '${{ github.event.inputs.LATEST_SUPPORTED_MC }}'/" docs/antora.yml
+
+      - name: Move API reference to docs repo
+        run: |
+          if cmp -s operator-repo/api-ref.adoc modules/ROOT/pages/api-ref.adoc; then
+              echo "No need to update API Reference doc"
+              exit 0
+          fi
+          mv operator-repo/api-ref.adoc modules/ROOT/pages/api-ref.adoc
 
       - name: Commit and push changes
         run: |
@@ -63,7 +76,7 @@ jobs:
           fi
 
           # Commit and push changes
-          git add docs/antora.yml
+          git add docs/antora.yml modules/ROOT/pages/api-ref.adoc
           git commit --signoff -m "Update docs to ${RELEASE_VERSION}"
           git push -u origin $BRANCH_NAME
 

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -46,3 +46,28 @@ jobs:
           curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
                -X PUT "https://hazelcast.jfrog.io/artifactory/operator/bundle-latest-snapshot.yaml" \
                -T bundle.yaml
+
+      - name: Generate API Reference Docs
+        run: |
+          make api-ref-doc > api-ref.adoc
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'hazelcast/hazelcast-platform-operator-docs'
+          ref: main
+          token: secrets.DEVOPS_GITHUB_TOKEN
+          path: docs-repo
+
+      - name: Push API Reference to Docs repo
+        working-directory: docs-repo
+        run: |
+          if cmp -s ../api-ref.adoc modules/ROOT/pages/api-ref.adoc; then
+              echo "No need to update API Reference doc"
+              exit 0
+          fi
+          mv ../api-ref.adoc modules/ROOT/pages/api-ref.adoc
+          git add modules/ROOT/pages/api-ref.adoc
+          git commit -m "Update API reference doc" && git push origin main
+          
+

--- a/Makefile
+++ b/Makefile
@@ -352,3 +352,9 @@ $(OCP_OLM_CATALOG_VALIDATOR):
 
 bundle-ocp-validate: ocp-olm-catalog-validator
 	 $(OCP_OLM_CATALOG_VALIDATOR) ./bundle  --optional-values="file=./bundle/metadata/annotations.yaml"
+
+api-ref-doc: 
+	@go build -o bin/docgen  ./apidocgen/main.go 
+	@./bin/docgen ./api/v1alpha1/hazelcast_types.go \
+				  ./api/v1alpha1/managementcenter_types.go \
+				  ./api/v1alpha1/hotbackup_types.go

--- a/apidocgen/main.go
+++ b/apidocgen/main.go
@@ -1,4 +1,6 @@
 /*
+ * Code taken and changed from https://github.com/oracle/coherence-operator/blob/v3.2.5/docgen/main.go
+ *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * http://oss.oracle.com/licenses/upl.

--- a/apidocgen/main.go
+++ b/apidocgen/main.go
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"strings"
+)
+
+const (
+	firstParagraph = `
+= Hazelcast Platform Operator API Docs
+
+A reference guide to the Hazelcast Platform Operator CRD types.
+
+== Hazelcast Platform Operator API Docs
+
+This is a reference for the Hazelcast Platform Operator API types.
+These are all the types and fields that are used in the Hazelcast Platform Operator CRDs. 
+
+TIP: This document was generated from comments in the Go code in the api/ directory.`
+
+	k8sLink = "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#"
+)
+
+type Field struct {
+	Name, Doc, Type, Default string
+	Mandatory                bool
+}
+
+type StructType struct {
+	Name, Doc string
+	Fields    []Field
+}
+
+type Const struct {
+	Name, Doc, Type, Value string
+}
+
+type StringType struct {
+	Name, Doc string
+	Consts    []Const
+}
+
+var (
+	selfLinks = map[string]string{}
+)
+
+func main() {
+	printAPIDocs(os.Args[1:])
+}
+
+func printAPIDocs(paths []string) {
+	fmt.Println(firstParagraph)
+
+	allTypes := getAllTypes(paths)
+	for _, t := range allTypes {
+		selfLinks[t.Name] = fmt.Sprintf("<<%s,%s>>", t.Name, t.Name)
+	}
+
+	printContentTable(allTypes)
+
+	printStructs(parseStructDocumentation(paths))
+	printStrings(parseStringTypeDocumentation(paths))
+}
+
+func getAllTypes(srcs []string) []*doc.Type {
+	var docForTypes []*doc.Type
+
+	for _, src := range srcs {
+		pkg := astFrom(src)
+		docForTypes = append(docForTypes, pkg.Types...)
+	}
+
+	return docForTypes
+}
+
+func parseStructDocumentation(srcs []string) []StructType {
+	var docForTypes []StructType
+
+	for _, src := range srcs {
+		pkg := astFrom(src)
+		for _, kubType := range pkg.Types {
+			if structType, ok := kubType.Decl.Specs[0].(*ast.TypeSpec).Type.(*ast.StructType); ok {
+				ks := processFields(structType, []Field{})
+				st := StructType{Name: kubType.Name, Doc: fmtRawDoc(kubType.Doc), Fields: ks}
+				docForTypes = append(docForTypes, st)
+			}
+		}
+	}
+	return docForTypes
+}
+
+func parseStringTypeDocumentation(srcs []string) []StringType {
+	var stTypes []StringType
+	for _, src := range srcs {
+		pkg := astFrom(src)
+		for _, kubType := range pkg.Types {
+			if stringType, ok := kubType.Decl.Specs[0].(*ast.TypeSpec).Type.(*ast.Ident); !ok || stringType.Name != "string" {
+				continue
+			}
+			var cs []Const
+			for _, kubTypeConst := range kubType.Consts {
+
+				for _, consPec := range kubTypeConst.Decl.Specs {
+					cons, ok := consPec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					// fmt.Printf("Doc for cons.Doc.Text() is %v\n", cons.Doc.Text())
+					bslit, ok := cons.Values[0].(*ast.BasicLit)
+					if !ok {
+						continue
+					}
+					if cons.Type.(*ast.Ident).Name != kubType.Name {
+						panic("Const type must be equal to its generated one.")
+					}
+					// fmt.Printf("Const type is %v, name is %v and val is %v\n", cons.Type.(*ast.Ident).Name, cons.Names[0], bslit.Value)
+					cs = append(cs, Const{Name: cons.Names[0].Name,
+						Doc:   fmtRawDoc(cons.Doc.Text()),
+						Type:  cons.Type.(*ast.Ident).Name,
+						Value: bslit.Value,
+					})
+				}
+			}
+			stTypes = append(stTypes, StringType{Name: kubType.Name, Doc: fmtRawDoc(kubType.Doc), Consts: cs})
+		}
+	}
+	return stTypes
+}
+
+func astFrom(filePath string) *doc.Package {
+	fset := token.NewFileSet()
+	m := make(map[string]*ast.File)
+
+	f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	m[filePath] = f
+	apkg, _ := ast.NewPackage(fset, m, nil, nil)
+
+	return doc.New(apkg, "", 0)
+}
+
+func fmtRawDoc(rawDoc string) string {
+	var buffer bytes.Buffer
+	delPrevChar := func() {
+		if buffer.Len() > 0 {
+			buffer.Truncate(buffer.Len() - 1) // Delete the last " " or "\n"
+		}
+	}
+
+	// Ignore all lines after ---
+	rawDoc = strings.Split(rawDoc, "---")[0]
+
+	for _, line := range strings.Split(rawDoc, "\n") {
+		line = strings.Trim(line, " ")
+		switch {
+		case len(line) == 0: // Keep paragraphs
+			delPrevChar()
+			buffer.WriteString("\n\n")
+		case strings.HasPrefix(line, "TODO"): // Ignore one line TODOs
+		case strings.HasPrefix(line, "+"): // Ignore instructions to go2idl
+		default:
+			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+				delPrevChar()
+				line = "\n" + line + " +\n" // Replace it with newline. This is useful when we have a line with: "Example:\n\tJSON-someting..."
+			} else {
+				line += " "
+			}
+			buffer.WriteString(line)
+		}
+	}
+
+	postDoc := strings.TrimRight(buffer.String(), "\n")
+	postDoc = strings.Replace(postDoc, "\\\"", "\"", -1) // replace user's \" to "
+	// postDoc = strings.Replace(postDoc, "\"", "\\\"", -1) // Escape "
+	postDoc = strings.Replace(postDoc, "\n", " +\n", -1)
+	postDoc = strings.Replace(postDoc, "\t", "&#160;&#160;&#160;&#160;", -1)
+	postDoc = strings.Replace(postDoc, "|", "\\|", -1)
+	return postDoc
+}
+
+func processFields(structType *ast.StructType, ks []Field) []Field {
+	for _, field := range structType.Fields.List {
+		typeString := fieldType(field.Type)
+		fieldMandatory := fieldRequired(field)
+		defaultValue := fieldDefault(field)
+		if n := fieldName(field); n != "-" {
+			fieldDoc := fmtRawDoc(field.Doc.Text())
+			ks = append(ks,
+				Field{Name: n,
+					Doc:       fieldDoc,
+					Type:      typeString,
+					Default:   defaultValue,
+					Mandatory: fieldMandatory})
+		} else if strings.Contains(field.Tag.Value, "json:\",inline") {
+			// TODO Try to find structs of selector expressions.
+			if ident, ok := field.Type.(*ast.Ident); ok && ident.Obj != nil {
+				if ts, ok := ident.Obj.Decl.(*ast.TypeSpec); ok {
+					if st, ok := ts.Type.(*ast.StructType); ok {
+						ks = processFields(st, ks)
+					}
+				}
+			}
+		}
+	}
+	return ks
+}
+
+func fieldType(typ ast.Expr) string {
+	switch t := typ.(type) {
+	case *ast.Ident:
+		return toLink(t.Name)
+	case *ast.StarExpr:
+		return "&#42;" + toLink(fieldType(typ.(*ast.StarExpr).X))
+	case *ast.SelectorExpr:
+		e := typ.(*ast.SelectorExpr)
+		pkg := e.X.(*ast.Ident)
+		return toLink(pkg.Name + "." + e.Sel.Name)
+	case *ast.ArrayType:
+		return "[]" + toLink(fieldType(typ.(*ast.ArrayType).Elt))
+	case *ast.MapType:
+		mapType := typ.(*ast.MapType)
+		return "map[" + toLink(fieldType(mapType.Key)) + "]" + toLink(fieldType(mapType.Value))
+	default:
+		return ""
+	}
+}
+
+func toLink(typeName string) string {
+	selfLink, hasSelfLink := selfLinks[typeName]
+	if hasSelfLink {
+		return selfLink
+	}
+
+	switch {
+	case strings.HasPrefix(typeName, "corev1."):
+		return fmt.Sprintf("%s%s-v1-core[%s]", k8sLink, strings.ToLower(typeName[7:]), escapeTypeName(typeName))
+	case strings.HasPrefix(typeName, "metav1."):
+		return fmt.Sprintf("%s%s-v1-meta[%s]", k8sLink, strings.ToLower(typeName[7:]), escapeTypeName(typeName))
+	}
+
+	return typeName
+}
+
+func escapeTypeName(typeName string) string {
+	if strings.HasPrefix(typeName, "*") {
+		return "&#42;" + typeName[1:]
+	}
+	return typeName
+}
+
+// fieldRequired returns whether a field is a required field.
+func fieldRequired(field *ast.Field) bool {
+	doc := field.Doc.Text()
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.Trim(line, " ")
+		if line == "+optional" {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldDefault(field *ast.Field) string {
+	doc := field.Doc.Text()
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.Trim(line, " ")
+		if strings.HasPrefix(line, "+kubebuilder:default:=") {
+			return strings.Split(line, ":=")[1]
+		}
+	}
+	return "-"
+}
+
+// fieldName returns the name of the field as it should appear in JSON format
+// "-" indicates that this field is not part of the JSON representation
+func fieldName(field *ast.Field) string {
+	jsonTag := ""
+	if field.Tag != nil {
+		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		if strings.Contains(jsonTag, "inline") {
+			return "-"
+		}
+	}
+
+	jsonTag = strings.Split(jsonTag, ",")[0] // This can return "-"
+	if jsonTag == "" {
+		if field.Names != nil {
+			return field.Names[0].Name
+		}
+		return field.Type.(*ast.Ident).Name
+	}
+	return jsonTag
+}
+
+func printContentTable(types []*doc.Type) {
+	fmt.Printf("\n=== Table of Contents\n")
+	for _, t := range types {
+		sn := t.Name
+		// if len(t.Fields) > 0 {
+		fmt.Printf("* <<%s,%s>>\n", sn, sn)
+		// }
+	}
+}
+
+func printStructs(structTypes []StructType) {
+	for _, t := range structTypes {
+		if len(t.Fields) > 0 {
+			fmt.Printf("\n=== %s\n\n%s\n\n", t.Name, t.Doc)
+
+			fmt.Println("[cols=\"4,10,4,2,2\"options=\"header\"]")
+			fmt.Println("|===")
+			fmt.Println("| Field | Description | Type | Required | Default")
+			for _, f := range t.Fields {
+				var d string
+				if f.Doc == "" {
+					d = "&#160;"
+				} else {
+					d = strings.ReplaceAll(f.Doc, "\\n", " +\n")
+				}
+				fmt.Println("m|", f.Name, "|", d, "m|", f.Type, "|", f.Mandatory, "|", f.Default)
+			}
+			fmt.Println("|===")
+			fmt.Println("")
+			fmt.Println("<<Table of Contents,Back to TOC>>")
+		}
+	}
+
+}
+
+func printStrings(stringTypes []StringType) {
+	for _, t := range stringTypes {
+		fmt.Printf("\n=== %s\n\n%s\n\n", t.Name, t.Doc)
+
+		fmt.Println("[cols=\"5,10\"options=\"header\"]")
+		fmt.Println("|===")
+		fmt.Println("| Value | Description")
+		for _, f := range t.Consts {
+			var d string
+			if f.Doc == "" {
+				d = "&#160;"
+			} else {
+				d = strings.ReplaceAll(f.Doc, "\\n", " +\n")
+			}
+			fmt.Println("m|", f.Value, "|", d)
+		}
+		fmt.Println("|===")
+		fmt.Println("")
+		fmt.Println("<<Table of Contents,Back to TOC>>")
+	}
+}

--- a/apidocgen/main.go
+++ b/apidocgen/main.go
@@ -266,7 +266,16 @@ func escapeTypeName(typeName string) string {
 }
 
 // fieldRequired returns whether a field is a required field.
+// If omitempty json tag or +optional kubebuilder tags is there, the field is optional. Otherwise, required.
 func fieldRequired(field *ast.Field) bool {
+	jsonTag := ""
+	if field.Tag != nil {
+		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		if strings.Contains(jsonTag, "omitempty") {
+			return false
+		}
+	}
+
 	doc := field.Doc.Text()
 	for _, line := range strings.Split(doc, "\n") {
 		line = strings.Trim(line, " ")


### PR DESCRIPTION
The API reference doc generation code is based on https://github.com/oracle/coherence-operator/tree/master/docgen. This code generates the API reference by going over the structs in the `api/` directory.

Changes to the code:
- General refactor of the structs and functions in the code.
- Use kubebuilder tags for filling `required` column instead of `json` tags.
- Use kubebuilder tags to fill `default` column.
- Add String types into the API ref with columns `value` and `description`.

I also added steps into `docs-release.yaml` and `publish-snapshot.yaml` to push the new API ref doc into docs repository.

To Decide:
- [x] How to handle reference to coherence operator.