### PR TITLE
Fix Slack notify job triggers

### DIFF
--- a/.github/workflows/nightly-e2e-aks.yaml
+++ b/.github/workflows/nightly-e2e-aks.yaml
@@ -114,10 +114,10 @@ jobs:
         run: |
           make clean-up-namespace NAMESPACE=${NAMESPACE}
 
-  clean-up:
+  delete-cluster:
     name: Delete AKS cluster
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
+    if: always()
     needs: ["prepare-env", "aks-e2e-tests"]
     steps:
       - name: Azure login
@@ -135,8 +135,8 @@ jobs:
 
   slack_notify:
     name: Slack Notify
-    needs: [ 'clean-up' ]
-    if: always() &&  needs.clean-up.result != 'success' 
+    needs: [ 'aks-e2e-tests', 'delete-cluster' ]
+    if: always() && ( needs.aks-e2e-tests.result != 'success' || needs.delete-cluster.result != 'success') 
     runs-on: ubuntu-latest
     steps:
       - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04

--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -123,14 +123,14 @@ jobs:
           make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=${NAMESPACE} NAME_PREFIX=${NAME_PREFIX}
 
       - name: Clean up after Tests
-        if: ${{ always() }}
+        if: always()
         run: |
           make clean-up-namespace NAMESPACE=${NAMESPACE}
 
-  clean-up:
+  delete-cluster:
     name: Delete EKS cluster
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
+    if: always()
     needs: [ "prepare-env", "eks-e2e-tests" ]
     steps:
       - name: Configure AWS Credentials
@@ -155,8 +155,8 @@ jobs:
 
   slack_notify:
     name: Slack Notify
-    needs: [ 'clean-up' ]
-    if: always() &&  needs.clean-up.result != 'success' 
+    needs: [ 'eks-e2e-tests', 'delete-cluster' ]
+    if: always() && ( needs.eks-e2e-tests.result != 'success' || needs.delete-cluster.result != 'success') 
     runs-on: ubuntu-latest
     steps:
       - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -155,8 +155,8 @@ jobs:
 
   slack_notify:
     name: Slack Notify
-    needs: [ 'delete-cluster' ]
-    if: always() &&  needs.delete-cluster.result != 'success' 
+    needs: [ 'gke-e2e-tests', 'delete-cluster' ]
+    if: always() && ( needs.gke-e2e-tests.result != 'success' || needs.delete-cluster.result != 'success') 
     runs-on: ubuntu-latest
     steps:
       - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -148,8 +148,8 @@ jobs:
 
   slack_notify:
     name: Slack Notify
-    needs: [ 'delete-cluster' ]
-    if: always() &&  needs.delete-cluster.result != 'success' 
+    needs: [ 'gke-ph-tests', 'delete-cluster' ]
+    if: always() &&  ( needs.gke-ph-tests.result != 'success' || needs.delete-cluster.result != 'success') 
     runs-on: ubuntu-latest
     steps:
       - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04


### PR DESCRIPTION
Current triggers for Slack jobs in some of the workflows, only get triggered from the `delete-cluster` job. This was OK, when we were not deleting the clusters if an E2E test failed. However, currently `delete-cluster` jobs always run and it will not trigger the Slack notify job even though the E2E tests fail.