### PR TITLE
[CN-220] Improve operator status for client

### DIFF
--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -187,7 +187,9 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	externalAddrs := util.GetExternalAddresses(ctx, r.Client, h, logger)
-	return update(ctx, r.Client, h, r.runningPhaseWithMembers(req).withExternalAddresses(externalAddrs))
+	return update(ctx, r.Client, h, r.runningPhaseWithMembers(req).
+		withExternalAddresses(externalAddrs).
+		withMessage(clientConnectionMessage(req)))
 }
 
 func (r *HazelcastReconciler) runningPhaseWithMembers(req ctrl.Request) optionsBuilder {
@@ -224,6 +226,24 @@ func getHazelcastCRName(pod *corev1.Pod) (string, bool) {
 	} else {
 		return "", false
 	}
+}
+
+func clientConnectionMessage(req ctrl.Request) string {
+	c, ok := GetClient(req.NamespacedName)
+	if !ok {
+		return "Operator failed to create connection to cluster . Some features might be unavailable."
+	}
+
+	if c.Error != nil {
+		// TODO: retry mechanism
+		return fmt.Sprintf("Operator failed to connect to the cluster. Some features might be unavailable. %s", c.Error.Error())
+	}
+
+	if c.client != nil && c.client.Running() {
+		return ""
+	}
+
+	return "Operator is in progress of connecting to the cluster. Some features might be unavailable."
 }
 
 func (r *HazelcastReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -231,7 +231,7 @@ func getHazelcastCRName(pod *corev1.Pod) (string, bool) {
 func clientConnectionMessage(req ctrl.Request) string {
 	c, ok := GetClient(req.NamespacedName)
 	if !ok {
-		return "Operator failed to create connection to cluster . Some features might be unavailable."
+		return "Operator failed to create connection to cluster, some features might be unavailable."
 	}
 
 	if c.Error != nil {

--- a/controllers/hazelcast/hazelcast_status_controller.go
+++ b/controllers/hazelcast/hazelcast_status_controller.go
@@ -115,9 +115,7 @@ func (c *HazelcastClient) start(ctx context.Context, config hazelcast.Config) {
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	c.Lock()
 	c.cancel = cancel
-	c.Unlock()
 
 	go func(ctx context.Context) {
 		c.initHzClient(ctx, config)
@@ -152,11 +150,13 @@ func (c *HazelcastClient) initHzClient(ctx context.Context, config hazelcast.Con
 }
 
 func (c *HazelcastClient) shutdown(ctx context.Context) {
-	c.Lock()
-	defer c.Unlock()
 	if c.cancel != nil {
 		c.cancel()
 	}
+
+	c.Lock()
+	defer c.Unlock()
+
 	if c.client == nil {
 		return
 	}

--- a/controllers/hazelcast/hazelcast_status_controller.go
+++ b/controllers/hazelcast/hazelcast_status_controller.go
@@ -25,6 +25,7 @@ type HazelcastClient struct {
 	client               *hazelcast.Client
 	cancel               context.CancelFunc
 	NamespacedName       types.NamespacedName
+	Error                error
 	Log                  logr.Logger
 	MemberMap            map[hztypes.UUID]*MemberData
 	triggerReconcileChan chan event.GenericEvent
@@ -144,6 +145,7 @@ func (c *HazelcastClient) initHzClient(ctx context.Context, config hazelcast.Con
 	if err != nil {
 		// Ignoring the connection error and just logging as it is expected for Operator that in some scenarios it cannot access the HZ cluster
 		c.Log.Info("Cannot connect to Hazelcast cluster. Some features might not be available.", "Reason", err.Error())
+		c.Error = err
 	} else {
 		c.client = hzClient
 	}


### PR DESCRIPTION
Changes:
- Fixed race condition between `initHzClient` and `shutdown`, where if `StartNewClientWithConfig` takes too much time reconcile function gets blocked for a very long time.
- Improved Hazelcast status messages about client's connection to the cluster. 

TODO:
- [ ] Operator still cannot understand when a connected client gets disconnected from the cluster. We need to use the functions in the client introduced in this commit https://github.com/hazelcast/hazelcast-go-client/commit/6845efd6ac3d6826c75e23ed75705b74c48a21aa.