### PR TITLE
[CN-475] Add finalizer logic for deleting dependent child CRs

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Phase represents the current state of the cluster
-// +kubebuilder:validation:Enum=Running;Failed;Pending
+// +kubebuilder:validation:Enum=Running;Failed;Pending;Terminating
 type Phase string
 
 const (
@@ -20,6 +20,8 @@ const (
 	Failed Phase = "Failed"
 	// Pending phase is the state of starting the cluster when not all the members are started yet
 	Pending Phase = "Pending"
+	// Terminating phase is the state where deletion of cluster scoped resources and Hazelcast dependent resources happen
+	Terminating Phase = "Terminating"
 )
 
 // HazelcastSpec defines the desired state of Hazelcast

--- a/api/v1alpha1/map_types.go
+++ b/api/v1alpha1/map_types.go
@@ -184,6 +184,7 @@ type MapStatus struct {
 	MemberStatuses map[string]MapConfigState `json:"memberStatuses,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Success;Failed;Pending;Persisting;Terminating
 type MapConfigState string
 
 const (
@@ -191,7 +192,8 @@ const (
 	MapSuccess MapConfigState = "Success"
 	MapPending MapConfigState = "Pending"
 	// Map config is added into all members but waiting for map to be persisten into ConfigMap
-	MapPersisting MapConfigState = "Persisting"
+	MapPersisting  MapConfigState = "Persisting"
+	MapTerminating MapConfigState = "Terminating"
 )
 
 type MapStoreConfig struct {

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1203,6 +1203,7 @@ spec:
                 - Running
                 - Failed
                 - Pending
+                - Terminating
                 type: string
               restore:
                 description: Status of restore process of the Hazelcast cluster
@@ -2296,6 +2297,7 @@ spec:
                 - Running
                 - Failed
                 - Pending
+                - Terminating
                 type: string
             type: object
         type: object
@@ -2516,11 +2518,23 @@ spec:
             properties:
               memberStatuses:
                 additionalProperties:
+                  enum:
+                  - Success
+                  - Failed
+                  - Pending
+                  - Persisting
+                  - Terminating
                   type: string
                 type: object
               message:
                 type: string
               state:
+                enum:
+                - Success
+                - Failed
+                - Pending
+                - Persisting
+                - Terminating
                 type: string
             type: object
         required:

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -1205,6 +1205,7 @@ spec:
                 - Running
                 - Failed
                 - Pending
+                - Terminating
                 type: string
               restore:
                 description: Status of restore process of the Hazelcast cluster

--- a/config/crd/bases/hazelcast.com_managementcenters.yaml
+++ b/config/crd/bases/hazelcast.com_managementcenters.yaml
@@ -957,6 +957,7 @@ spec:
                 - Running
                 - Failed
                 - Pending
+                - Terminating
                 type: string
             type: object
         type: object

--- a/config/crd/bases/hazelcast.com_maps.yaml
+++ b/config/crd/bases/hazelcast.com_maps.yaml
@@ -206,11 +206,23 @@ spec:
             properties:
               memberStatuses:
                 additionalProperties:
+                  enum:
+                  - Success
+                  - Failed
+                  - Pending
+                  - Persisting
+                  - Terminating
                   type: string
                 type: object
               message:
                 type: string
               state:
+                enum:
+                - Success
+                - Failed
+                - Pending
+                - Persisting
+                - Terminating
                 type: string
             type: object
         required:

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -120,6 +120,11 @@ func (r *HazelcastReconciler) deleteDependentHotBackups(ctx context.Context, h *
 	if err := r.Client.List(ctx, hbl, fieldMatcher, nsMatcher); err != nil {
 		return fmt.Errorf("Hazelcast dependent HotBackup resources are not deleted yet %w", err)
 	}
+
+	if len(hbl.Items) != 0 {
+		return fmt.Errorf("Hazelcast dependent HotBackup resources are not deleted yet.")
+	}
+
 	return nil
 }
 
@@ -152,6 +157,11 @@ func (r *HazelcastReconciler) deleteDependentMaps(ctx context.Context, h *hazelc
 	if err := r.Client.List(ctx, ml, fieldMatcher, nsMatcher); err != nil {
 		return fmt.Errorf("Hazelcast dependent Map resources are not deleted yet %w", err)
 	}
+
+	if len(ml.Items) != 0 {
+		return fmt.Errorf("Hazelcast dependent Map resources are not deleted yet.")
+	}
+
 	return nil
 }
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hazelcast/hazelcast-go-client"
 	proto "github.com/hazelcast/hazelcast-go-client"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,9 @@ func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcast
 	if !controllerutil.ContainsFinalizer(h, n.Finalizer) {
 		return nil
 	}
-
+	if err := r.deleteDependentCRs(ctx, h, logger); err != nil {
+		return fmt.Errorf("Could not delete all dependent CRs: %w", err)
+	}
 	if err := r.removeClusterRole(ctx, h, logger); err != nil {
 		return fmt.Errorf("ClusterRole could not be removed: %w", err)
 	}
@@ -73,6 +76,88 @@ func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcast
 		delete(r.metrics.HazelcastMetrics, h.UID)
 	}
 	hzclient.ShutdownClient(ctx, types.NamespacedName{Name: h.Name, Namespace: h.Namespace})
+	return nil
+}
+
+func (r *HazelcastReconciler) deleteDependentCRs(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+	err := r.deleteDependentHotBackups(ctx, h, logger)
+	if err != nil {
+		return err
+	}
+	err = r.deleteDependentMaps(ctx, h, logger)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *HazelcastReconciler) deleteDependentHotBackups(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+	hbl := &hazelcastv1alpha1.HotBackupList{}
+
+	if err := r.Client.List(ctx, hbl,
+		client.MatchingFields{"hazelcastResourceName": h.Name},
+		client.InNamespace(h.Namespace),
+	); err != nil {
+		return fmt.Errorf("Could not get Hazelcast dependent HotBackups %w", err)
+	}
+
+	if len(hbl.Items) == 0 {
+		return nil
+	}
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	for i := 0; i < len(hbl.Items); i++ {
+		i := i
+		g.Go(func() error {
+			return util.DeleteObject(groupCtx, r.Client, &hbl.Items[i])
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("Error deleting HotBackup CRs %w", err)
+	}
+
+	if err := r.Client.List(ctx, hbl,
+		client.MatchingFields{"hazelcastResourceName": h.Name},
+		client.InNamespace(h.Namespace),
+	); err != nil {
+		return fmt.Errorf("Hazelcast dependent HotBackup resources are not deleted yet %w", err)
+	}
+	return nil
+}
+
+func (r *HazelcastReconciler) deleteDependentMaps(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+	ml := &hazelcastv1alpha1.MapList{}
+
+	if err := r.Client.List(ctx, ml,
+		client.MatchingFields{"hazelcastResourceName": h.Name},
+		client.InNamespace(h.Namespace),
+	); err != nil {
+		return fmt.Errorf("Could not get Hazelcast dependent Maps resources %w", err)
+	}
+
+	if len(ml.Items) == 0 {
+		return nil
+	}
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	for i := 0; i < len(ml.Items); i++ {
+		i := i
+		g.Go(func() error {
+			return util.DeleteObject(groupCtx, r.Client, &ml.Items[i])
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("Error deleting Map resources %w", err)
+	}
+
+	if err := r.Client.List(ctx, ml,
+		client.MatchingFields{"hazelcastResourceName": h.Name},
+		client.InNamespace(h.Namespace),
+	); err != nil {
+		return fmt.Errorf("Hazelcast dependent Maps resources are not deleted yet %w", err)
+	}
 	return nil
 }
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -92,13 +92,13 @@ func (r *HazelcastReconciler) deleteDependentCRs(ctx context.Context, h *hazelca
 }
 
 func (r *HazelcastReconciler) deleteDependentHotBackups(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+	fieldMatcher := client.MatchingFields{"hazelcastResourceName": h.Name}
+	nsMatcher := client.InNamespace(h.Namespace)
+
 	hbl := &hazelcastv1alpha1.HotBackupList{}
 
-	if err := r.Client.List(ctx, hbl,
-		client.MatchingFields{"hazelcastResourceName": h.Name},
-		client.InNamespace(h.Namespace),
-	); err != nil {
-		return fmt.Errorf("Could not get Hazelcast dependent HotBackups %w", err)
+	if err := r.Client.List(ctx, hbl, fieldMatcher, nsMatcher); err != nil {
+		return fmt.Errorf("Could not get Hazelcast dependent HotBackup resources %w", err)
 	}
 
 	if len(hbl.Items) == 0 {
@@ -114,26 +114,23 @@ func (r *HazelcastReconciler) deleteDependentHotBackups(ctx context.Context, h *
 	}
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("Error deleting HotBackup CRs %w", err)
+		return fmt.Errorf("Error deleting HotBackup resources %w", err)
 	}
 
-	if err := r.Client.List(ctx, hbl,
-		client.MatchingFields{"hazelcastResourceName": h.Name},
-		client.InNamespace(h.Namespace),
-	); err != nil {
+	if err := r.Client.List(ctx, hbl, fieldMatcher, nsMatcher); err != nil {
 		return fmt.Errorf("Hazelcast dependent HotBackup resources are not deleted yet %w", err)
 	}
 	return nil
 }
 
 func (r *HazelcastReconciler) deleteDependentMaps(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+	fieldMatcher := client.MatchingFields{"hazelcastResourceName": h.Name}
+	nsMatcher := client.InNamespace(h.Namespace)
+
 	ml := &hazelcastv1alpha1.MapList{}
 
-	if err := r.Client.List(ctx, ml,
-		client.MatchingFields{"hazelcastResourceName": h.Name},
-		client.InNamespace(h.Namespace),
-	); err != nil {
-		return fmt.Errorf("Could not get Hazelcast dependent Maps resources %w", err)
+	if err := r.Client.List(ctx, ml, fieldMatcher, nsMatcher); err != nil {
+		return fmt.Errorf("Could not get Hazelcast dependent Map resources %w", err)
 	}
 
 	if len(ml.Items) == 0 {
@@ -152,11 +149,8 @@ func (r *HazelcastReconciler) deleteDependentMaps(ctx context.Context, h *hazelc
 		return fmt.Errorf("Error deleting Map resources %w", err)
 	}
 
-	if err := r.Client.List(ctx, ml,
-		client.MatchingFields{"hazelcastResourceName": h.Name},
-		client.InNamespace(h.Namespace),
-	); err != nil {
-		return fmt.Errorf("Hazelcast dependent Maps resources are not deleted yet %w", err)
+	if err := r.Client.List(ctx, ml, fieldMatcher, nsMatcher); err != nil {
+		return fmt.Errorf("Hazelcast dependent Map resources are not deleted yet %w", err)
 	}
 	return nil
 }

--- a/controllers/hazelcast/hazelcast_status.go
+++ b/controllers/hazelcast/hazelcast_status.go
@@ -47,6 +47,13 @@ func runningPhase() optionsBuilder {
 	}
 }
 
+func terminatingPhase(err error) optionsBuilder {
+	return optionsBuilder{
+		phase: hazelcastv1alpha1.Terminating,
+		err:   err,
+	}
+}
+
 func (o optionsBuilder) withStatus(s *hzclient.Status) optionsBuilder {
 	o.readyMembers = s.MemberMap
 	o.restoreState = s.ClusterHotRestartStatus

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -187,12 +187,12 @@ func (r *MapReconciler) executeFinalizer(ctx context.Context, m *hazelcastv1alph
 }
 
 func (r *MapReconciler) deleteDependentCRs(ctx context.Context, m *hazelcastv1alpha1.Map, logger logr.Logger) error {
+	fieldMatcher := client.MatchingFields{"mapResourceName": m.Name}
+	nsMatcher := client.InNamespace(m.Namespace)
+
 	wrl := &hazelcastv1alpha1.WanReplicationList{}
 
-	if err := r.Client.List(ctx, wrl,
-		client.MatchingFields{"mapResourceName": m.Name},
-		client.InNamespace(m.Namespace),
-	); err != nil {
+	if err := r.Client.List(ctx, wrl, fieldMatcher, nsMatcher); err != nil {
 		return fmt.Errorf("Could not get Map dependent WanReplication resources %w", err)
 	}
 
@@ -212,10 +212,7 @@ func (r *MapReconciler) deleteDependentCRs(ctx context.Context, m *hazelcastv1al
 		return fmt.Errorf("Error deleting WanReplication resources %w", err)
 	}
 
-	if err := r.Client.List(ctx, &hazelcastv1alpha1.WanReplicationList{},
-		client.MatchingFields{"mapResourceName": m.Name},
-		client.InNamespace(m.Namespace),
-	); err != nil {
+	if err := r.Client.List(ctx, wrl, fieldMatcher, nsMatcher); err != nil {
 		return fmt.Errorf("Map dependent WanReplication resources are not deleted yet %w", err)
 	}
 	return nil

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -215,6 +215,11 @@ func (r *MapReconciler) deleteDependentCRs(ctx context.Context, m *hazelcastv1al
 	if err := r.Client.List(ctx, wrl, fieldMatcher, nsMatcher); err != nil {
 		return fmt.Errorf("Map dependent WanReplication resources are not deleted yet %w", err)
 	}
+
+	if len(wrl.Items) != 0 {
+		return fmt.Errorf("Map dependent WanReplication resources are not deleted yet.")
+	}
+
 	return nil
 }
 

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hazelcast/hazelcast-go-client"
 	proto "github.com/hazelcast/hazelcast-go-client"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -53,6 +54,21 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get Map: %w", err)
+	}
+
+	err = r.addFinalizer(ctx, m, logger)
+	if err != nil {
+		return updateMapStatus(ctx, r.Client, m, failedStatus(err).withMessage(err.Error()))
+	}
+
+	if m.GetDeletionTimestamp() != nil {
+		updateMapStatus(ctx, r.Client, m, terminatingStatus(nil)) //nolint:errcheck
+		err = r.executeFinalizer(ctx, m, logger)
+		if err != nil {
+			return updateMapStatus(ctx, r.Client, m, terminatingStatus(err).withMessage(err.Error()))
+		}
+		logger.V(2).Info("Finalizer's pre-delete function executed successfully and the finalizer removed from custom resource", "Name:", n.Finalizer)
+		return ctrl.Result{}, nil
 	}
 
 	h := &hazelcastv1alpha1.Hazelcast{}
@@ -141,6 +157,68 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	return updateMapStatus(ctx, r.Client, m, successStatus().
 		withMemberStatuses(nil))
+}
+
+func (r *MapReconciler) addFinalizer(ctx context.Context, m *hazelcastv1alpha1.Map, logger logr.Logger) error {
+	if !controllerutil.ContainsFinalizer(m, n.Finalizer) && m.GetDeletionTimestamp() == nil {
+		controllerutil.AddFinalizer(m, n.Finalizer)
+		err := r.Update(ctx, m)
+		if err != nil {
+			return err
+		}
+		logger.V(util.DebugLevel).Info("Finalizer added into custom resource successfully")
+	}
+	return nil
+}
+
+func (r *MapReconciler) executeFinalizer(ctx context.Context, m *hazelcastv1alpha1.Map, logger logr.Logger) error {
+	if !controllerutil.ContainsFinalizer(m, n.Finalizer) {
+		return nil
+	}
+	if err := r.deleteDependentCRs(ctx, m, logger); err != nil {
+		return fmt.Errorf("Could not delete all dependent CRs: %w", err)
+	}
+	controllerutil.RemoveFinalizer(m, n.Finalizer)
+	err := r.Update(ctx, m)
+	if err != nil {
+		return fmt.Errorf("failed to remove finalizer from custom resource: %w", err)
+	}
+	return nil
+}
+
+func (r *MapReconciler) deleteDependentCRs(ctx context.Context, m *hazelcastv1alpha1.Map, logger logr.Logger) error {
+	wrl := &hazelcastv1alpha1.WanReplicationList{}
+
+	if err := r.Client.List(ctx, wrl,
+		client.MatchingFields{"mapResourceName": m.Name},
+		client.InNamespace(m.Namespace),
+	); err != nil {
+		return fmt.Errorf("Could not get Map dependent WanReplication resources %w", err)
+	}
+
+	if len(wrl.Items) == 0 {
+		return nil
+	}
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	for i := 0; i < len(wrl.Items); i++ {
+		index := i
+		g.Go(func() error {
+			return util.DeleteObject(groupCtx, r.Client, &wrl.Items[index])
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("Error deleting WanReplication resources %w", err)
+	}
+
+	if err := r.Client.List(ctx, &hazelcastv1alpha1.WanReplicationList{},
+		client.MatchingFields{"mapResourceName": m.Name},
+		client.InNamespace(m.Namespace),
+	); err != nil {
+		return fmt.Errorf("Map dependent WanReplication resources are not deleted yet %w", err)
+	}
+	return nil
 }
 
 func ValidatePersistence(pe bool, h *hazelcastv1alpha1.Hazelcast) error {
@@ -370,6 +448,12 @@ func (r *MapReconciler) validateMapConfigPersistence(ctx context.Context, h *haz
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &hazelcastv1alpha1.WanReplication{}, "mapResourceName", func(rawObj client.Object) []string {
+		wr := rawObj.(*hazelcastv1alpha1.WanReplication)
+		return []string{wr.Spec.MapResourceName}
+	}); err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hazelcastv1alpha1.Map{}).
 		Complete(r)

--- a/controllers/hazelcast/map_status.go
+++ b/controllers/hazelcast/map_status.go
@@ -46,6 +46,13 @@ func persistingStatus(retryAfter time.Duration) mapOptionsBuilder {
 	}
 }
 
+func terminatingStatus(err error) mapOptionsBuilder {
+	return mapOptionsBuilder{
+		status: hazelcastv1alpha1.MapTerminating,
+		err:    err,
+	}
+}
+
 func (o mapOptionsBuilder) withMessage(m string) mapOptionsBuilder {
 	o.message = m
 	return o

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -302,3 +302,11 @@ func stringSliceEquals(a, b []string) bool {
 	}
 	return true
 }
+
+func DeleteObject(ctx context.Context, c client.Client, obj client.Object) error {
+	err := c.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	if err != nil && !kerrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/test/e2e/hazelcast_backup_slow_test.go
+++ b/test/e2e/hazelcast_backup_slow_test.go
@@ -266,16 +266,7 @@ var _ = Describe("Hazelcast Backup", Label("backup_slow"), func() {
 		hotBackup := hazelcastconfig.HotBackupAgent(hbLookupKey, hazelcast.Name, labels, bucketURI, secretName)
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 
-		By("waiting for backup to finish")
-		hb := &hazelcastcomv1alpha1.HotBackup{}
-		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
-			err := k8sClient.Get(
-				context.Background(), types.NamespacedName{Name: hotBackup.Name, Namespace: hzNamespace}, hb)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hb.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hb.Status.Message)
-			return hb.Status.State
-		}, 20*Minute, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
-
+		assertHotBackupSuccess(hotBackup, 20*Minute)
 		seq := GetBackupSequence(t, hzLookupKey)
 
 		By("removing cluster")

--- a/test/e2e/hazelcast_map_persistence_test.go
+++ b/test/e2e/hazelcast_map_persistence_test.go
@@ -108,15 +108,7 @@ var _ = Describe("Hazelcast Map Config with Persistence", Label("map_persistence
 		hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 
-		By("Wait for backup to finish")
-		hb := &hazelcastcomv1alpha1.HotBackup{}
-		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
-			err := k8sClient.Get(
-				context.Background(), types.NamespacedName{Name: hotBackup.Name, Namespace: hzNamespace}, hb)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hb.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hb.Status.Message)
-			return hb.Status.State
-		}, 10*Minute, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
+		assertHotBackupSuccess(hotBackup, 1*Minute)
 
 		seq := GetBackupSequence(t, hzLookupKey)
 		RemoveHazelcastCR(hazelcast)

--- a/test/e2e/hazelcast_persistence_test.go
+++ b/test/e2e/hazelcast_persistence_test.go
@@ -125,14 +125,7 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 			Should(ContainSubstring("ClusterStateChange{type=class com.hazelcast.cluster.ClusterState, newState=ACTIVE}"))
 		Expect(logs.Close()).Should(Succeed())
 
-		hb := &hazelcastcomv1alpha1.HotBackup{}
-		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
-			err := k8sClient.Get(
-				context.Background(), types.NamespacedName{Name: hotBackup.Name, Namespace: hzNamespace}, hb)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hb.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hb.Status.Message)
-			return hb.Status.State
-		}, 10*Minute, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
+		assertHotBackupSuccess(hotBackup, 1*Minute)
 
 		By("checking the Map size")
 		client := GetHzClient(ctx, hzLookupKey, true)
@@ -159,15 +152,7 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 		hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 
-		By("Wait for backup to finish")
-		hb := &hazelcastcomv1alpha1.HotBackup{}
-		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
-			err := k8sClient.Get(
-				context.Background(), types.NamespacedName{Name: hotBackup.Name, Namespace: hzNamespace}, hb)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hb.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hb.Status.Message)
-			return hb.Status.State
-		}, 10*Minute, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
+		assertHotBackupSuccess(hotBackup, 1*Minute)
 
 		seq := GetBackupSequence(t, hzLookupKey)
 		RemoveHazelcastCR(hazelcast)
@@ -197,15 +182,7 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 		hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 
-		By("Wait for backup to finish")
-		hb := &hazelcastcomv1alpha1.HotBackup{}
-		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
-			err := k8sClient.Get(
-				context.Background(), types.NamespacedName{Name: hotBackup.Name, Namespace: hzNamespace}, hb)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hb.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hb.Status.Message)
-			return hb.Status.State
-		}, 10*Minute, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
+		assertHotBackupSuccess(hotBackup, 1*Minute)
 
 		seq := GetBackupSequence(t, hzLookupKey)
 		RemoveHazelcastCR(hazelcast)
@@ -269,15 +246,7 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 		hotBackup := hazelcastconfig.HotBackupAgent(hbLookupKey, hazelcast.Name, labels, bucketURI, secretName)
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 
-		By("Wait for backup to finish")
-		hb := &hazelcastcomv1alpha1.HotBackup{}
-		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
-			err := k8sClient.Get(
-				context.Background(), types.NamespacedName{Name: hotBackup.Name, Namespace: hzNamespace}, hb)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hb.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hb.Status.Message)
-			return hb.Status.State
-		}, 10*Minute, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
+		assertHotBackupSuccess(hotBackup, 1*Minute)
 
 		seq := GetBackupSequence(t, hzLookupKey)
 

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	hazelcastconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/hazelcast"
@@ -116,4 +117,36 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 		})
 	})
 
+	Describe("Hazelcast CR dependent CRs", func() {
+		When("Hazelcast CR is deleted", func() {
+			FIt("dependent Map, WanReplication and HotBackup CRs should be deleted", Label("fast"), func() {
+				setLabelAndCRName("h-6")
+				hz := hazelcastconfig.PersistenceEnabled(hzLookupKey, "/data/hot-backup", labels)
+				CreateHazelcastCR(hz)
+				evaluateReadyMembers(hzLookupKey, 3)
+
+				m := hazelcastconfig.DefaultMap(mapLookupKey, hz.Name, labels)
+				Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
+				assertMapStatus(m, hazelcastcomv1alpha1.MapSuccess)
+
+				hb := hazelcastconfig.HotBackup(hbLookupKey, hz.Name, labels)
+				Expect(k8sClient.Create(context.Background(), hb)).Should(Succeed())
+				assertHotBackupSuccess(hb, 1*Minute)
+
+				wr := hazelcastconfig.DefaultWanReplication(wanLookupKey, m.Name, "target", "endpoints", labels)
+				Expect(k8sClient.Create(context.Background(), wr)).Should(Succeed())
+
+				DeleteAllOf(hz, &hazelcastcomv1alpha1.HazelcastList{}, hz.Namespace, labels)
+
+				err := k8sClient.Get(context.Background(), wanLookupKey, wr)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+
+				err = k8sClient.Get(context.Background(), mapLookupKey, m)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+
+				err = k8sClient.Get(context.Background(), hbLookupKey, hb)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+	})
 })

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 
 	Describe("Hazelcast CR dependent CRs", func() {
 		When("Hazelcast CR is deleted", func() {
-			FIt("dependent Map, WanReplication and HotBackup CRs should be deleted", Label("fast"), func() {
+			It("dependent Map, WanReplication and HotBackup CRs should be deleted", Label("fast"), func() {
 				setLabelAndCRName("h-6")
 				hz := hazelcastconfig.PersistenceEnabled(hzLookupKey, "/data/hot-backup", labels)
 				CreateHazelcastCR(hz)

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -120,6 +120,9 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 	Describe("Hazelcast CR dependent CRs", func() {
 		When("Hazelcast CR is deleted", func() {
 			It("dependent Map, WanReplication and HotBackup CRs should be deleted", Label("fast"), func() {
+				if !ee {
+					Skip("This test will only run in EE configuration")
+				}
 				setLabelAndCRName("h-6")
 				hz := hazelcastconfig.PersistenceEnabled(hzLookupKey, "/data/hot-backup", labels)
 				CreateHazelcastCR(hz)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"log"
 	"math"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	. "time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	hzclienttypes "github.com/hazelcast/hazelcast-go-client/types"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -559,4 +560,18 @@ func assertScheduledES(expectedSES hazelcastcomv1alpha1.ScheduledExecutorService
 	Expect(expectedSES.Capacity).Should(Equal(actualSES.Capacity))
 	Expect(expectedSES.Durability).Should(Equal(actualSES.Durability))
 	Expect(expectedSES.CapacityPolicy).Should(Equal(actualSES.CapacityPolicy))
+}
+
+func assertHotBackupSuccess(hb *hazelcastcomv1alpha1.HotBackup, t Duration) *hazelcastcomv1alpha1.HotBackup {
+	hbCheck := &hazelcastcomv1alpha1.HotBackup{}
+	By("waiting for HotBackup CR status to be Success", func() {
+		Eventually(func() hazelcastcomv1alpha1.HotBackupState {
+			err := k8sClient.Get(
+				context.Background(), types.NamespacedName{Name: hb.Name, Namespace: hzNamespace}, hbCheck)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hbCheck.Status.State).ShouldNot(Equal(hazelcastcomv1alpha1.HotBackupFailure), "Message: %v", hbCheck.Status.Message)
+			return hbCheck.Status.State
+		}, t, interval).Should(Equal(hazelcastcomv1alpha1.HotBackupSuccess))
+	})
+	return hbCheck
 }


### PR DESCRIPTION
Changes done to both
- Hazelcast CR: before deletion it deletes dependent Map and HotBackup CRs.
- Map CR: before deletion it deletes dependent WanReplication CRs.