### PR TITLE
Prepare workflows for release branch

### DIFF
--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -138,30 +138,16 @@ jobs:
           gh pr create --title "operator ${OPERATOR_NAME} (${BUNDLE_RELEASE_VERSION})" \
             --body "" --repo ${REPO_OWNER}/${REPO_NAME}
 
-  after_release:
-    name: Update repository after release
+  slack_notify:
+    name: Slack Notify
+    needs: [ 'publish_image', 'operatorhub_release' ]
+    if: always() && ( needs.publish_image.result != 'success' || needs.redhat_bundle_release.result != 'success' )
     runs-on: ubuntu-latest
-    needs: publish_image
-    env:
-      RELEASE_VERSION: ${{ needs.publish_image.outputs.RELEASE_VERSION }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
         with:
-          ref: 'main'
-
-      - name: Convert changes to latest-snapshot
-        run: |
-          sed -i  "s|ARG version=\"${RELEASE_VERSION}\"|ARG version=\"latest-snapshot\"|" Dockerfile
-          sed -i  "s|VERSION ?= ${RELEASE_VERSION}|VERSION ?= latest-snapshot|" Makefile
-
-          make generate-bundle-yaml
-
-      - name: Commit and push changes to bundle
-        run: |
-          git config user.email "devopshelm@hazelcast.com"
-          git config user.name "devOpsHelm"
-
-          git add Makefile Dockerfile bundle.yaml config/
-          git commit --signoff -m "${RELEASE_VERSION} to latest-snapshot"
-          git push origin main
+          fields: repo,commit,author,action,eventName,workflow
+          status: ${{ needs.operatorhub_release.result }}
+          channel: "#github-actions-log"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/redhat-connect-release.yaml
+++ b/.github/workflows/redhat-connect-release.yaml
@@ -74,9 +74,6 @@ jobs:
     name: Create a PR in
     runs-on: ubuntu-latest
     needs: publish_image
-    strategy:
-      fail-fast: false
-
     env:
       REPO_NAME: certified-operators
       REPO_OWNER: redhat-openshift-ecosystem
@@ -150,10 +147,9 @@ jobs:
     name: Slack Notify
     needs: [ 'publish_image', 'redhat_bundle_release' ]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && ( needs.publish_image.result != 'success' || needs.redhat_bundle_release.result != 'success' )
     steps:
       - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
-        if: needs.publish_image.result != 'success' || needs.redhat_bundle_release.result != 'success'
         with:
           fields: repo,commit,author,action,eventName,workflow
           status: ${{ needs.redhat_bundle_release.result }}


### PR DESCRIPTION
Changes:
- Remove job for after release push in "dockerhub-release.yaml", which
  reverted release version to latest-snapshot. We will not need it
anymore since we are releasing from a ephemeral branch.
- Fix slack notify job and add it into dockerhub-release.yaml
- Fix syntax error in redhat-connect-release.yaml, fail-fast requires
  matrix to be present.