### PR TITLE
[CN-473] Add backup package with retry logic

### DIFF
--- a/controllers/hazelcast/config/hazelcast_config.go
+++ b/controllers/hazelcast/config/hazelcast_config.go
@@ -1,7 +1,7 @@
 //go:build !localrun && !unittest
 // +build !localrun,!unittest
 
-package hazelcast
+package config
 
 import (
 	"fmt"
@@ -13,7 +13,7 @@ import (
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 )
 
-func buildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
+func BuildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
 	config := hazelcast.Config{
 		Logger: logger.Config{
 			Level: logger.OffLevel,
@@ -21,14 +21,14 @@ func buildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
 	}
 	cc := &config.Cluster
 	cc.Name = h.Spec.ClusterName
-	cc.Network.SetAddresses(hazelcastUrl(h))
+	cc.Network.SetAddresses(HazelcastUrl(h))
 	return config
 }
 
-func restUrl(h *hazelcastv1alpha1.Hazelcast) string {
-	return fmt.Sprintf("http://%s", hazelcastUrl(h))
+func RestUrl(h *hazelcastv1alpha1.Hazelcast) string {
+	return fmt.Sprintf("http://%s", HazelcastUrl(h))
 }
 
-func hazelcastUrl(h *hazelcastv1alpha1.Hazelcast) string {
+func HazelcastUrl(h *hazelcastv1alpha1.Hazelcast) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", h.Name, h.Namespace, n.DefaultHzPort)
 }

--- a/controllers/hazelcast/config/hazelcast_config_local_run.go
+++ b/controllers/hazelcast/config/hazelcast_config_local_run.go
@@ -3,7 +3,7 @@
 
 // This file is used  for running operator locally and connect to the cluster that uses ExposeExternally feature
 
-package hazelcast
+package config
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ import (
 
 const localUrl = "127.0.0.1:8000"
 
-func buildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
+func BuildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
 	config := hazelcast.Config{
 		Logger: logger.Config{
 			Level: logger.OffLevel,
@@ -24,15 +24,15 @@ func buildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
 	}
 	cc := &config.Cluster
 	cc.Name = h.Spec.ClusterName
-	cc.Network.SetAddresses(hazelcastUrl(h))
+	cc.Network.SetAddresses(HazelcastUrl(h))
 	cc.Unisocket = true
 	return config
 }
 
-func restUrl(h *hazelcastv1alpha1.Hazelcast) string {
-	return fmt.Sprintf("http://%s", hazelcastUrl(h))
+func RestUrl(h *hazelcastv1alpha1.Hazelcast) string {
+	return fmt.Sprintf("http://%s", HazelcastUrl(h))
 }
 
-func hazelcastUrl(_ *hazelcastv1alpha1.Hazelcast) string {
+func HazelcastUrl(_ *hazelcastv1alpha1.Hazelcast) string {
 	return localUrl
 }

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client"
 	"github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/validation"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/phonehome"
@@ -175,7 +176,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	CreateClient(ctx, h, r.triggerReconcileChan, r.Log)
+	hzclient.CreateClient(ctx, h, r.triggerReconcileChan, r.Log)
 
 	if util.IsPhoneHomeEnabled() {
 		firstDeployment := r.metrics.HazelcastMetrics[h.UID].FillAfterDeployment(h)
@@ -196,7 +197,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 func (r *HazelcastReconciler) runningPhaseWithStatus(req ctrl.Request) optionsBuilder {
-	if hzClient, ok := GetClient(req.NamespacedName); ok {
+	if hzClient, ok := hzclient.GetClient(req.NamespacedName); ok {
 		return runningPhase().withStatus(hzClient.Status)
 	}
 	return runningPhase()
@@ -253,7 +254,7 @@ func getHazelcastCRName(pod *corev1.Pod) (string, bool) {
 }
 
 func clientConnectionMessage(req ctrl.Request) string {
-	c, ok := GetClient(req.NamespacedName)
+	c, ok := hzclient.GetClient(req.NamespacedName)
 	if !ok {
 		return "Operator failed to create connection to cluster, some features might be unavailable."
 	}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/config"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/platform"
@@ -65,7 +66,7 @@ func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcast
 	if util.IsPhoneHomeEnabled() {
 		delete(r.metrics.HazelcastMetrics, h.UID)
 	}
-	ShutdownClient(ctx, types.NamespacedName{Name: h.Name, Namespace: h.Namespace})
+	hzclient.ShutdownClient(ctx, types.NamespacedName{Name: h.Name, Namespace: h.Namespace})
 	return nil
 }
 

--- a/controllers/hazelcast/hazelcast_resources_test.go
+++ b/controllers/hazelcast/hazelcast_resources_test.go
@@ -9,6 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client"
 )
 
 func Test_clientShutdownWhenConnectionNotEstablished(t *testing.T) {
@@ -19,7 +20,7 @@ func Test_clientShutdownWhenConnectionNotEstablished(t *testing.T) {
 		},
 	}
 	r := reconcilerWithCR(h)
-	clients.Store(types.NamespacedName{Name: h.Name, Namespace: h.Namespace}, &Client{})
+	hzclient.Clients.Store(types.NamespacedName{Name: h.Name, Namespace: h.Namespace}, &hzclient.Client{})
 
 	err := r.executeFinalizer(context.Background(), h, ctrl.Log)
 	if err != nil {

--- a/controllers/hazelcast/hazelcast_rest_client.go
+++ b/controllers/hazelcast/hazelcast_rest_client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	"github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/config"
 )
 
 // Section contains the REST API endpoints.
@@ -42,7 +43,7 @@ type stateResponse struct {
 
 func NewRestClient(h *v1alpha1.Hazelcast) *RestClient {
 	return &RestClient{
-		url:         restUrl(h),
+		url:         config.RestUrl(h),
 		clusterName: h.Spec.ClusterName,
 	}
 }

--- a/controllers/hazelcast/hot_backup_status.go
+++ b/controllers/hazelcast/hot_backup_status.go
@@ -1,11 +1,6 @@
 package hazelcast
 
 import (
-	"context"
-	"errors"
-	"time"
-
-	hztypes "github.com/hazelcast/hazelcast-go-client/types"
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 )
 
@@ -26,48 +21,5 @@ func failedHbStatus(err error) hotBackupOptionsBuilder {
 		status:  hazelcastv1alpha1.HotBackupFailure,
 		err:     err,
 		message: err.Error(),
-	}
-}
-
-var (
-	errBackupFailed            = errors.New("Backup failed")
-	errBackupMemberStateFailed = errors.New("Backup member state update failed")
-	errBackupNoTask            = errors.New("Backup member state indicates no task started")
-)
-
-func waitUntilBackupSucceed(ctx context.Context, client *Client, uuid hztypes.UUID) error {
-	var n int
-	for {
-		state := client.getTimedMemberState(ctx, uuid)
-		if state == nil {
-			return errBackupMemberStateFailed
-		}
-
-		s := state.TimedMemberState.MemberState.HotRestartState.BackupTaskState
-		switch s {
-		case "FAILURE":
-			return errBackupFailed
-		case "SUCCESS":
-			return nil
-		case "NO_TASK":
-			// sometimes it takes few seconds for task to start
-			if n > 10 {
-				return errBackupNoTask
-			}
-			n++
-		case "IN_PROGRESS":
-			// expected, check status again (no return)
-		default:
-			return errors.New("Backup unknown status: " + s)
-
-		}
-
-		// wait for timer or context to cancel
-		select {
-		case <-time.After(1 * time.Second):
-			continue
-		case <-ctx.Done():
-			return ctx.Err()
-		}
 	}
 }

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/config"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/protocol/codec"
@@ -185,15 +186,15 @@ func ValidateNotUpdatableFields(current *hazelcastv1alpha1.MapSpec, last *hazelc
 }
 
 func GetHazelcastClient(m *hazelcastv1alpha1.Map) (*hazelcast.Client, error) {
-	hzcl, ok := GetClient(types.NamespacedName{Name: m.Spec.HazelcastResourceName, Namespace: m.Namespace})
+	hzcl, ok := hzclient.GetClient(types.NamespacedName{Name: m.Spec.HazelcastResourceName, Namespace: m.Namespace})
 	if !ok {
 		return nil, errors.NewInternalError(fmt.Errorf("cannot connect to the cluster for %s", m.Spec.HazelcastResourceName))
 	}
-	if hzcl.client == nil || !hzcl.client.Running() {
+	if hzcl.Client == nil || !hzcl.Client.Running() {
 		return nil, fmt.Errorf("trying to connect to the cluster %s", m.Spec.HazelcastResourceName)
 	}
 
-	return hzcl.client, nil
+	return hzcl.Client, nil
 }
 
 func (r *MapReconciler) ReconcileMapConfig(

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,0 +1,171 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/hazelcast/hazelcast-platform-operator/internal/rest"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+
+	hztypes "github.com/hazelcast/hazelcast-go-client/types"
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client"
+	hzconfig "github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/config"
+)
+
+type ClusterBackup struct {
+	client  *hzclient.Client
+	service *rest.HazelcastService
+
+	clusterName string
+	members     map[hztypes.UUID]*hzclient.MemberData
+
+	cancelOnce sync.Once
+}
+
+var (
+	errBackupClientNotFound  = errors.New("client not found for hot backup CR")
+	errBackupClientNoMembers = errors.New("client couldnt connect to members")
+)
+
+func NewClusterBackup(h *hazelcastv1alpha1.Hazelcast) (*ClusterBackup, error) {
+	c, ok := hzclient.GetClient(types.NamespacedName{Namespace: h.Namespace, Name: h.Name})
+	if !ok {
+		return nil, errBackupClientNotFound
+	}
+
+	c.UpdateMembers(context.TODO())
+
+	if c.Status == nil {
+		return nil, errBackupClientNoMembers
+	}
+
+	if c.Status.MemberMap == nil {
+		return nil, errBackupClientNoMembers
+	}
+
+	s, err := rest.NewHazelcastService(hzconfig.RestUrl(h))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClusterBackup{
+		client:      c,
+		service:     s,
+		members:     c.Status.MemberMap,
+		clusterName: h.Spec.ClusterName,
+	}, nil
+}
+
+func (b *ClusterBackup) Start(ctx context.Context) error {
+	// switch cluster to passive for the time of hot backup
+	err := retryOnError(retry.DefaultRetry, func() error {
+		_, _, err := b.service.ChangeState(ctx, b.clusterName, "PASSIVE")
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	// activate cluster after backup, silently ignore state change status
+	defer retryOnError(retry.DefaultRetry, func() error { //nolint:errcheck
+		_, _, err := b.service.ChangeState(ctx, b.clusterName, "ACTIVE")
+		return err
+	})
+
+	return retryOnError(retry.DefaultBackoff, func() error {
+		_, err := b.service.HotBackup(ctx, b.clusterName)
+		return err
+	})
+}
+
+func (b *ClusterBackup) Cancel(ctx context.Context) error {
+	var err error
+	b.cancelOnce.Do(func() {
+		_, err = b.service.HotBackupInterrupt(ctx, b.clusterName)
+	})
+	return err
+}
+
+func (b *ClusterBackup) Members() []*MemberBackup {
+	var mb []*MemberBackup
+	for uuid, m := range b.members {
+		mb = append(mb, &MemberBackup{
+			client:  b.client,
+			Address: m.Address,
+			UUID:    uuid,
+		})
+	}
+	return mb
+}
+
+type MemberBackup struct {
+	client *hzclient.Client
+
+	UUID    hztypes.UUID
+	Address string
+}
+
+var (
+	errMemberBackupFailed      = errors.New("member backup failed")
+	errMemberBackupStateFailed = errors.New("member backup state update failed")
+	errMemberBackupNoTask      = errors.New("member backup state indicates no task started")
+)
+
+func (mb *MemberBackup) Wait(ctx context.Context) error {
+	var n int
+	for {
+		state := mb.client.GetTimedMemberState(ctx, mb.UUID)
+		if state == nil {
+			return errMemberBackupStateFailed
+		}
+
+		s := state.TimedMemberState.MemberState.HotRestartState.BackupTaskState
+		switch s {
+		case "FAILURE":
+			return errMemberBackupFailed
+		case "SUCCESS":
+			return nil
+		case "NO_TASK":
+			// sometimes it takes few seconds for task to start
+			if n > 10 {
+				return errMemberBackupNoTask
+			}
+			n++
+		case "IN_PROGRESS":
+			// expected, check status again (no return)
+		default:
+			return errors.New("backup unknown status: " + s)
+
+		}
+
+		// wait for timer or context to cancel
+		select {
+		case <-time.After(1 * time.Second):
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func retryOnError(backoff wait.Backoff, fn func() error) error {
+	return retry.OnError(backoff, isHazelcastError, fn)
+}
+
+func isHazelcastError(err error) bool {
+	switch err.(type) {
+	// normal response but with failed status
+	case *rest.HazelcastError:
+		return true
+	// hot backup sometimes fails with generic 500
+	case *rest.ErrorResponse:
+		return true
+	// all other errors including connection errors should fail
+	default:
+		return false
+	}
+}

--- a/internal/rest/hazelcast_service.go
+++ b/internal/rest/hazelcast_service.go
@@ -1,0 +1,153 @@
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type HazelcastService struct {
+	client *Client
+}
+
+func NewHazelcastService(address string) (*HazelcastService, error) {
+	baseURL, err := url.Parse(address)
+	if err != nil {
+		return nil, err
+	}
+	return &HazelcastService{
+		client: &Client{
+			BaseURL: baseURL,
+			client:  &http.Client{},
+		},
+	}, nil
+}
+
+type HazelcastState struct {
+	Status string `json:"status,omitempty"`
+	State  string `json:"state,omitempty"`
+
+	// exceptionResponse
+	Message string `json:"message,omitempty"`
+}
+
+func (s *HazelcastService) GetState(ctx context.Context, clusterName string) (*HazelcastState, *http.Response, error) {
+	u := "hazelcast/rest/management/cluster/state"
+	b := fmt.Sprintf("%s&", clusterName) // "${CLUSTERNAME}&${PASSWORD}"
+
+	req, err := s.client.NewRequest("POST", u, b)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	state := new(HazelcastState)
+	resp, err := s.client.Do(ctx, req, state)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if err := checkState(resp, state); err != nil {
+		return nil, resp, err
+	}
+
+	return state, resp, nil
+}
+
+func (s *HazelcastService) ChangeState(ctx context.Context, clusterName, newState string) (*HazelcastState, *http.Response, error) {
+	u := "hazelcast/rest/management/cluster/changeState"
+	b := fmt.Sprintf("%s&&%s", clusterName, newState) // "${CLUSTERNAME}&${PASSWORD}&${STATE}"
+
+	req, err := s.client.NewRequest("POST", u, b)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	state := new(HazelcastState)
+	resp, err := s.client.Do(ctx, req, state)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if err := checkState(resp, state); err != nil {
+		return nil, resp, err
+	}
+
+	return state, resp, nil
+}
+
+type HazelcastStatus struct {
+	Status string `json:"status,omitempty"`
+
+	// exceptionResponse
+	Message string `json:"message,omitempty"`
+}
+
+func (s *HazelcastService) HotBackup(ctx context.Context, clusterName string) (*http.Response, error) {
+	u := "hazelcast/rest/management/cluster/hotBackup"
+	b := fmt.Sprintf("%s&", clusterName) // "${CLUSTERNAME}&${PASSWORD}"
+
+	req, err := s.client.NewRequest("POST", u, b)
+	if err != nil {
+		return nil, err
+	}
+
+	status := new(HazelcastStatus)
+	resp, err := s.client.Do(ctx, req, status)
+	if err != nil {
+		return resp, err
+	}
+
+	if err := checkStatus(resp, status); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+func (s *HazelcastService) HotBackupInterrupt(ctx context.Context, clusterName string) (*http.Response, error) {
+	u := "hazelcast/rest/management/cluster/hotBackupInterrupt"
+	b := fmt.Sprintf("%s&", clusterName) // "${CLUSTERNAME}&${PASSWORD}"
+
+	req, err := s.client.NewRequest("POST", u, b)
+	if err != nil {
+		return nil, err
+	}
+
+	status := new(HazelcastStatus)
+	resp, err := s.client.Do(ctx, req, status)
+	if err != nil {
+		return resp, err
+	}
+
+	if err := checkStatus(resp, status); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+type HazelcastError struct {
+	Status   string
+	Message  string
+	Response *http.Response
+}
+
+func (r *HazelcastError) Error() string {
+	return fmt.Sprintf("%v %v: %d %v %+v",
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Status, r.Message)
+}
+
+func checkState(r *http.Response, s *HazelcastState) error {
+	if s.Status == "success" {
+		return nil
+	}
+	return &HazelcastError{Status: s.Status, Message: s.Message, Response: r}
+}
+
+func checkStatus(r *http.Response, s *HazelcastStatus) error {
+	if s.Status == "success" {
+		return nil
+	}
+	return &HazelcastError{Status: s.Status, Message: s.Message, Response: r}
+}


### PR DESCRIPTION
In addition to creating `backup` package we needed to move `client` and `config` to new packages to avoid circular dependency.

Retry logic will try to rerun http request only if it was successful http request but Hazelcast status is other than `success`.