### PR TITLE
Fix multiple E2E test errors

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -80,7 +80,7 @@ type HazelcastSpec struct {
 
 	// B&R Agent configurations
 	// +optional
-	// +kubebuilder:default:={repository: "docker.io/hazelcast/platform-operator-agent", version: "0.1.2"}
+	// +kubebuilder:default:={repository: "docker.io/hazelcast/platform-operator-agent", version: "0.1.3"}
 	Agent *AgentConfiguration `json:"agent,omitempty"`
 
 	// Custom Classes to Download into Class Path
@@ -113,7 +113,7 @@ type AgentConfiguration struct {
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Hazelcast Platform Operator Agent.
-	// +kubebuilder:default:="0.1.2"
+	// +kubebuilder:default:="0.1.3"
 	// +optional
 	Version string `json:"version,omitempty"`
 }

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -52,7 +52,7 @@ spec:
               agent:
                 default:
                   repository: docker.io/hazelcast/platform-operator-agent
-                  version: 0.1.2
+                  version: 0.1.3
                 description: B&R Agent configurations
                 properties:
                   repository:
@@ -60,7 +60,7 @@ spec:
                     description: Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
                     type: string
                   version:
-                    default: 0.1.2
+                    default: 0.1.3
                     description: Version of Hazelcast Platform Operator Agent.
                     type: string
                 type: object

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -54,7 +54,7 @@ spec:
               agent:
                 default:
                   repository: docker.io/hazelcast/platform-operator-agent
-                  version: 0.1.2
+                  version: 0.1.3
                 description: B&R Agent configurations
                 properties:
                   repository:
@@ -62,7 +62,7 @@ spec:
                     description: Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
                     type: string
                   version:
-                    default: 0.1.2
+                    default: 0.1.3
                     description: Version of Hazelcast Platform Operator Agent.
                     type: string
                 type: object

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -49,7 +49,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	return []byte{}
 }, func(bytes []byte) {
-	setupEnv()
+	cfg := setupEnv()
+	platform.FindAndSetPlatform(cfg)
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -50,7 +50,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	return []byte{}
 }, func(bytes []byte) {
 	cfg := setupEnv()
-	platform.FindAndSetPlatform(cfg)
+	err := platform.FindAndSetPlatform(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/hazelcast_persistence_test.go
+++ b/test/e2e/hazelcast_persistence_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 				Namespace: hzNamespace,
 			}, hz)
 			return hz.Status.Restore
-		}, 5*Second, interval).Should(And(
+		}, 20*Second, interval).Should(And(
 			Not(BeNil()),
 			WithTransform(func(h *hazelcastcomv1alpha1.RestoreStatus) hazelcastcomv1alpha1.RestoreState {
 				return h.State

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 				err := k8sClient.Get(context.Background(), hzLookupKey, hz)
 				Expect(err).ToNot(HaveOccurred())
 				return hz.Status.Phase
-			}, 10*Second, interval).Should(Equal(phase))
+			}, 30*Second, interval).Should(Equal(phase))
 			Expect(hz.Status.Message).Should(Not(BeEmpty()))
 		}
 


### PR DESCRIPTION
Changes:
- Increased timeout for external API errors test
- Platform was not set for all parallel running processes, now it is set.
- Increased timeout for restore status check
- Using agent version 0.1.3 for GCP Bucket fixes. GCP buckets were opened by disregarding the prefix the in query. Now, prefix is also applied.