### PR TITLE
Remove unsupported argument from golangci lint action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,7 +36,6 @@ jobs:
         if: always()
         with:
           args: --timeout 2m
-          skip-go-installation: true
 
       - name: Run yamllint
         uses: ibiqlik/action-yamllint@v3
@@ -225,7 +224,7 @@ jobs:
 
           make docker-build-ci IMG=$IMAGE VERSION=${{github.sha}}
           make docker-push IMG=$IMAGE
-          
+
       - name: Deploy Operator to GKE
         run: |
           kubectl create namespace ${{ env.NAMESPACE }}


### PR DESCRIPTION
Golangci Linter Action removed the argument from the supported list since it is no longer adjustable.
This PR eliminates the corresponding warnings in CI runs.