### PR TITLE
Disable lowDataMode as not needed

### DIFF
--- a/.github/newrelic/newrelic-values.yaml
+++ b/.github/newrelic/newrelic-values.yaml
@@ -1,7 +1,6 @@
 newrelic-infrastructure:
   # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true
-  lowDataMode: true
   common:
     config:
       namespaceSelector:
@@ -33,7 +32,6 @@ nri-kube-events:
 newrelic-logging:
   # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
   enabled: true
-  lowDataMode: false
   fluentBit:
     config:
       filters: |


### PR DESCRIPTION
As for NewRelic settings, I have disabled scraping the needed GKE clusters data, which was the main reason for the huge amount of data ingestion. Without this, the `lowDataMode` is not needed as the data ingestion is less than 1GB a day for all the clouds