### PR TITLE
Fixed "orange" test suite for community operator

### DIFF
--- a/.github/workflows/community-operator-tests.yaml
+++ b/.github/workflows/community-operator-tests.yaml
@@ -11,6 +11,7 @@ env:
   SCRIPT_URL: https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/ci/latest/ci/scripts/opp.sh
   OPP_DEBUG: 1
   OPP_PRODUCTION_TYPE: k8s
+  OPP_RELEASE_INDEX_NAME: "catalog_tmp"
   PARDOT_ID: redhat
 
 jobs:


### PR DESCRIPTION
Added env variable `OPP_RELEASE_INDEX_NAME: "catalog_tmp"` that fixes below issue:
```
TASK [operator_index : Remove 'hazelcast-platform-operator' operator to index image kind-registry:5000/test-operator/catalog:latest] ***
fatal: [localhost]: FAILED! => changed=true 
  cmd: /tmp/operator-test/bin/opm index rm -c podman --operators hazelcast-platform-operator --tag kind-registry:5000/test-operator/catalog:latest --permissive --from-index kind-registry:5000/test-operator/catalog:latest
```