### PR TITLE
[CN-446] Format Hazelcast Pod logs as JSON

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1002,6 +1002,10 @@ func env(h *hazelcastv1alpha1.Hazelcast) []v1.EnvVar {
 			Name:  "HZ_PHONE_HOME_ENABLED",
 			Value: strconv.FormatBool(util.IsPhoneHomeEnabled()),
 		},
+		{
+			Name:  "LOGGING_PATTERN",
+			Value: `{"time":"%date{ISO8601}", "logger": "%logger{36}", "level": "%level", "msg": "%enc{%m %xEx}{JSON}"}%n`,
+		},
 	}
 	if h.Spec.LicenseKeySecret != "" {
 		envs = append(envs,


### PR DESCRIPTION
Always use structured logging for easier cloud logging integrations.

Example:
```json
{"time":"2022-07-25T09:08:43,462", "logger": "com.hazelcast.client.impl.protocol.task.AuthenticationMessageTask", "level": "INFO", "msg": "[10.244.0.5]:5701 [dev] [5.1.2] Received auth from Connection[id=19, /10.244.0.5:5701->/172.18.0.1:32840, qualifier=null, endpoint=[172.18.0.1]:32840, remoteUuid=4dad2ad4-d082-4c06-888f-4861d00ce9d9, alive=true, connectionType=GOO, planeIndex=-1], successfully authenticated, clientUuid: 4dad2ad4-d082-4c06-888f-4861d00ce9d9, client name: hz.client_1, client version: 1.2.0 "}
```