### PR TITLE
Setup CSI driver to support EBS volumes on EKS cluster

### DIFF
--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -45,6 +45,8 @@ jobs:
             --nodes 3 \
             --managed
 
+          eksctl create addon --name aws-ebs-csi-driver --cluster "${CLUSTER_NAME}"
+
   new-relic-setup:
     name: Setup New Relic agent
     needs: "prepare-env"


### PR DESCRIPTION
According to the documentation if you plan to deploy workloads that use Amazon EBS volumes in a new **1.23 cluster**, install the Amazon EBS CSI driver in your cluster before deploying the workloads your cluster.