### PR TITLE
ci: increase timeout for cleanup "pages-build-deployment" workflow

### DIFF
--- a/.github/workflows/generate-test-report.yaml
+++ b/.github/workflows/generate-test-report.yaml
@@ -7,7 +7,7 @@ on:
         type: string
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CLEANUP_TIMEOUT: 10
+  CLEANUP_TIMEOUT: 20
   GITHUB_PAGES_URL: https://${{ github.repository_owner }}.github.io/hazelcast-platform-operator
   NEW_RELIC_BASE_URL: https://one.eu.newrelic.com/launcher/logger.log-launcher
   NEW_RELIC_SHORT_URL_GEN: https://urly.service.newrelic.com


### PR DESCRIPTION
Sometimes "nightly-e2e-test" fails because of timeout for cleanup "pages-build-deployment". So the solution is to increase up to 20min to wait until the test report is deployed