### PR TITLE
fix scheduled update

### DIFF
--- a/controllers/hazelcast/hot_backup_controller_test.go
+++ b/controllers/hazelcast/hot_backup_controller_test.go
@@ -49,7 +49,7 @@ func TestHotBackupReconciler_shouldScheduleHotBackupExecution(t *testing.T) {
 	r := hotBackupReconcilerWithCRs(h, hb)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: n})
 	if err != nil {
-		t.Errorf("Error executing Reconcile: %e", err)
+		t.Errorf("Error executing Reconcile: %v", err)
 	}
 	load, _ := r.scheduled.Load(n)
 	Expect(load).ShouldNot(BeNil())
@@ -88,7 +88,7 @@ func TestHotBackupReconciler_shouldRemoveScheduledBackup(t *testing.T) {
 	r := hotBackupReconcilerWithCRs(h, hb)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: n})
 	if err != nil {
-		t.Errorf("Error executing Reconcile: %e", err)
+		t.Errorf("Error executing Reconcile: %v", err)
 	}
 
 	Expect(r.cron.Entries()).Should(BeEmpty())
@@ -209,6 +209,61 @@ func TestHotBackupReconciler_shouldNotTriggerHotBackupTwice(t *testing.T) {
 	reconcileWg.Wait()
 
 	Expect(hotBackupTriggers).Should(Equal(int32(1)))
+}
+
+func TestHotBackupReconciler_shouldUpdateWhenScheduledBackupChangedToInstantBackup(t *testing.T) {
+	RegisterFailHandler(fail(t))
+	n := types.NamespacedName{
+		Name:      "hazelcast",
+		Namespace: "default",
+	}
+	h := &hazelcastv1alpha1.Hazelcast{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.Name,
+			Namespace: n.Namespace,
+		},
+		Status: hazelcastv1alpha1.HazelcastStatus{Phase: hazelcastv1alpha1.Running},
+	}
+	hb := &hazelcastv1alpha1.HotBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.Name,
+			Namespace: n.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HotBackupSpec{
+			HazelcastResourceName: "hazelcast",
+			Schedule:              "0 23 31 2 *",
+		},
+	}
+	ts, err := fakeHttpServer(hazelcastUrl(h), func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(200)
+		_, _ = writer.Write([]byte("{\"status\":\"success\"}"))
+	})
+	if err != nil {
+		t.Errorf("Failed to start fake HTTP server: %v", err)
+	}
+	defer ts.Close()
+
+	r := hotBackupReconcilerWithCRs(h, hb)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: n})
+	if err != nil {
+		t.Errorf("Error executing Reconcile: %v", err)
+	}
+
+	Expect(r.cron.Entries()).Should(HaveLen(1))
+
+	Expect(r.Client.Get(context.TODO(), n, hb)).Should(Succeed())
+	hb.Spec.Schedule = ""
+	Expect(r.Client.Update(context.TODO(), hb)).Should(Succeed())
+
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: n})
+	if err != nil {
+		t.Errorf("Error executing Reconcile: %v", err)
+	}
+	Expect(r.cron.Entries()).Should(BeEmpty())
+	r.scheduled.Range(func(key, value interface{}) bool {
+		t.Errorf("Scheduled map should be empty. But contains key: %v value: %v", key, value)
+		return false
+	})
 }
 
 func fail(t *testing.T) func(message string, callerSkip ...int) {


### PR DESCRIPTION
Fix the bug when the `scheduled` part is removed from the `HotBackup CR`. When so, the schedule must be removed, and instead the `HotBackup` must be triggered immediately