### PR TITLE
disable lowDataMode for logging

### DIFF
--- a/.github/newrelic/newrelic-values.yaml
+++ b/.github/newrelic/newrelic-values.yaml
@@ -1,6 +1,7 @@
 newrelic-infrastructure:
   # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true
+  lowDataMode: true
 
 nri-prometheus:
   # nri-prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)

--- a/.github/newrelic/newrelic-values.yaml
+++ b/.github/newrelic/newrelic-values.yaml
@@ -27,6 +27,7 @@ nri-kube-events:
 newrelic-logging:
   # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
   enabled: true
+  lowDataMode: false
   fluentBit:
     config:
       filters: |
@@ -127,7 +128,7 @@ global:
 
   # -- (bool) Reduces number of metrics sent in order to reduce costs
   # @default -- false
-  lowDataMode: true
+  lowDataMode:
 
   # -- (bool) In each integration it has different behavior. See [Further information](#values-managed-globally-3) but all aims to send less metrics to the backend to try to save costs |
   # @default -- false


### PR DESCRIPTION
We need to disable `lowDataMode` for logging as we need the `k8s` attributes included in the logs (such as pod name, namespace, etc.). On the other hand, `nri-infrastructure` data should be in the `lowDataMode` as this is the main source of data ingestion