### PR TITLE
CN-356-Increase timeout

### DIFF
--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -56,7 +56,7 @@ func assertDoesNotExist(name types.NamespacedName, obj client.Object) {
 			return false
 		}
 		return errors.IsNotFound(err)
-	}, 3*Minute, interval).Should(BeTrue())
+	}, 8*Minute, interval).Should(BeTrue())
 }
 
 func assertExists(name types.NamespacedName, obj client.Object) {


### PR DESCRIPTION
Fix the small timeout for removing CR's causes the issue when tests start to fail for AWS and OCP
[no ci]