### PR TITLE
Rename name for docs-release.yaml from 

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -1,4 +1,4 @@
-name: Publish Docs Site
+name: (5) Publish Docs Site
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Renamed the name for docs-release.yaml from 'Publish Docs Site' to '(5) Publish Docs Site' to have more clear order among our workflow files (to know the running order)
[no ci]