### PR TITLE
Skip cleanup step if there is a failure before

### DIFF
--- a/.github/workflows/nightly-e2e-aks.yaml
+++ b/.github/workflows/nightly-e2e-aks.yaml
@@ -110,7 +110,6 @@ jobs:
           make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=${NAMESPACE} NAME_PREFIX=${NAME_PREFIX}
 
       - name: Clean up after Tests
-        if: ${{ always() }}
         run: |
           make clean-up-namespace NAMESPACE=${NAMESPACE}
 

--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -123,7 +123,6 @@ jobs:
           make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=${NAMESPACE} NAME_PREFIX=${NAME_PREFIX}
 
       - name: Clean up after Tests
-        if: ${{ always() }}
         run: |
           make clean-up-namespace NAMESPACE=${NAMESPACE}
 

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -129,7 +129,6 @@ jobs:
           make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=$NAMESPACE NAME_PREFIX=$NAME_PREFIX
 
       - name: Clean up after Tests
-        if: always()
         run: |
           make clean-up-namespace NAMESPACE=${NAMESPACE}
 


### PR DESCRIPTION
We skip delete-cluster step if there is a failure. 
We need to extend this condition to cleanup-namespace step too.