### PR TITLE
CN-376-Update-release-workflow

### DIFF
--- a/.github/actions/operator-tests/action.yml
+++ b/.github/actions/operator-tests/action.yml
@@ -1,12 +1,9 @@
 name: "Install tool dependency"
-description: "Installing all required libraries and data: go, cache, preflight, opm, operator SDK and PFLT_CERTIFICATION_PROJECT_ID"
+description: "Installing all required libraries and data: go, cache, preflight, opm, operator SDK"
 
 inputs:
   PFLT_PYXIS_API_TOKEN:
     description: "An API Key can be created in Red Hat Partner Connect at the following URL: https://connect.redhat.com/account/api-keys"
-    required: false
-  PROJECT_ID:
-    description: "Certification Project ID from connect.redhat.com. Should be supplied w/ the ospid- prefix."
     required: false
   PREFLIGHT_VERSION:
     description: "Preflight tool version"
@@ -17,11 +14,9 @@ inputs:
   OPM_INSTALL:
     description: "Install opm tool or not. Non empty values are consider as 'true'."
     required: false
-
-outputs:
-  PFLT_CERTIFICATION_PROJECT_ID:
-    description: "Certification Project ID from connect.redhat.com. Should be supplied w/o the ospid- prefix."
-    value: ${{ steps.pflt-cert-prj.outputs.PFLT_CERTIFICATION_PROJECT_ID }}
+  DEVOPS_GITHUB_TOKEN:
+    description: "Authentication token for GitHub"
+    required: false
 
 runs:
   using: "composite"
@@ -47,26 +42,18 @@ runs:
       run: |
         if [[ ! -z "${{ inputs.PREFLIGHT_VERSION }}" ]]; then
            echo "✅ Installing preflight tool"
+           echo "PREFLIGHT_VERSION=${{ inputs.PREFLIGHT_VERSION }}" >> $GITHUB_ENV
+        if [[ "${{ inputs.PREFLIGHT_VERSION }}" -eq "latest" ]]; then
+           PREFLIGHT_VERSION=$(curl --silent -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ inputs.DEVOPS_GITHUB_TOKEN }}" \
+           https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r '.name')
+           echo "PREFLIGHT_VERSION=$PREFLIGHT_VERSION" >> $GITHUB_ENV
+        fi
            mkdir -p ${GITHUB_WORKSPACE}/bin
            echo "${GITHUB_WORKSPACE}/bin" >> ${GITHUB_PATH}
-           curl -L --fail --show-error --silent https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${{ inputs.PREFLIGHT_VERSION }}/preflight-linux-amd64 \
+           curl -L --fail --show-error --silent https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${PREFLIGHT_VERSION}/preflight-linux-amd64 \
            -o ${GITHUB_WORKSPACE}/bin/preflight && chmod +x ${GITHUB_WORKSPACE}/bin/preflight
         else
            echo "⏭ Skipping preflight tool installation"
-        fi
-
-    - name: Get Certification ID
-      shell: bash
-      id: pflt-cert-prj
-      run: |
-        if [[ ! -z "${{ inputs.PROJECT_ID }}" ]]; then
-          echo "✅ Getting PFLT_CERTIFICATION_PROJECT_ID variable"
-          PFLT_CERTIFICATION_PROJECT_ID=$(curl --fail --show-error --silent --request GET -H "X-API-KEY: ${{ inputs.PFLT_PYXIS_API_TOKEN }}" \
-          "https://catalog.redhat.com/api/containers/v1/projects/certification/pid/${{ inputs.PROJECT_ID }}" | jq -r '._id')
-          echo "PFLT_CERTIFICATION_PROJECT_ID=${PFLT_CERTIFICATION_PROJECT_ID}" >> $GITHUB_ENV
-          echo "::set-output name=PFLT_CERTIFICATION_PROJECT_ID::${PFLT_CERTIFICATION_PROJECT_ID}"
-        else
-           echo "⏭ Skipping getting preflight certification Id"
         fi
 
     - name: Install OPM tool

--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -12,10 +12,8 @@ on:
     - cron: "0 9 * * *"
 
 env:
-  PROJECT_ID: ${{ secrets.PROJECT_ID }}
   PFLT_PYXIS_API_TOKEN: ${{ secrets.RHEL_API_KEY }}
-  PFLT_DOCKERCONFIG: /home/runner/.docker/config.json
-  PREFLIGHT_VERSION: 1.1.0
+  PREFLIGHT_VERSION: latest
   NAMESPACE: oc-test-operator-${{ github.run_id }}
   PARDOT_ID: redhat
 
@@ -29,7 +27,6 @@ jobs:
     outputs:
       RELEASE_VERSION: ${{ steps.setup-envs.outputs.RELEASE_VERSION }}
       CONTAINER_IMAGE: ${{ steps.setup-envs.outputs.CONTAINER_IMAGE }}
-      PROJECT_ID: ${{ steps.setup-envs.outputs.PROJECT_ID }}
       PREFLIGHT_VERSION: ${{ steps.setup-envs.outputs.PREFLIGHT_VERSION }}
     steps:
       - name: Checkout to hazelcast-operator
@@ -39,8 +36,8 @@ jobs:
         uses: ./.github/actions/operator-tests
         with:
           PFLT_PYXIS_API_TOKEN: $PFLT_PYXIS_API_TOKEN
-          PROJECT_ID: $PROJECT_ID
           PREFLIGHT_VERSION: $PREFLIGHT_VERSION
+          DEVOPS_GITHUB_TOKEN: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
       - name: Set Environment Variables And Job Outputs
         id: setup-envs
@@ -59,7 +56,6 @@ jobs:
               CONTAINER_IMAGE=ttl.sh/$CONTAINER_REPOSITORY:1h
               echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> $GITHUB_ENV
               echo "::set-output name=CONTAINER_IMAGE::${CONTAINER_IMAGE}"
-              echo "::set-output name=PROJECT_ID::${PROJECT_ID}"
               echo "::set-output name=PREFLIGHT_VERSION::${PREFLIGHT_VERSION}"
 
       - name: Validate version
@@ -146,6 +142,7 @@ jobs:
         uses: ./.github/actions/operator-tests
         with:
           PREFLIGHT_VERSION: $PREFLIGHT_VERSION
+          DEVOPS_GITHUB_TOKEN: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
           OPM_INSTALL: true
 
       - name: Set Environment Variables And Job Outputs
@@ -207,6 +204,7 @@ jobs:
         uses: ./.github/actions/operator-tests
         with:
           PREFLIGHT_VERSION: $PREFLIGHT_VERSION
+          DEVOPS_GITHUB_TOKEN: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
           OPERATOR_SDK_INSTALL: true
 
       - name: Login to Docker Hub Registry
@@ -240,12 +238,15 @@ jobs:
     uses: ./.github/workflows/publish-release.yaml
     with:
       RELEASE_VERSION: ${{ needs.test_container.outputs.RELEASE_VERSION }}
-      PROJECT_ID: ${{ needs.test_container.outputs.PROJECT_ID }}
       PREFLIGHT_VERSION: ${{ needs.test_container.outputs.PREFLIGHT_VERSION }}
     secrets:
       PFLT_PYXIS_API_TOKEN: ${{ secrets.RHEL_API_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      PROJECT_ID: ${{ secrets.PROJECT_ID }}
+      JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
+      DEVOPS_GITHUB_TOKEN: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   clean_up_artifacts:
     if: always()

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -5,10 +5,6 @@ on:
       RELEASE_VERSION:
         required: true
         type: string
-      PROJECT_ID:
-        description: "Certification Project ID from connect.redhat.com. Should be supplied without the ospid- prefix"
-        required: true
-        type: string
       PREFLIGHT_VERSION:
         description: "preflight tool version"
         required: true
@@ -23,13 +19,21 @@ on:
       DOCKERHUB_PASSWORD:
         description: "Docker Hub registry password"
         required: true
+      PROJECT_ID:
+        description: "Project ID w/o osp prefix"
+        required: true
+      JFROG_TOKEN:
+        required: true
+      DEVOPS_GITHUB_TOKEN:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: true
 
 env:
   OPERATOR_NAME: "hazelcast-platform-operator"
   RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
-  PROJECT_ID: ${{ inputs.PROJECT_ID }}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
   PFLT_PYXIS_API_TOKEN: ${{ secrets.PFLT_PYXIS_API_TOKEN }}
-  PFLT_DOCKERCONFIG: /home/runner/.docker/config.json
   PREFLIGHT_VERSION: ${{ inputs.PREFLIGHT_VERSION }}
   TIMEOUT_IN_MINS: "60"
 
@@ -40,6 +44,8 @@ jobs:
     outputs:
       RELEASE_VERSION: ${{ steps.set-outputs.outputs.RELEASE_VERSION }}
       IMAGE_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      IMAGE_DIGEST: ${{ steps.push-operator-image.outputs.IMAGE_DIGEST }}
+      CURRENT_LATEST_TAG: ${{ steps.get-current-latest-tag.outputs.CURRENT_LATEST_TAG }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -50,11 +56,26 @@ jobs:
       - name: Set Release Version
         id: set-outputs
         run: |
-          IMAGE_NAME=hazelcast/${OPERATOR_NAME}:${RELEASE_VERSION}
+          IMAGE_NAME=docker.io/hazelcast/${OPERATOR_NAME}:${RELEASE_VERSION}
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "::set-output name=RELEASE_VERSION::${RELEASE_VERSION}"
           echo "::set-output name=IMAGE_NAME::${IMAGE_NAME}"
+
+      - name: Get the Current Latest Tag
+        id: get-current-latest-tag
+        run: |
+          token=$(curl --fail -L -s -X POST 'https://hub.docker.com/v2/users/login' \
+          -H 'Content-Type: application/json' \
+          --data-raw '{
+            "username": "${{ secrets.DOCKERHUB_USERNAME }}",
+            "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
+          }'| jq -r '.token')
+
+          CURRENT_LATEST_TAG=$(curl --fail -L -s -X GET 'https://hub.docker.com/v2/namespaces/hazelcast/repositories/hazelcast-platform-operator/images?status=active&currently_tagged=true&page_size=100' \
+          -H "Authorization: Bearer $token" | jq -r  '.results[] | select((.tags | length == 2) and .tags[].tag =="latest") | .tags[].tag | select(. !="latest")')
+          echo "CURRENT_LATEST_TAG=${CURRENT_LATEST_TAG}" >> $GITHUB_ENV
+          echo "::set-output name=CURRENT_LATEST_TAG::${CURRENT_LATEST_TAG}"
 
       - name: Build Operator Image
         run: |
@@ -66,17 +87,22 @@ jobs:
             docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
       - name: Push Operator Image
-        run: make docker-push docker-push-latest IMG="${IMAGE_NAME}"
+        id: push-operator-image
+        run: |
+          make docker-push docker-push-latest IMG="${IMAGE_NAME}"
+          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_NAME} | cut -d'@' -f2)
+          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_ENV
+          echo "::set-output name=IMAGE_DIGEST::${IMAGE_DIGEST}"
 
       - name: Upload Bundle to Jfrog
         run: |
           make generate-bundle-yaml VERSION=${RELEASE_VERSION}
 
-          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+          curl --fail -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
                -X PUT "https://hazelcast.jfrog.io/artifactory/operator/bundle-latest.yaml" \
                -T bundle.yaml
 
-          curl -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+          curl --fail -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
                -X PUT "https://hazelcast.jfrog.io/artifactory/operator/bundle-${RELEASE_VERSION}.yaml" \
                -T bundle.yaml
 
@@ -98,32 +124,38 @@ jobs:
         uses: ./.github/actions/operator-tests
         with:
           PFLT_PYXIS_API_TOKEN: $PFLT_PYXIS_API_TOKEN
-          PROJECT_ID: $PROJECT_ID
           PREFLIGHT_VERSION: $PREFLIGHT_VERSION
+          DEVOPS_GITHUB_TOKEN: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
       - name: Test and Submit Container Results to Red Hat [prod]
         run: |
           echo "Submit test container results to Red Hat"
+          podman login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }} docker.io --authfile /home/runner/.docker/config.json
+
           preflight check container $IMAGE_NAME \
           --submit \
-          --certification-project-id=${{ steps.setup-tools.outputs.PFLT_CERTIFICATION_PROJECT_ID }}
+          --docker-config=/home/runner/.docker/config.json \
+          --certification-project-id=$PROJECT_ID
           grep -E -q "Preflight result: PASSED\"( |$)" preflight.log || exit 1
 
       - name: Publish the Hazelcast-Platform-Operator Image
         run: |
           source .github/scripts/publish-rhel.sh
+          checking_image_grade "$PROJECT_ID" "$RELEASE_VERSION" "$PFLT_PYXIS_API_TOKEN"
           publish_the_image "$PROJECT_ID" "$RELEASE_VERSION" "$PFLT_PYXIS_API_TOKEN"
           wait_for_container_publish "$PROJECT_ID" "$RELEASE_VERSION" "$PFLT_PYXIS_API_TOKEN" "$TIMEOUT_IN_MINS"
 
   redhat_bundle_release:
+    if: ${{ false }}
     name: Create a PR in 'certified-operators' Repository
     runs-on: ubuntu-latest
-    needs: publish_docker_image
+    needs: ['publish_docker_image', 'publish_redhat_image']
     env:
       REPO_NAME: certified-operators
       REPO_OWNER: redhat-openshift-ecosystem
       RELEASE_VERSION: ${{ needs.publish_docker_image.outputs.RELEASE_VERSION }}
       IMAGE_NAME: ${{ needs.publish_docker_image.outputs.IMAGE_NAME }}
+      IMAGE_DIGEST: ${{ needs.publish_docker_image.outputs.IMAGE_DIGEST }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -134,7 +166,8 @@ jobs:
 
       - name: Build Red Hat Bundle
         run: |
-          make bundle IMG=${IMAGE_NAME} VERSION=${RELEASE_VERSION}
+          IMAGE_NAME_DIGEST=docker.io/hazelcast/${OPERATOR_NAME}@${IMAGE_DIGEST}
+          make bundle IMG=${IMAGE_NAME_DIGEST} VERSION=${RELEASE_VERSION}
           cat >> ./bundle/metadata/annotations.yaml <<EOF
             # OpenShift annotations.
             com.redhat.openshift.versions: "v4.6"
@@ -190,9 +223,10 @@ jobs:
           "operator ${OPERATOR_NAME} (${BUNDLE_RELEASE_VERSION})" --body "" --repo ${REPO_OWNER}/${REPO_NAME}
 
   operatorhub_release:
+    if: ${{ false }}
     name: Create a PR in
     runs-on: ubuntu-latest
-    needs: publish_docker_image
+    needs: ['publish_docker_image', 'publish_redhat_image']
     strategy:
       fail-fast: false
       matrix:
@@ -266,6 +300,80 @@ jobs:
           echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
           gh pr create --title "operator ${OPERATOR_NAME} (${BUNDLE_RELEASE_VERSION})" \
             --body "" --repo ${REPO_OWNER}/${REPO_NAME}
+
+  revert_changes:
+    name: Revert Release Changes
+    needs: ['publish_docker_image', 'publish_redhat_image']
+    if: always() && (needs.publish_docker_image.result == 'failure' || needs.publish_redhat_image.result == 'failure')
+    runs-on: ubuntu-latest
+    env:
+      CURRENT_LATEST_TAG: ${{ needs.publish_docker_image.outputs.CURRENT_LATEST_TAG }}
+      IMAGE_DIGEST: ${{ needs.publish_docker_image.outputs.IMAGE_DIGEST }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Removing Published Docker Image
+        run: |
+          auth_token=$(curl --fail -L -s -X POST 'https://hub.docker.com/v2/users/login' \
+          -H 'Content-Type: application/json' \
+          --data-raw '{
+            "username": "${{ secrets.DOCKERHUB_USERNAME }}",
+            "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
+          }'| jq -r '.token')
+
+          curl --fail -L -s -X POST 'https://hub.docker.com/v2/namespaces/hazelcast/delete-images' \
+          -H "Authorization: Bearer $auth_token" \
+          -H 'Content-Type: application/json' \
+          --data-raw '{
+              "manifests": [
+                  {
+                      "repository": "${{ env.OPERATOR_NAME }}",
+                      "digest": "${{ env.IMAGE_DIGEST }}"
+                  }
+              ],
+              "ignore_warnings": [
+                  {
+                      "repository": "${{ env.OPERATOR_NAME }}",
+                      "digest": "${{ env.IMAGE_DIGEST }}",
+                      "warning": "is_active"
+                  },
+                  {
+                      "repository": "${{ env.OPERATOR_NAME }}",
+                      "digest": "${{ env.IMAGE_DIGEST }}",
+                      "warning": "current_tag",
+                      "tags": [
+                          "${{ env.RELEASE_VERSION }}",
+                          "latest"
+                      ]
+                  }
+              ]
+          }'
+
+      - name: Login to Docker Hub
+        run: |
+          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | \
+          docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Making Previous Docker Image Tag As 'latest'
+        run: |
+          docker pull docker.io/hazelcast/${OPERATOR_NAME}:${CURRENT_LATEST_TAG}
+          make docker-push-latest IMG="docker.io/hazelcast/${OPERATOR_NAME}:${CURRENT_LATEST_TAG}"
+
+      - name: Removing Published Jfrog Bundle and Making Previous Bundle As 'latest'
+        run: |
+          curl --fail -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+               -X DELETE https://hazelcast.jfrog.io/artifactory/operator/bundle-${RELEASE_VERSION}.yaml
+
+          curl --fail -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+               -X DELETE https://hazelcast.jfrog.io/artifactory/operator/bundle-latest.yaml
+
+          curl --fail -L -H "Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" \
+               -X POST "https://hazelcast.jfrog.io/artifactory/api/copy/operator/bundle-${CURRENT_LATEST_TAG}.yaml?to=/operator/bundle-latest.yaml"
+
+      - name: Removing Release Tag
+        run: |
+          git push --delete origin v${RELEASE_VERSION}
 
   slack_notify:
     name: Slack Notify


### PR DESCRIPTION
- Added function to check image health index before publishing on RedHat
- Added function to remove the published image (docker.io) and revert the previous image tag to the latest
- Added function to remove release tag (Github) in case of failure
- Added function to remove published bundle from Jfrog in case of failure and revert the previous bundle to latest
- Added dependency to skip creating PR in case of the image was not published to RedHat
- Added '--fail' option to all curl calls
- Added option to install the latest preflight tool
- Added SHA instead of tag during Build Red Hat Bundle