### PR TITLE
Increase timeout for MC from 2 to 5 minute to prevent flaky tests

### DIFF
--- a/test/e2e/management_center_test.go
+++ b/test/e2e/management_center_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Management-Center", Label("mc"), func() {
 				err := k8sClient.Get(context.Background(), mcLookupKey, mc)
 				Expect(err).ToNot(HaveOccurred())
 				return isManagementCenterRunning(mc)
-			}, 2*Minute, interval).Should(BeTrue())
+			}, 5*Minute, interval).Should(BeTrue())
 		})
 	}
 
@@ -96,7 +96,7 @@ var _ = Describe("Management-Center", Label("mc"), func() {
 					err := k8sClient.Get(context.Background(), mcLookupKey, &cr)
 					Expect(err).ToNot(HaveOccurred())
 					return cr.Status.ExternalAddresses
-				}, 1*Minute, interval).Should(Not(BeEmpty()))
+				}, 5*Minute, interval).Should(Not(BeEmpty()))
 			})
 		})
 	})


### PR DESCRIPTION
Increase timeout for MC from 2 to 5 minutes to prevent flaky tests  (OCP env)
[no ci]