### PR TITLE
[CN-395] Make resources and scheduling spec fields updatable for HZ and MC

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -660,17 +660,6 @@ func (r *HazelcastReconciler) reconcileStatefulset(ctx context.Context, h *hazel
 		},
 	}
 
-	if h.Spec.Scheduling != nil {
-		sts.Spec.Template.Spec.Affinity = h.Spec.Scheduling.Affinity
-		sts.Spec.Template.Spec.Tolerations = h.Spec.Scheduling.Tolerations
-		sts.Spec.Template.Spec.NodeSelector = h.Spec.Scheduling.NodeSelector
-		sts.Spec.Template.Spec.TopologySpreadConstraints = h.Spec.Scheduling.TopologySpreadConstraints
-	}
-
-	if h.Spec.Resources != nil {
-		sts.Spec.Template.Spec.Containers[0].Resources = *h.Spec.Resources
-	}
-
 	if h.Spec.Persistence.IsEnabled() {
 		if h.Spec.Persistence.UseHostPath() {
 			sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, hostPathVolume(h))
@@ -711,6 +700,24 @@ func (r *HazelcastReconciler) reconcileStatefulset(ctx context.Context, h *hazel
 		sts.Spec.Template.Spec.Containers[0].Image = h.DockerImage()
 		sts.Spec.Template.Spec.Containers[0].Env = env(h)
 		sts.Spec.Template.Spec.Containers[0].ImagePullPolicy = h.Spec.ImagePullPolicy
+
+		if h.Spec.Scheduling != nil {
+			sts.Spec.Template.Spec.Affinity = h.Spec.Scheduling.Affinity
+			sts.Spec.Template.Spec.Tolerations = h.Spec.Scheduling.Tolerations
+			sts.Spec.Template.Spec.NodeSelector = h.Spec.Scheduling.NodeSelector
+			sts.Spec.Template.Spec.TopologySpreadConstraints = h.Spec.Scheduling.TopologySpreadConstraints
+		} else {
+			sts.Spec.Template.Spec.Affinity = nil
+			sts.Spec.Template.Spec.Tolerations = nil
+			sts.Spec.Template.Spec.NodeSelector = nil
+			sts.Spec.Template.Spec.TopologySpreadConstraints = nil
+		}
+
+		if h.Spec.Resources != nil {
+			sts.Spec.Template.Spec.Containers[0].Resources = *h.Spec.Resources
+		} else {
+			sts.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{}
+		}
 		return nil
 	})
 	if opResult != controllerutil.OperationResultNone {

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -276,16 +276,6 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 		},
 	}
 
-	if mc.Spec.Scheduling != nil {
-		sts.Spec.Template.Spec.Affinity = mc.Spec.Scheduling.Affinity
-		sts.Spec.Template.Spec.Tolerations = mc.Spec.Scheduling.Tolerations
-		sts.Spec.Template.Spec.NodeSelector = mc.Spec.Scheduling.NodeSelector
-	}
-
-	if mc.Spec.Resources != nil {
-		sts.Spec.Template.Spec.Containers[0].Resources = *mc.Spec.Resources
-	}
-
 	if platform.GetType() == platform.OpenShift {
 		sts.Spec.Template.Spec.ServiceAccountName = mc.Name
 	}
@@ -310,6 +300,23 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 		sts.Spec.Template.Spec.Containers[0].Image = mc.DockerImage()
 		sts.Spec.Template.Spec.Containers[0].Env = env(mc)
 		sts.Spec.Template.Spec.Containers[0].ImagePullPolicy = mc.Spec.ImagePullPolicy
+		if mc.Spec.Scheduling != nil {
+			sts.Spec.Template.Spec.Affinity = mc.Spec.Scheduling.Affinity
+			sts.Spec.Template.Spec.Tolerations = mc.Spec.Scheduling.Tolerations
+			sts.Spec.Template.Spec.NodeSelector = mc.Spec.Scheduling.NodeSelector
+			sts.Spec.Template.Spec.TopologySpreadConstraints = mc.Spec.Scheduling.TopologySpreadConstraints
+		} else {
+			sts.Spec.Template.Spec.Affinity = nil
+			sts.Spec.Template.Spec.Tolerations = nil
+			sts.Spec.Template.Spec.NodeSelector = nil
+			sts.Spec.Template.Spec.TopologySpreadConstraints = nil
+		}
+
+		if mc.Spec.Resources != nil {
+			sts.Spec.Template.Spec.Containers[0].Resources = *mc.Spec.Resources
+		} else {
+			sts.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{}
+		}
 		return nil
 	})
 	if opResult != controllerutil.OperationResultNone {

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -814,6 +815,112 @@ var _ = Describe("Hazelcast controller", func() {
 					ss := getStatefulSet(hz)
 					return len(ss.Spec.Template.Spec.Containers)
 				}, timeout, interval).Should(Equal(2))
+
+				Delete(hz)
+			})
+		})
+	})
+
+	Context("Statefulset Updates", func() {
+		firstSpec := hazelcastv1alpha1.HazelcastSpec{
+			ClusterSize:      pointer.Int32Ptr(2),
+			Repository:       "hazelcast/hazelcast-enterprise",
+			Version:          "5.2",
+			ImagePullPolicy:  corev1.PullAlways,
+			ImagePullSecrets: nil,
+			ExposeExternally: nil,
+			LicenseKeySecret: "key-secret",
+			Scheduling:       nil,
+			Resources:        nil,
+		}
+		secondSpec := hazelcastv1alpha1.HazelcastSpec{
+			ClusterSize:     pointer.Int32Ptr(3),
+			Repository:      "hazelcast/hazelcast",
+			Version:         "5.3",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "secret1"},
+				{Name: "secret2"},
+			},
+			ExposeExternally: &hazelcastv1alpha1.ExposeExternallyConfiguration{
+				Type: hazelcastv1alpha1.ExposeExternallyTypeSmart,
+			},
+			LicenseKeySecret: "",
+			Scheduling: &hazelcastv1alpha1.SchedulingConfiguration{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{Key: "node.gpu", Operator: corev1.NodeSelectorOpExists},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Resources: &corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("250m"),
+					corev1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+		}
+		When("Hazelcast Spec is updated", func() {
+			It("Should forward changes to StatefulSet", Label("fast"), func() {
+				hz := &hazelcastv1alpha1.Hazelcast{
+					ObjectMeta: GetRandomObjectMeta(),
+					Spec:       firstSpec,
+				}
+
+				Create(hz)
+				hz = EnsureStatus(hz)
+				hz.Spec = secondSpec
+				Update(hz)
+				ss := getStatefulSet(hz)
+
+				By("Checking if StatefulSet ClusterSize is updated")
+				Eventually(func() int32 {
+					ss = getStatefulSet(hz)
+					return *ss.Spec.Replicas
+				}, timeout, interval).Should(Equal(*secondSpec.ClusterSize))
+
+				By("Checking if StatefulSet Image is updated")
+				Expect(ss.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("%s:%s", secondSpec.Repository, secondSpec.Version)))
+
+				By("Checking if StatefulSet ImagePullPolicy is updated")
+				Expect(ss.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(secondSpec.ImagePullPolicy))
+
+				By("Checking if StatefulSet ImagePullSecrets is updated")
+				Expect(ss.Spec.Template.Spec.ImagePullSecrets).To(Equal(secondSpec.ImagePullSecrets))
+
+				By("Checking if StatefulSet ExposeExternally is updated")
+				an, ok := ss.Annotations[n.ServicePerPodCountAnnotation]
+				Expect(ok).To(BeTrue())
+				Expect(an).To(Equal(strconv.Itoa(int(*hz.Spec.ClusterSize))))
+
+				an, ok = ss.Spec.Template.Annotations[n.ExposeExternallyAnnotation]
+				Expect(ok).To(BeTrue())
+				Expect(an).To(Equal(string(hz.Spec.ExposeExternally.MemberAccessType())))
+
+				By("Checking if StatefulSet LicenseKeySecret is updated")
+				el := ss.Spec.Template.Spec.Containers[0].Env
+				for _, env := range el {
+					if env.Name == "HZ_LICENSEKEY" {
+						Expect(env.ValueFrom.SecretKeyRef.Key).To(Equal(secondSpec.LicenseKeySecret))
+					}
+				}
+
+				By("Checking if StatefulSet Scheduling is updated")
+				Expect(*ss.Spec.Template.Spec.Affinity).To(Equal(*secondSpec.Scheduling.Affinity))
+				Expect(ss.Spec.Template.Spec.NodeSelector).To(Equal(secondSpec.Scheduling.NodeSelector))
+				Expect(ss.Spec.Template.Spec.Tolerations).To(Equal(secondSpec.Scheduling.Tolerations))
+				Expect(ss.Spec.Template.Spec.TopologySpreadConstraints).To(Equal(secondSpec.Scheduling.TopologySpreadConstraints))
+
+				By("Checking if StatefulSet Resources is updated")
+				Expect(ss.Spec.Template.Spec.Containers[0].Resources).To(Equal(*secondSpec.Resources))
 
 				Delete(hz)
 			})


### PR DESCRIPTION
With the current changes, `persistence` is the only field that updates are not reflected in the operator.