### PR TITLE
Add Namespaced Role for secret access

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3137,6 +3137,7 @@ rules:
   verbs:
   - create
   - get
+  - list
   - watch
 - apiGroups:
   - apps
@@ -3260,7 +3261,6 @@ rules:
   - endpoints
   - nodes
   - pods
-  - secrets
   - services
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,7 +12,6 @@ rules:
   - endpoints
   - nodes
   - pods
-  - secrets
   - services
   verbs:
   - get
@@ -213,6 +212,7 @@ rules:
   verbs:
   - create
   - get
+  - list
   - watch
 - apiGroups:
   - apps

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -57,11 +57,11 @@ func NewHazelcastReconciler(c client.Client, log logr.Logger, s *runtime.Scheme,
 //+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts/status,verbs=get;update;patch,namespace=system
 //+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts/finalizers,verbs=update,namespace=system
 // ClusterRole inherited from Hazelcast ClusterRole
-//+kubebuilder:rbac:groups="",resources=endpoints;secrets;pods;nodes;services,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=endpoints;pods;nodes;services,verbs=get;list
 // Role related to Reconcile()
 //+kubebuilder:rbac:groups="",resources=events;services;serviceaccounts;configmaps;pods,verbs=get;list;watch;create;update;patch;delete,namespace=system
 //+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get,namespace=system
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get;list,namespace=system
 // ClusterRole related to Reconcile()
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 
@@ -103,12 +103,22 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				withMessage(fmt.Sprintf("error validating new Spec: %s", err)))
 	}
 
+	err = r.reconcileRole(ctx, h, logger)
+	if err != nil {
+		return update(ctx, r.Client, h, failedPhase(err))
+	}
+
 	err = r.reconcileClusterRole(ctx, h, logger)
 	if err != nil {
 		return update(ctx, r.Client, h, failedPhase(err))
 	}
 
 	err = r.reconcileServiceAccount(ctx, h, logger)
+	if err != nil {
+		return update(ctx, r.Client, h, failedPhase(err))
+	}
+
+	err = r.reconcileRoleBinding(ctx, h, logger)
 	if err != nil {
 		return update(ctx, r.Client, h, failedPhase(err))
 	}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -327,7 +327,7 @@ func (r *HazelcastReconciler) reconcileClusterRole(ctx context.Context, h *hazel
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"endpoints", "pods", "nodes", "services", "secrets"},
+				Resources: []string{"endpoints", "pods", "nodes", "services"},
 				Verbs:     []string{"get", "list"},
 			},
 		},
@@ -347,6 +347,37 @@ func (r *HazelcastReconciler) reconcileClusterRole(ctx context.Context, h *hazel
 	})
 	if opResult != controllerutil.OperationResultNone {
 		logger.Info("Operation result", "ClusterRole", h.ClusterScopedName(), "result", opResult)
+	}
+	return err
+}
+
+func (r *HazelcastReconciler) reconcileRole(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      h.Name,
+			Namespace: h.Namespace,
+			Labels:    labels(h),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+
+	err := controllerutil.SetControllerReference(h, role, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to set owner reference on Role: %w", err)
+	}
+
+	opResult, err := util.CreateOrUpdate(ctx, r.Client, role, func() error {
+		return nil
+	})
+	if opResult != controllerutil.OperationResultNone {
+		logger.Info("Operation result", "Role", h.Name, "result", opResult)
 	}
 	return err
 }
@@ -397,6 +428,42 @@ func (r *HazelcastReconciler) reconcileClusterRoleBinding(ctx context.Context, h
 	})
 	if opResult != controllerutil.OperationResultNone {
 		logger.Info("Operation result", "ClusterRoleBinding", csName, "result", opResult)
+	}
+	return err
+}
+
+func (r *HazelcastReconciler) reconcileRoleBinding(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      h.Name,
+			Namespace: h.Namespace,
+			Labels:    labels(h),
+		},
+	}
+
+	err := controllerutil.SetControllerReference(h, rb, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to set owner reference on RoleBinding: %w", err)
+	}
+
+	opResult, err := util.CreateOrUpdate(ctx, r.Client, rb, func() error {
+		rb.Subjects = []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      h.Name,
+				Namespace: h.Namespace,
+			},
+		}
+		rb.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     h.Name,
+		}
+
+		return nil
+	})
+	if opResult != controllerutil.OperationResultNone {
+		logger.Info("Operation result", "RoleBinding", h.Name, "result", opResult)
 	}
 	return err
 }


### PR DESCRIPTION
Cluster-wide secret list/get privileges to namespaced ServiceAccount is removed.
New namespaced Role and RoleBinding are created and passed to namespaced serviceaccount of hazelcast cluster to grant secret access. 