### PR TITLE
ci: add autolabeling option and draft release creator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->
+
+## User Impact
+
+<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           tag: v${{ inputs.RELEASE_VERSION }}
           name: ${{ inputs.RELEASE_VERSION }}
-          config-name: release-drafter-config.yml
+          config-name: workflows/release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -6,6 +6,9 @@ on:
         description: "Version in the form of X.Y[.Z]"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   create_release:
     name: Create release
@@ -54,6 +57,21 @@ jobs:
           TAG_VERSION=v${RELEASE_VERSION}
           git tag ${TAG_VERSION}
           git push origin ${TAG_VERSION}
+
+  update_draft_release:
+    needs: create_release
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          tag: v${{ inputs.RELEASE_VERSION }}
+          name: ${{ inputs.RELEASE_VERSION }}
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   slack_notify:
     name: Slack Notify

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         with:
-          config-name: release-drafter-config.yml
+          config-name: workflows/release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  update-pr-labels:
+    name: Update Draft Release
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   linter:
     name: Run linters
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter-config.yml
+++ b/.github/workflows/release-drafter-config.yml
@@ -1,0 +1,90 @@
+commitish: 'main'
+categories:
+  - title: 'New Features'
+    labels:
+      - 'feature'
+  - title: 'Changes'
+    labels:
+      - 'enhancement'
+      - 'refactor'
+  - title: 'Fixed Issues'
+    labels:
+      - 'fix'
+include-labels:
+  - 'feature'
+  - 'enhancement'
+  - 'fix'
+  - 'refactor'
+replacers:
+  - search: '/\[(.*?)\]/g'
+    replace: ''
+  - search: '^Add'
+    replace: 'Added'
+  - search: 'feat:'
+    replace: ''
+  - search: 'fix:'
+    replace: ''
+  - search: 'refactor:'
+    replace: ''
+  - search: 'enhancement:'
+    replace: ''
+autolabeler:
+  - label: 'feature'
+    branch:
+      - '/feat\/.+/'
+    title:
+      - '/feature/i'
+      - '/feat/i'
+      - '/implement/i'
+      - '/support/i'
+    body:
+      - '/feature/i'
+      - '/implement/i'
+      - '/support/i'
+  - label: 'enhancement'
+    branch:
+      - '/enhancement\/.+/'
+    title:
+      - '/enhancement/i'
+      - '/improve/i'
+      - '/upgrade/i'
+      - '/update/i'
+    body:
+      - '/improve/i'
+      - '/upgrade/i'
+      - '/update/i'
+  - label: 'refactor'
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - '/refactor/i'
+    body:
+      - '/refactor/i'
+  - label: 'fix'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+      - '/bug/i'
+      - '/issue/i'
+      - '/error/i'
+    body:
+      - '/fix/i'
+      - '/bug/i'
+      - '/issue/i'
+      - '/error/i'
+  - label: 'ci'
+    files:
+      - '.github/workflows/*'
+  - label: 'test'
+    files:
+      - 'test/*'
+  - label: 'documentation'
+    files:
+      - '*.md'
+change-template: '- $TITLE (#$NUMBER)'
+template: |
+  # Release notes
+  In this release, we introduced the {REPLACE THIS}. We also introduced {REPLACE THIS}.
+  $CHANGES
+

--- a/.github/workflows/release-drafter-config.yml
+++ b/.github/workflows/release-drafter-config.yml
@@ -28,6 +28,8 @@ replacers:
     replace: ''
   - search: 'enhancement:'
     replace: ''
+  - search: '/(##[\s\S]Description)\s+\w.*\s+(##[\s\S]User)\s+\w.*\s+/g'
+    replace: '   - '
 autolabeler:
   - label: 'feature'
     branch:
@@ -82,7 +84,7 @@ autolabeler:
   - label: 'documentation'
     files:
       - '*.md'
-change-template: '- $TITLE (#$NUMBER)'
+change-template: '- $TITLE (#$NUMBER)$BODY'
 template: |
   # Release notes
   In this release, we introduced the {REPLACE THIS}. We also introduced {REPLACE THIS}.

--- a/.github/workflows/release-drafter-config.yml
+++ b/.github/workflows/release-drafter-config.yml
@@ -6,7 +6,6 @@ categories:
   - title: 'Changes'
     labels:
       - 'enhancement'
-      - 'refactor'
   - title: 'Fixed Issues'
     labels:
       - 'fix'
@@ -14,7 +13,6 @@ include-labels:
   - 'feature'
   - 'enhancement'
   - 'fix'
-  - 'refactor'
 replacers:
   - search: '/\[(.*?)\]/g'
     replace: ''
@@ -23,8 +21,6 @@ replacers:
   - search: 'feat:'
     replace: ''
   - search: 'fix:'
-    replace: ''
-  - search: 'refactor:'
     replace: ''
   - search: 'enhancement:'
     replace: ''
@@ -39,10 +35,6 @@ autolabeler:
       - '/feat/i'
       - '/implement/i'
       - '/support/i'
-    body:
-      - '/feature/i'
-      - '/implement/i'
-      - '/support/i'
   - label: 'enhancement'
     branch:
       - '/enhancement\/.+/'
@@ -51,26 +43,10 @@ autolabeler:
       - '/improve/i'
       - '/upgrade/i'
       - '/update/i'
-    body:
-      - '/improve/i'
-      - '/upgrade/i'
-      - '/update/i'
-  - label: 'refactor'
-    branch:
-      - '/refactor\/.+/'
-    title:
-      - '/refactor/i'
-    body:
-      - '/refactor/i'
   - label: 'fix'
     branch:
       - '/fix\/.+/'
     title:
-      - '/fix/i'
-      - '/bug/i'
-      - '/issue/i'
-      - '/error/i'
-    body:
       - '/fix/i'
       - '/bug/i'
       - '/issue/i'


### PR DESCRIPTION
This new functionality will allow creating of release notes automatically based on labels which are will automatically add base on the commit or branch name.
![image](https://user-images.githubusercontent.com/8906445/203800929-13e5c163-4dbb-4544-9eeb-871da467f07c.png)
![image](https://user-images.githubusercontent.com/8906445/203801058-c963acde-f40a-4192-8584-a2be7b60ddfc.png)
