### PR TITLE
[CN-452] Fix CreateHazelcastCR function

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -82,7 +82,9 @@ func CreateHazelcastCR(hazelcast *hazelcastcomv1alpha1.Hazelcast) {
 		hz := &hazelcastcomv1alpha1.Hazelcast{}
 		Eventually(func() bool {
 			err := k8sClient.Get(context.Background(), lk, hz)
-			Expect(err).ToNot(HaveOccurred())
+			if err != nil {
+				return false
+			}
 			return isHazelcastRunning(hz)
 		}, 10*Minute, interval).Should(BeTrue())
 	})


### PR DESCRIPTION
In Eventually block of function CreateHazelcastCR, there is an Expect block which makes the logic of Eventually block obsolete. Related error is here https://github.com/hazelcast/hazelcast-platform-operator/runs/7211567958?check_suite_focus=true
