### PR TITLE
Update the Dockerfile to avoid failing security vulnerability scans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -tags hazelcas
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
+RUN microdnf upgrade -y && \
+    microdnf clean all
+
 ARG version="5.4"
 ARG pardotID="dockerhub"
 ENV OPERATOR_VERSION=${version}


### PR DESCRIPTION
Red Hat base images (including the RHEL and UBI images) are periodically rebuilt to address security vulnerabilities within them, but there can be a lag between when Important vulnerabilities arise and when they are addressed via a UBI release. This can lead to an image being built on the UBI, for example, failing security vulnerability scans in between release cycles of the UBI itself.

https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/containers/troubleshooting.md#ubi-minimal
