### PR TITLE
Fix PR builder create-gke-cluster trigger

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -91,15 +91,16 @@ jobs:
     runs-on: ubuntu-20.04
     needs: ['unit-tests','linter']
     if: >-
-      ${{ !cancelled() }} && (
-      (github.event_name == 'pull_request_target'
-        && github.event.action == 'labeled'
-        && github.event.label.name == 'safe-to-test'
-        && github.event.pull_request.head.repo.full_name != github.repository)
-      ||
-      (github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name == github.repository
-        && needs.unit-tests.result == 'success'))
+      ( !cancelled()
+      && ((github.event_name == 'pull_request_target'
+            && github.event.action == 'labeled'
+            && github.event.label.name == 'safe-to-test'
+            && github.event.pull_request.head.repo.full_name != github.repository)
+          ||
+          (github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository))
+      && needs.unit-tests.result == 'success'
+      && needs.linter.result == 'success')
     outputs:
       CLUSTER_NAME: ${{ steps.set-cluster-name.outputs.CLUSTER_NAME }}
     env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Run integration tests (EE)
         run: make GO_TEST_FLAGS="-ee=true" test-it
 
+
   create-gke-cluster:
     name: Create GKE cluster and push image
     runs-on: ubuntu-20.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -91,16 +91,15 @@ jobs:
     runs-on: ubuntu-20.04
     needs: ['unit-tests','linter']
     if: >-
-      ${{ !cancelled() }} 
-      && (((github.event_name == 'pull_request_target'
-            && github.event.action == 'labeled'
-            && github.event.label.name == 'safe-to-test'
-            && github.event.pull_request.head.repo.full_name != github.repository)
-          ||
-          (github.event_name == 'pull_request'
-            && github.event.pull_request.head.repo.full_name == github.repository))
-      && needs.unit-tests.result == 'success'
-      && needs.linter.result == 'success')
+      ${{ !cancelled() }} && (
+      (github.event_name == 'pull_request_target'
+        && github.event.action == 'labeled'
+        && github.event.label.name == 'safe-to-test'
+        && github.event.pull_request.head.repo.full_name != github.repository)
+      ||
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && needs.unit-tests.result == 'success'))
     outputs:
       CLUSTER_NAME: ${{ steps.set-cluster-name.outputs.CLUSTER_NAME }}
     env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Run integration tests (EE)
         run: make GO_TEST_FLAGS="-ee=true" test-it
 
-
   create-gke-cluster:
     name: Create GKE cluster and push image
     runs-on: ubuntu-20.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -91,7 +91,7 @@ jobs:
     needs: ['unit-tests','linter']
     if: >-
       ${{ !cancelled() }} 
-      && ((github.event_name == 'pull_request_target'
+      && (((github.event_name == 'pull_request_target'
             && github.event.action == 'labeled'
             && github.event.label.name == 'safe-to-test'
             && github.event.pull_request.head.repo.full_name != github.repository)
@@ -99,7 +99,7 @@ jobs:
           (github.event_name == 'pull_request'
             && github.event.pull_request.head.repo.full_name == github.repository))
       && needs.unit-tests.result == 'success'
-      && needs.linter.result == 'success'
+      && needs.linter.result == 'success')
     outputs:
       CLUSTER_NAME: ${{ steps.set-cluster-name.outputs.CLUSTER_NAME }}
     env:


### PR DESCRIPTION
Currently when the workflow is cancelled `create-gke-cluster` workflow does not get cancelled. With the following changes it gets cancelled. 