### PR TITLE
[CN-478] Ignore NotFound errors when waiting for StatefulSet

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -50,6 +50,9 @@ func CheckIfRunning(ctx context.Context, cl client.Client, namespacedName types.
 	sts := &appsv1.StatefulSet{}
 	err := cl.Get(ctx, client.ObjectKey{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, sts)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	if isStatefulSetReady(sts, expectedReplicas) {


### PR DESCRIPTION
This should avoid loggoing not found error when we wait for StatefulSet:
```
2022-08-11T12:31:14.696+0200    ERROR   controller-runtime.manager.controller.hazelcast Reconciler error        {"reconciler group": "hazelcast.com", "reconciler kind": "Hazelcast", "name": "hazelcast", "namespace": "default", "error": "StatefulSet.apps \"hazelcast\" not found"}
```