### PR TITLE
Update deprecated set-output commands

### DIFF
--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -27,7 +27,7 @@ jobs:
         id: set-cluster-name
         run: |-
           CLUSTER_NAME="operator-e2e-backup-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-          echo "::set-output name=CLUSTER_NAME::${CLUSTER_NAME}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \
             --project=${{ env.GCP_PROJECT_ID }} \
@@ -61,12 +61,12 @@ jobs:
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             IMG=ttl.sh/$(uuidgen):2h
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
 
   gke-e2e-backup-tests:

--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -42,18 +42,18 @@ jobs:
         run: |
           if [[ ${{ github.event_name == 'schedule' }} == true ]]; then
               echo "RELEASE_VERSION=7.8.0" >> $GITHUB_ENV
-              echo "::set-output name=RELEASE_VERSION::7.8.0"
+              echo "RELEASE_VERSION=7.8.0" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
               echo "RELEASE_VERSION=${{ github.event.inputs.RELEASE_VERSION }}" >> $GITHUB_ENV
-              echo "::set-output name=RELEASE_VERSION::${{ github.event.inputs.RELEASE_VERSION }}"
+              echo "RELEASE_VERSION=${{ github.event.inputs.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event_name == 'push' }} == true ]]; then
               echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
-              echo "::set-output name=RELEASE_VERSION::${GITHUB_REF:11}"
+              echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
           fi
               CONTAINER_REPOSITORY=$(uuidgen)
               CONTAINER_IMAGE=ttl.sh/$CONTAINER_REPOSITORY:1h
               echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> $GITHUB_ENV
-              echo "::set-output name=CONTAINER_IMAGE::${CONTAINER_IMAGE}"
+              echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> $GITHUB_OUTPUT
 
       - name: Validate version
         run: |
@@ -71,7 +71,7 @@ jobs:
           echo "Pushing the operator image to ttl.sh repository"
           make docker-push IMG=$CONTAINER_IMAGE
           CONTAINER_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${CONTAINER_IMAGE} | cut -d'@' -f2)
-          echo "::set-output name=CONTAINER_IMAGE_DIGEST::${CONTAINER_IMAGE_DIGEST}"
+          echo "CONTAINER_IMAGE_DIGEST=${CONTAINER_IMAGE_DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Initiating a Container Scan
         run: |
@@ -160,9 +160,9 @@ jobs:
           echo "BUNDLE_REPOSITORY=${BUNDLE_REPOSITORY}" >> $GITHUB_ENV
           echo "BUNDLE_IMAGE=${BUNDLE_IMAGE}" >> $GITHUB_ENV
           echo "PFLT_INDEXIMAGE=${PFLT_INDEXIMAGE}" >> $GITHUB_ENV
-          echo "::set-output name=BUNDLE_VERSION::${BUNDLE_VERSION}"
-          echo "::set-output name=BUNDLE_IMAGE::${BUNDLE_IMAGE}"
-          echo "::set-output name=PFLT_INDEXIMAGE::${PFLT_INDEXIMAGE}"
+          echo "BUNDLE_VERSION=${BUNDLE_VERSION}" >> $GITHUB_OUTPUT
+          echo "BUNDLE_IMAGE=${BUNDLE_IMAGE}" >> $GITHUB_OUTPUT
+          echo "PFLT_INDEXIMAGE=${PFLT_INDEXIMAGE}" >> $GITHUB_OUTPUT
 
       - name: Build Bundle
         run: |
@@ -186,7 +186,7 @@ jobs:
           docker build -f bundle.Dockerfile -t ${BUNDLE_IMAGE} .
           docker push ${BUNDLE_IMAGE}
           BUNDLE_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${BUNDLE_IMAGE} | cut -d'@' -f2)
-          echo "::set-output name=BUNDLE_IMAGE_DIGEST::${BUNDLE_IMAGE_DIGEST}"
+          echo "BUNDLE_IMAGE_DIGEST=${BUNDLE_IMAGE_DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Create Bundle Index
         run: |
@@ -229,7 +229,7 @@ jobs:
         run: |
           oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
           oc new-project ${NAMESPACE}
-          echo ::set-output name=exit_code::$?
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Initiating an Operator Bundle Scan
         run: |

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -29,12 +29,12 @@ jobs:
 
           MAJOR_MINOR_VERSION=$(echo ${RELEASE_VERSION} | sed 's|\([0-9]*\.[0-9]*\)\.[0-9]*|\1|')
           echo "MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION}" >> $GITHUB_ENV
-          echo "::set-output name=MAJOR_MINOR_VERSION::${MAJOR_MINOR_VERSION}"
+          echo "MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION}" >> $GITHUB_OUTPUT
 
           if [[ ${MAJOR_MINOR_VERSION} == ${RELEASE_VERSION} ]] ;then
-            echo "::set-output name=OPERATOR_DOCS_BRANCH::main"
+            echo "OPERATOR_DOCS_BRANCH=main" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=OPERATOR_DOCS_BRANCH::v/$MAJOR_MINOR_VERSION"
+            echo "OPERATOR_DOCS_BRANCH=v/$MAJOR_MINOR_VERSION" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout to Operator docs repo
@@ -128,9 +128,9 @@ jobs:
             let line_number-=1
             json_object="    {\n      \"url\": \"https://docs.hazelcast.com/operator/(?P<version>.*?)/\",\n      \"tags\": [\n        \"operator-${MAJOR_MINOR_VERSION}\"\n      ],\n      \"variables\": {\n        \"version\": [\n          \"${MAJOR_MINOR_VERSION}\"\n        ]\n      },\n      \"selectors_key\": \"operator\"\n    },"
             awk -i inplace -v json="$json_object" -v line="$line_number" 'NR==line{print json}1' search-config.json
-            echo '::set-output name=HZ_DOCS_CHANGED::true'
+            echo "HZ_DOCS_CHANGED=true" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=HZ_DOCS_CHANGED::false'
+            echo "HZ_DOCS_CHANGED=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Commit and push changes

--- a/.github/workflows/nightly-e2e-aks.yaml
+++ b/.github/workflows/nightly-e2e-aks.yaml
@@ -26,7 +26,7 @@ jobs:
           azcliversion: 2.31.0
           inlineScript: |
             CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-            echo "::set-output name=CLUSTER_NAME::${CLUSTER_NAME}"
+            echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
             az aks create --resource-group ${AZURE_RESOURCE_GROUP} --name "${CLUSTER_NAME}" \
               --node-count 3 --generate-ssh-keys
 
@@ -81,12 +81,12 @@ jobs:
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             IMG=ttl.sh/$(uuidgen):2h
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
 
   aks-e2e-tests:

--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -32,7 +32,7 @@ jobs:
         id: create-cluster
         run: |-
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-          echo "::set-output name=CLUSTER_NAME::${CLUSTER_NAME}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           eksctl create cluster --name "${CLUSTER_NAME}" \
             --zones ${AWS_REGION}a \
             --zones ${AWS_REGION}c \
@@ -100,12 +100,12 @@ jobs:
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             IMG=ttl.sh/$(uuidgen):2h
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
 
   eks-e2e-tests:

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -27,7 +27,7 @@ jobs:
         id: set-cluster-name
         run: |-
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-          echo "::set-output name=CLUSTER_NAME::${CLUSTER_NAME}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \
             --project=${{ env.GCP_PROJECT_ID }} \
@@ -61,12 +61,12 @@ jobs:
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             IMG=ttl.sh/$(uuidgen):2h
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
 
   gke-e2e-tests:

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -28,7 +28,7 @@ jobs:
         id: set-cluster-name
         run: |-
           CLUSTER_NAME="operator-ph-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-          echo "::set-output name=CLUSTER_NAME::${CLUSTER_NAME}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \
             --project=${{ env.GCP_PROJECT_ID }} \
@@ -65,12 +65,12 @@ jobs:
             IMG=ttl.sh/$(uuidgen):2h
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
-            echo "::set-output name=IMG::${IMG}"
-            echo "::set-output name=VERSION::${{github.sha}}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
+            echo "VERSION=${{github.sha}}" >> $GITHUB_OUTPUT
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
-            echo "::set-output name=IMG::${IMG}"
-            echo "::set-output name=VERSION::latest-snapshot"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
+            echo "VERSION=latest-snapshot" >> $GITHUB_OUTPUT
           fi
 
   gke-ph-tests:

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -26,12 +26,12 @@ jobs:
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             IMG=ttl.sh/$(uuidgen):2h
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
 
   create-gke-cluster:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -41,8 +41,8 @@ jobs:
           IMAGE_NAME=docker.io/hazelcast/${OPERATOR_NAME}:${RELEASE_VERSION}
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
-          echo "::set-output name=RELEASE_VERSION::${RELEASE_VERSION}"
-          echo "::set-output name=IMAGE_NAME::${IMAGE_NAME}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Get the Current Latest Tag
         id: get-current-latest-tag
@@ -57,7 +57,7 @@ jobs:
           CURRENT_LATEST_TAG=$(curl --fail -L -s -X GET 'https://hub.docker.com/v2/namespaces/hazelcast/repositories/hazelcast-platform-operator/images?status=active&currently_tagged=true&page_size=100' \
           -H "Authorization: Bearer $token" | jq -r  '.results[] | select((.tags | length == 2) and .tags[].tag =="latest") | select(.tags[1].is_current == true) | .tags[].tag | select(. !="latest")')
           echo "CURRENT_LATEST_TAG=${CURRENT_LATEST_TAG}" >> $GITHUB_ENV
-          echo "::set-output name=CURRENT_LATEST_TAG::${CURRENT_LATEST_TAG}"
+          echo "CURRENT_LATEST_TAG=${CURRENT_LATEST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Build Operator Image
         run: |
@@ -74,7 +74,7 @@ jobs:
           make docker-push docker-push-latest IMG="${IMAGE_NAME}"
           IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_NAME} | cut -d'@' -f2)
           echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_ENV
-          echo "::set-output name=IMAGE_DIGEST::${IMAGE_DIGEST}"
+          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Upload Bundle to Jfrog
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -98,9 +98,9 @@ jobs:
         id: decide-ref
         run: |
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "::set-output name=ref::${{github.ref}}"
+            echo "ref=${{github.ref}}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/merge"
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout
@@ -125,7 +125,7 @@ jobs:
         id: set-cluster-name
         run: |-
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-          echo "::set-output name=CLUSTER_NAME::${CLUSTER_NAME}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \
             --project=${{ env.GCP_PROJECT_ID }} \
@@ -158,7 +158,7 @@ jobs:
         id: build-img
         run: |
             IMG=ttl.sh/$(uuidgen):2h
-            echo "::set-output name=IMG::${IMG}"
+            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
 
             make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
             make docker-push IMG=$IMG
@@ -182,9 +182,9 @@ jobs:
         id: decide-ref
         run: |
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "::set-output name=ref::${{github.ref}}"
+            echo "ref=${{github.ref}}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/merge"
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout


### PR DESCRIPTION
Starting 1st June 2023, workflows using set-output commands via stdout will fail with an error. Currently, we have a lot of warnings in our workflows