### PR TITLE
[CN-321] Add phone home config for HZ and MC pods

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -634,6 +634,10 @@ func env(h *hazelcastv1alpha1.Hazelcast) []v1.EnvVar {
 			Name:  "HZ_PARDOT_ID",
 			Value: "operator",
 		},
+		{
+			Name:  "HZ_PHONE_HOME_ENABLED",
+			Value: strconv.FormatBool(util.IsPhoneHomeEnabled()),
+		},
 	}
 	if h.Spec.LicenseKeySecret != "" {
 		envs = append(envs,

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -361,15 +361,17 @@ func env(mc *hazelcastv1alpha1.ManagementCenter) []v1.EnvVar {
 				},
 			},
 			v1.EnvVar{
-				Name:  javaOpts,
-				Value: "-Dhazelcast.mc.license=$(MC_LICENSE_KEY) -Dhazelcast.mc.healthCheck.enable=true -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false",
+				Name: javaOpts,
+				Value: fmt.Sprintf("-Dhazelcast.mc.license=$(MC_LICENSE_KEY) -Dhazelcast.mc.healthCheck.enable=true"+
+					" -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false -Dhazelcast.mc.phone.home.enabled=%t", util.IsPhoneHomeEnabled()),
 			},
 		)
 	} else {
 		envs = append(envs,
 			v1.EnvVar{
-				Name:  javaOpts,
-				Value: "-Dhazelcast.mc.healthCheck.enable=true -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false",
+				Name: javaOpts,
+				Value: fmt.Sprintf("-Dhazelcast.mc.healthCheck.enable=true -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false"+
+					" -Dhazelcast.mc.phone.home.enabled=%t", util.IsPhoneHomeEnabled()),
 			},
 		)
 	}


### PR DESCRIPTION
Added config for HZ and MC following the documentation:

https://docs.hazelcast.com/management-center/5.1/deploy-manage/phone-homes#disabling-the-collection-of-usage-analytics

https://docs.hazelcast.com/hazelcast/5.1/phone-homes