### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is a short video to deploy a simple Hazelcast Platform cluster and Manageme
 ## Documentation
 
 1. [Get started](https://docs.hazelcast.com/operator/latest/get-started) with the Operator.
-2. [Connect the cluster from outside Kubernetes](https://guides.hazelcast.org/hazelcast-platform-operator-expose-externally/main)
+2. [Connect the cluster from outside Kubernetes](https://guides.hazelcast.org/hazelcast-platform-operator-expose-externally)
    from the outside.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is a short video to deploy a simple Hazelcast Platform cluster and Manageme
 ## Documentation
 
 1. [Get started](https://docs.hazelcast.com/operator/latest/get-started) with the Operator.
-2. [Connect the cluster from outside Kubernetes](https://guides.hazelcast.org/hazelcast-platform-operator-expose-externally)
+2. [Connect the cluster from outside Kubernetes](https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally)
    from the outside.
 
 ## Features


### PR DESCRIPTION
Fixed link for "Connect the cluster from outside Kubernetes", "/main" removed.