### PR TITLE
[CN-214] Disable error logs for Hazelcast go-client

### DIFF
--- a/controllers/hazelcast/hazelcast_config.go
+++ b/controllers/hazelcast/hazelcast_config.go
@@ -7,13 +7,18 @@ import (
 	"fmt"
 
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/logger"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	n "github.com/hazelcast/hazelcast-platform-operator/controllers/naming"
 )
 
 func buildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
-	config := hazelcast.Config{}
+	config := hazelcast.Config{
+		Logger: logger.Config{
+			Level: logger.OffLevel,
+		},
+	}
 	cc := &config.Cluster
 	cc.Name = h.Spec.ClusterName
 	cc.Network.SetAddresses(fmt.Sprintf("%s.%s.svc.cluster.local:%d", h.Name, h.Namespace, n.DefaultHzPort))

--- a/controllers/hazelcast/hazelcast_config_local_run.go
+++ b/controllers/hazelcast/hazelcast_config_local_run.go
@@ -7,6 +7,7 @@ package hazelcast
 
 import (
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/logger"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 )
@@ -14,7 +15,11 @@ import (
 const localUrl = "127.0.0.1:8000"
 
 func buildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
-	config := hazelcast.Config{}
+	config := hazelcast.Config{
+		Logger: logger.Config{
+			Level: logger.OffLevel,
+		},
+	}
 	cc := &config.Cluster
 	cc.Name = h.Spec.ClusterName
 	cc.Network.SetAddresses(localUrl)


### PR DESCRIPTION
We already log errors in operator so we can suppress errors from the library.