### PR TITLE
[CN-447] Use unique names per test case

### DIFF
--- a/test/e2e/custom_resource_test.go
+++ b/test/e2e/custom_resource_test.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	"fmt"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	labels            = map[string]string{}
+	hzLookupKey       = types.NamespacedName{}
+	mapLookupKey      = types.NamespacedName{}
+	hbLookupKey       = types.NamespacedName{}
+	hzSourceLookupKey = types.NamespacedName{}
+	hzTargetLookupKey = types.NamespacedName{}
+	wanLookupKey      = types.NamespacedName{}
+	mcLookupKey       = types.NamespacedName{}
+)
+
+func setCRNamespace(ns string) {
+	hzLookupKey.Namespace = ns
+	mapLookupKey.Namespace = ns
+	hbLookupKey.Namespace = ns
+	hzSourceLookupKey.Namespace = ns
+	hzTargetLookupKey.Namespace = ns
+	wanLookupKey.Namespace = ns
+	mcLookupKey.Namespace = ns
+}
+
+func setLabelAndCRName(n string) {
+	n = n + "-" + randString(6) + "-" + fmt.Sprintf("%d", GinkgoParallelProcess())
+	labels["test_suite"] = n
+	hzLookupKey.Name = n
+	mapLookupKey.Name = n
+	hbLookupKey.Name = n
+	hzSourceLookupKey.Name = "src" + "-" + n
+	hzTargetLookupKey.Name = "trg" + "-" + n
+	wanLookupKey.Name = n
+	mcLookupKey.Name = n
+	GinkgoWriter.Printf("Resource name is: %s\n", n)
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyz" +
+	"0123456789"
+
+func randString(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/test/e2e/custom_resource_test.go
+++ b/test/e2e/custom_resource_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"fmt"
 	"math/rand"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,7 +29,7 @@ func setCRNamespace(ns string) {
 }
 
 func setLabelAndCRName(n string) {
-	n = n + "-" + randString(6) + "-" + fmt.Sprintf("%d", GinkgoParallelProcess())
+	n = n + "-" + randString(6)
 	labels["test_suite"] = n
 	hzLookupKey.Name = n
 	mapLookupKey.Name = n

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -81,6 +81,7 @@ func setupEnv() *rest.Config {
 	Expect(k8sClient).NotTo(BeNil())
 
 	controllerManagerName.Namespace = hzNamespace
+	setCRNamespace(hzNamespace)
 
 	return cfg
 }

--- a/test/e2e/hazelcast_expose_externally_test.go
+++ b/test/e2e/hazelcast_expose_externally_test.go
@@ -2,30 +2,18 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	. "time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	hazelcastconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/hazelcast"
 )
 
 var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose_externally"), func() {
-	hzName := fmt.Sprintf("hz-ex-ex-%d", GinkgoParallelProcess())
 
-	var hzLookupKey = types.NamespacedName{
-		Name:      hzName,
-		Namespace: hzNamespace,
-	}
-	labels := map[string]string{
-		"test_suite": fmt.Sprintf("hz_expose_externally_%d", GinkgoParallelProcess()),
-	}
 	BeforeEach(func() {
 		if !useExistingCluster() {
 			Skip("End to end tests require k8s cluster. Set USE_EXISTING_CLUSTER=true")
@@ -42,9 +30,9 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 	})
 
 	AfterEach(func() {
-		Expect(k8sClient.Delete(context.Background(), emptyHazelcast(hzLookupKey), client.PropagationPolicy(v1.DeletePropagationForeground))).Should(Succeed())
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
+		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, hzNamespace, labels)
 	})
+
 	ctx := context.Background()
 	assertExternalAddressesNotEmpty := func() {
 		By("status external addresses should not be empty")
@@ -57,6 +45,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 	}
 
 	It("should create Hazelcast cluster and allow connecting with Hazelcast unisocket client", Label("slow"), func() {
+		setLabelAndCRName("hee-1")
 		assertUseHazelcastUnisocket := func() {
 			FillTheMapData(ctx, hzLookupKey, false, "map", 100)
 		}
@@ -67,6 +56,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 	})
 
 	It("should create Hazelcast cluster exposed with NodePort services and allow connecting with Hazelcast smart client", Label("slow"), func() {
+		setLabelAndCRName("hee-2")
 		assertUseHazelcastSmart := func() {
 			FillTheMapData(ctx, hzLookupKey, false, "map", 100)
 		}
@@ -77,6 +67,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 	})
 
 	It("should create Hazelcast cluster exposed with LoadBalancer services and allow connecting with Hazelcast smart client", Label("slow"), func() {
+		setLabelAndCRName("hee-3")
 		assertUseHazelcastSmart := func() {
 			FillTheMapData(ctx, hzLookupKey, false, "map", 100)
 		}

--- a/test/e2e/hazelcast_expose_externally_test.go
+++ b/test/e2e/hazelcast_expose_externally_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 	It("should create Hazelcast cluster and allow connecting with Hazelcast unisocket client", Label("slow"), func() {
 		setLabelAndCRName("hee-1")
 		assertUseHazelcastUnisocket := func() {
-			FillTheMapData(ctx, hzLookupKey, false, "map", 100)
+			FillTheMapData(ctx, hzLookupKey, true, "map", 100)
 		}
 		hazelcast := hazelcastconfig.ExposeExternallyUnisocket(hzLookupKey, ee, labels)
 		CreateHazelcastCR(hazelcast)

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -2,50 +2,18 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	. "time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	hazelcastconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/hazelcast"
 )
 
 var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
-	hzName := fmt.Sprintf("hz-wan-%d", GinkgoParallelProcess())
-	hzTargetName := fmt.Sprintf("hz-wan-target-%d", GinkgoParallelProcess())
-	wanName := fmt.Sprintf("hz-wan-wan-%d", GinkgoParallelProcess())
-	mapName := fmt.Sprintf("hz-wan-map-%d", GinkgoParallelProcess())
-
-	hzSourceLookupKey := types.NamespacedName{
-		Name:      hzName,
-		Namespace: hzNamespace,
-	}
-
-	hzTargetLookupKey := types.NamespacedName{
-		Name:      hzTargetName,
-		Namespace: hzNamespace,
-	}
-
-	wanLookupKey := types.NamespacedName{
-		Name:      wanName,
-		Namespace: hzNamespace,
-	}
-
-	mapLookupKey := types.NamespacedName{
-		Name:      mapName,
-		Namespace: hzNamespace,
-	}
-
-	labels := map[string]string{
-		"test_suite": fmt.Sprintf("hz_wan_%d", GinkgoParallelProcess()),
-	}
-
 	waitForLBAddress := func(name types.NamespacedName) string {
 		By("waiting for load balancer address")
 		hz := &hazelcastcomv1alpha1.Hazelcast{}
@@ -75,28 +43,16 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 	})
 
 	AfterEach(func() {
-		Expect(k8sClient.DeleteAllOf(
-			context.Background(),
-			&hazelcastcomv1alpha1.WanReplication{},
-			client.InNamespace(hzNamespace),
-			client.PropagationPolicy(v1.DeletePropagationForeground),
-			client.MatchingLabels(labels)),
-		).Should(Succeed())
-		Expect(k8sClient.DeleteAllOf(
-			context.Background(),
-			&hazelcastcomv1alpha1.Map{},
-			client.InNamespace(hzNamespace),
-			client.PropagationPolicy(v1.DeletePropagationForeground),
-			client.MatchingLabels(labels)),
-		).Should(Succeed())
-		Expect(k8sClient.Delete(context.Background(), emptyHazelcast(hzSourceLookupKey), client.PropagationPolicy(v1.DeletePropagationForeground))).Should(Succeed())
-		Expect(k8sClient.Delete(context.Background(), emptyHazelcast(hzTargetLookupKey), client.PropagationPolicy(v1.DeletePropagationForeground))).Should(Succeed())
+		DeleteAllOf(&hazelcastcomv1alpha1.WanReplication{}, hzNamespace, labels)
+		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, hzNamespace, labels)
+		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, hzNamespace, labels)
 	})
 
 	It("should send data to another cluster", Label("slow"), func() {
 		if !ee {
 			Skip("This test will only run in EE configuration")
 		}
+		setLabelAndCRName("hw-1")
 		// Create source and target Hazelcast clusters
 		hazelcastSource := hazelcastconfig.ExposeExternallyUnisocket(hzSourceLookupKey, ee, labels)
 		hazelcastSource.Spec.ClusterName = "source"

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -24,7 +24,6 @@ import (
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -247,15 +246,6 @@ func CreateClientPod(hzAddress string, mapSizeInGb string, mapName string) *core
 	return clientPod
 }
 
-func emptyHazelcast(lk types.NamespacedName) *hazelcastcomv1alpha1.Hazelcast {
-	return &hazelcastcomv1alpha1.Hazelcast{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      lk.Name,
-			Namespace: lk.Namespace,
-		},
-	}
-}
-
 func isHazelcastRunning(hz *hazelcastcomv1alpha1.Hazelcast) bool {
 	return hz.Status.Phase == "Running"
 }
@@ -400,15 +390,6 @@ func createHazelcastClient(ctx context.Context, h *hazelcastcomv1alpha1.Hazelcas
 	client, err := hzClient.StartNewClientWithConfig(ctx, config)
 	Expect(err).To(BeNil())
 	return client
-}
-
-func emptyManagementCenter(lk types.NamespacedName) *hazelcastcomv1alpha1.ManagementCenter {
-	return &hazelcastcomv1alpha1.ManagementCenter{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      lk.Name,
-			Namespace: lk.Namespace,
-		},
-	}
 }
 
 func isManagementCenterRunning(mc *hazelcastcomv1alpha1.ManagementCenter) bool {

--- a/test/e2e/options_test.go
+++ b/test/e2e/options_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"flag"
+	"math/rand"
 	"time"
 )
 
@@ -15,4 +16,5 @@ func init() {
 	flag.StringVar(&hzNamespace, "namespace", "default", "The namespace to run e2e tests")
 	flag.DurationVar(&interval, "interval", 1*time.Second, "The length of time between checks")
 	flag.BoolVar(&ee, "ee", true, "Flag to define whether Enterprise edition of Hazelcast will be used")
+	rand.Seed(time.Now().UnixNano())
 }

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -231,3 +231,13 @@ func deletePods(lk types.NamespacedName) {
 		}
 	}
 }
+
+func DeleteAllOf(obj client.Object, ns string, labels map[string]string) {
+	Expect(k8sClient.DeleteAllOf(
+		context.Background(),
+		obj,
+		client.InNamespace(ns),
+		client.MatchingLabels(labels),
+		client.PropagationPolicy(metav1.DeletePropagationForeground),
+	)).Should(Succeed())
+}


### PR DESCRIPTION
Changes:
- Used unique resource names for each test case. 
- Formatted AfterEach Block to reuse code.