### PR TITLE
Fix wan nightly test failures

### DIFF
--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -355,7 +355,7 @@ func defaultWanReplicationRefCodec(hz *hazelcastv1alpha1.Hazelcast, m *hazelcast
 }
 
 func defaultWanReplicationRefName(m *hazelcastv1alpha1.Map) string {
-	return m.GetName() + "-default"
+	return m.MapName() + "-default"
 }
 
 func copyIndexes(idx []hazelcastv1alpha1.IndexConfig) []codecTypes.IndexConfig {

--- a/test/e2e/hazelcast_user_code_test.go
+++ b/test/e2e/hazelcast_user_code_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Hazelcast User Code Deployment", Label("custom_class"), func()
 		defer func() {
 			Expect(cl.Shutdown(context.Background())).Should(Succeed())
 		}()
-		mp, err := cl.GetMap(context.Background(), m.GetName())
+		mp, err := cl.GetMap(context.Background(), m.MapName())
 		Expect(err).To(BeNil())
 
 		entries := make([]hzTypes.Entry, entryCount)
@@ -107,7 +107,7 @@ var _ = Describe("Hazelcast User Code Deployment", Label("custom_class"), func()
 		for k, v := range secretData {
 			Expect(line).To(ContainSubstring(k + "=" + v))
 		}
-		test.EventuallyInLogs(scanner, 10*Second, logInterval).Should(ContainSubstring(fmt.Sprintf("SimpleStore - Map name is %s", m.GetName())))
+		test.EventuallyInLogs(scanner, 10*Second, logInterval).Should(ContainSubstring(fmt.Sprintf("SimpleStore - Map name is %s", m.MapName())))
 		test.EventuallyInLogs(scanner, 10*Second, logInterval).Should(ContainSubstring("SimpleStore - loading all keys"))
 		test.EventuallyInLogs(scanner, 10*Second, logInterval).Should(ContainSubstring(fmt.Sprintf("SimpleStore - storing key: %d", entryCount-1)))
 


### PR DESCRIPTION
For the Map CR we are using `MapName` function to get map's name but in some places kubernetes default `GetName` function is used. I just replaced them with `MapName`.

`MapName` checks if spec.Name is not empty. If so return it. If not, return metadata.Name
`GetName` returns metadata.Name