### PR TITLE
Update Go, Hazelcast, MC and Hazelcast Go Client versions

### DIFF
--- a/.github/actions/operator-tests/action.yml
+++ b/.github/actions/operator-tests/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Set up Golang
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16'
+        go-version: '1.17'
 
     - name: Cache Golang dependencies
       uses: actions/cache@v3

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Cache Golang dependencies
         uses: actions/cache@v3

--- a/.github/workflows/redhat-connect-release.yaml
+++ b/.github/workflows/redhat-connect-release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Cache Golang dependencies
         uses: actions/cache@v3
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Cache Golang dependencies
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -36,7 +36,7 @@ type HazelcastSpec struct {
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Hazelcast Platform.
-	// +kubebuilder:default:="5.1.2"
+	// +kubebuilder:default:="5.1.3"
 	// +optional
 	Version string `json:"version,omitempty"`
 

--- a/api/v1alpha1/managementcenter_types.go
+++ b/api/v1alpha1/managementcenter_types.go
@@ -16,7 +16,7 @@ type ManagementCenterSpec struct {
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Management Center.
-	// +kubebuilder:default:="5.1.3"
+	// +kubebuilder:default:="5.1.4"
 	// +optional
 	Version string `json:"version,omitempty"`
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1115,7 +1115,7 @@ spec:
                     type: array
                 type: object
               version:
-                default: 5.1.2
+                default: 5.1.3
                 description: Version of Hazelcast Platform.
                 type: string
             type: object
@@ -2277,7 +2277,7 @@ spec:
                     type: array
                 type: object
               version:
-                default: 5.1.3
+                default: 5.1.4
                 description: Version of Management Center.
                 type: string
             type: object

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -1117,7 +1117,7 @@ spec:
                     type: array
                 type: object
               version:
-                default: 5.1.2
+                default: 5.1.3
                 description: Version of Hazelcast Platform.
                 type: string
             type: object

--- a/config/crd/bases/hazelcast.com_managementcenters.yaml
+++ b/config/crd/bases/hazelcast.com_managementcenters.yaml
@@ -938,7 +938,7 @@ spec:
                     type: array
                 type: object
               version:
-                default: 5.1.3
+                default: 5.1.4
                 description: Version of Management Center.
                 type: string
             type: object

--- a/config/samples/_v1alpha1_hazelcast.yaml
+++ b/config/samples/_v1alpha1_hazelcast.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.2'
+  version: '5.1.3'
   licenseKeySecret: hazelcast-license-key

--- a/config/samples/_v1alpha1_hazelcast_expose_externally.yaml
+++ b/config/samples/_v1alpha1_hazelcast_expose_externally.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.2'
+  version: '5.1.3'
   licenseKeySecret: hazelcast-license-key
   exposeExternally:
     type: Smart

--- a/config/samples/_v1alpha1_hazelcast_persistence.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.2'
+  version: '5.1.3'
   licenseKeySecret: hazelcast-license-key
   persistence:
     baseDir: "/data/hot-restart/"

--- a/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.2'
+  version: '5.1.3'
   licenseKeySecret: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent

--- a/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
@@ -9,7 +9,6 @@ spec:
   licenseKeySecret: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent
-    version: 0.1.0
   persistence:
     baseDir: "/data/hot-restart/"
     clusterDataRecoveryPolicy: "FullRecoveryOnly"

--- a/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: "docker.io/hazelcast/hazelcast-enterprise"
-  version: "5.1.2"
+  version: "5.1.3"
   licenseKeySecret: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent

--- a/config/samples/_v1alpha1_managementcenter.yaml
+++ b/config/samples/_v1alpha1_managementcenter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  version: '5.1.3'
+  version: '5.1.4'
   licenseKeySecret: hazelcast-license-key
   externalConnectivity:
     type: LoadBalancer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hazelcast/hazelcast-platform-operator
 
-go 1.16
+go 1.17
 
 require (
 	cloud.google.com/go/bigquery v1.4.0
@@ -11,7 +11,6 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/robfig/cron/v3 v3.0.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/tools v0.1.7 // indirect
 	google.golang.org/api v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.20.2
@@ -19,6 +18,78 @@ require (
 	k8s.io/client-go v0.20.2
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 	sigs.k8s.io/controller-runtime v0.8.3
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.1 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/zapr v0.2.0 // indirect
+	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/googleapis/gnostic v0.5.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.7.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.2.0 // indirect
+	github.com/shirou/gopsutil/v3 v3.21.5 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tklauser/go-sysconf v0.3.4 // indirect
+	github.com/tklauser/numcpus v0.2.1 // indirect
+	go.opencensus.io v0.22.3 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/tools v0.1.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
+	google.golang.org/grpc v1.27.1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
+	k8s.io/apiextensions-apiserver v0.20.1 // indirect
+	k8s.io/component-base v0.20.2 // indirect
+	k8s.io/klog/v2 v2.4.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // to fix vulnerability: CVE-2021-3121 in github.com/gogo/protobuf < v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/bigquery v1.4.0
 	github.com/go-logr/logr v0.3.0
 	github.com/google/uuid v1.1.2
-	github.com/hazelcast/hazelcast-go-client v1.2.0
+	github.com/hazelcast/hazelcast-go-client v1.3.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/robfig/cron/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hazelcast/hazelcast-go-client v1.2.0 h1:TZ3UnsnwuJ2rukWMb11miL38jfFG8GRbnh8al0A/Nk0=
-github.com/hazelcast/hazelcast-go-client v1.2.0/go.mod h1:fxnzya2+IbQ5Y3CjpIe8RLqoDpzMcBwdKEkUXClqTFs=
+github.com/hazelcast/hazelcast-go-client v1.3.0 h1:az9avrL53glcpdCoWm3dd/vSOOhr5u3PefPNMcpQULA=
+github.com/hazelcast/hazelcast-go-client v1.3.0/go.mod h1:JH7sI0kvMSlJJ5D+YFRg/J/P41MRPffzCt0bN9LYd0M=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -73,7 +73,7 @@ const (
 	// HazelcastEERepo image repository for Hazelcast EE
 	HazelcastEERepo = "docker.io/hazelcast/hazelcast-enterprise"
 	// HazelcastVersion version of Hazelcast image
-	HazelcastVersion = "5.1.2"
+	HazelcastVersion = "5.1.3"
 	// HazelcastImagePullPolicy pull policy for Hazelcast Platform image
 	HazelcastImagePullPolicy = corev1.PullIfNotPresent
 )
@@ -83,7 +83,7 @@ const (
 	// MCRepo image repository for Management Center
 	MCRepo = "docker.io/hazelcast/management-center"
 	// MCVersion version of Management Center image
-	MCVersion = "5.1.3"
+	MCVersion = "5.1.4"
 	// MCImagePullPolicy pull policy for Management Center image
 	MCImagePullPolicy = corev1.PullIfNotPresent
 )


### PR DESCRIPTION
New versions:
- Go: 1.16 -> 1.17
- Hazelcast: 5.1.2 -> 5.1.3
- Management Center: 5.1.3 -> 5.1.4
- Hazelcast Go Client: 1.2.0 -> 1.3.0