### PR TITLE
[CN-507] Fix operator idle issue

### DIFF
--- a/controllers/hazelcast/client/client.go
+++ b/controllers/hazelcast/client/client.go
@@ -62,6 +62,7 @@ func (cl *Client) AreAllMembersAccessible() bool {
 }
 
 type Status struct {
+	sync.Mutex
 	MemberMap               map[hztypes.UUID]*MemberData
 	ClusterHotRestartStatus ClusterHotRestartStatus
 }
@@ -253,10 +254,10 @@ func (c *Client) UpdateMembers(ctx context.Context) {
 		}
 	}
 
-	c.Lock()
+	c.Status.Lock()
 	c.Status.MemberMap = activeMembers
 	c.Status.ClusterHotRestartStatus = *newClusterHotRestartStatus
-	c.Unlock()
+	c.Status.Unlock()
 }
 
 func fetchTimedMemberState(ctx context.Context, client *hazelcast.Client, uuid hztypes.UUID) (string, error) {


### PR DESCRIPTION
While the operator is on stuck state, I got the thread dumps and found a deadlock. It seems the reason of the idle issue is this deadlock. In [client UpdateMembers](https://github.com/hazelcast/hazelcast-platform-operator/blob/84b24ea233482eb617f0847398cd1057f2a264be/controllers/hazelcast/client/client.go#L256-L259) function and in [client shutdown](https://github.com/hazelcast/hazelcast-platform-operator/blob/84b24ea233482eb617f0847398cd1057f2a264be/controllers/hazelcast/client/client.go#L196-L197) function, same mutex is tried to be locked. I fixed the issue by using another mutex for `client.Status` field. The only update operation on  `client.Status` field occurs in UpdateMembers function.

```
goroutine 18662 [semacquire, 7 minutes]:
sync.runtime_SemacquireMutex(0x2, 0x2b, 0x188e020)
	/usr/local/go/src/runtime/sema.go:71 +0x25
sync.(*Mutex).lockSlow(0xc0004e13b0)
	/usr/local/go/src/sync/mutex.go:138 +0x165
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:81
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client.(*Client).UpdateMembers(0xc0004e13b0, {0x18babf0, 0xc0005db700})
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/client/client.go:256 +0x245
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client.(*Client).start.func2({0x18babf0, 0xc0005db700}, 0xc00026e770)
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/client/client.go:171 +0xd0
created by github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client.(*Client).start
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/client/client.go:165 +0x325
```

```
goroutine 407 [chan send, 7 minutes]:
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client.(*StatusTicker).stop(...)
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/client/client.go:107
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client.(*Client).shutdown(0xc0004e13b0, {0x18bac98, 0xc000657650})
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/client/client.go:200 +0xf2
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast/client.ShutdownClient({0x18bac98, 0xc000657650}, {{0xc000d5c789, 0x19016a8}, {0xc000d5c770, 0x0}})
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/client/client.go:132 +0x7a
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast.(*HazelcastReconciler).executeFinalizer(0xc0005b7c40, {0x18bac98, 0xc000657650}, 0xc000a62780, {0x18d5630, 0xc000488780})
	/Users/cagriciftci/Desktop/hazelcast-platform-operator/controllers/hazelcast/hazelcast_resources.go:76 +0x25d
github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast.(*HazelcastReconciler).Reconcile(0xc0005b7c40, {0x18bac98, 0xc000657650}, {{{0xc000bb9a59, 0x7}, {0xc000bb9a40, 0xb}}})
```

Even though It seems to fix the issue, I still have a doubt about the reason of the issue. If the only problem is deadlock then how does the operator escape from deadlock after some time? I mean how does it get working state from stuck state after some time ? Do you have any idea?