### PR TITLE
[CN-473] Fix sporadic issue with checking HotBackup creation sequence

### DIFF
--- a/test/e2e/hazelcast_persistence_test.go
+++ b/test/e2e/hazelcast_persistence_test.go
@@ -115,8 +115,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 		test.EventuallyInLogs(scanner, 15*Second, logInterval).
 			Should(ContainSubstring("Starting new hot backup with sequence"))
 		test.EventuallyInLogs(scanner, 15*Second, logInterval).
-			Should(MatchRegexp("Backup of hot restart store \\S+ finished"))
-		test.EventuallyInLogs(scanner, 15*Second, logInterval).
 			Should(ContainSubstring("ClusterStateChange{type=class com.hazelcast.cluster.ClusterState, newState=ACTIVE}"))
 		Expect(logs.Close()).Should(Succeed())
 


### PR DESCRIPTION
We do not have to check if backup finished. We care only about the order of triggering backup.

Right now backup can sometimes finish after we activate the cluster failing the test.