### PR TITLE
[CN-594] allow watch verb on statefulsets resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ SUITE = $(subst =,-,$(GO_TEST_FLAGS))
 test-it: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -ginkgo.label-filter="slow || fast" -coverprofile cover.out $(GO_TEST_FLAGS) -timeout 5m
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -coverprofile cover.out $(GO_TEST_FLAGS) -timeout 5m
 
 test-it-focus: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ SUITE = $(subst =,-,$(GO_TEST_FLAGS))
 test-it: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -coverprofile cover.out $(GO_TEST_FLAGS) -timeout 5m
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -ginkgo.label-filter="slow || fast" -coverprofile cover.out $(GO_TEST_FLAGS) -timeout 5m
 
 test-it-focus: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}

--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -55,7 +55,7 @@ type HazelcastSpec struct {
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Hazelcast Platform.
-	// +kubebuilder:default:="5.1.4"
+	// +kubebuilder:default:="5.2.0"
 	// +optional
 	Version string `json:"version,omitempty"`
 

--- a/api/v1alpha1/managementcenter_types.go
+++ b/api/v1alpha1/managementcenter_types.go
@@ -16,7 +16,7 @@ type ManagementCenterSpec struct {
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Management Center.
-	// +kubebuilder:default:="5.1.4"
+	// +kubebuilder:default:="5.2.0"
 	// +optional
 	Version string `json:"version,omitempty"`
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3414,12 +3414,6 @@ rules:
   resources:
   - statefulsets
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - hazelcast.com

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3410,6 +3410,18 @@ rules:
   - get
   - list
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - hazelcast.com
   resources:
   - cronhotbackups

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1265,7 +1265,7 @@ spec:
                     type: string
                 type: object
               version:
-                default: 5.1.4
+                default: 5.2.0
                 description: Version of Hazelcast Platform.
                 type: string
             type: object
@@ -2418,7 +2418,7 @@ spec:
                     type: array
                 type: object
               version:
-                default: 5.1.4
+                default: 5.2.0
                 description: Version of Management Center.
                 type: string
             type: object

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -1140,7 +1140,7 @@ spec:
                     type: string
                 type: object
               version:
-                default: 5.1.4
+                default: 5.2.0
                 description: Version of Hazelcast Platform.
                 type: string
             type: object

--- a/config/crd/bases/hazelcast.com_managementcenters.yaml
+++ b/config/crd/bases/hazelcast.com_managementcenters.yaml
@@ -938,7 +938,7 @@ spec:
                     type: array
                 type: object
               version:
-                default: 5.1.4
+                default: 5.2.0
                 description: Version of Management Center.
                 type: string
             type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,18 @@ rules:
   - get
   - list
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - hazelcast.com
   resources:
   - cronhotbackups

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,12 +21,6 @@ rules:
   resources:
   - statefulsets
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - hazelcast.com

--- a/config/samples/_v1alpha1_hazelcast.yaml
+++ b/config/samples/_v1alpha1_hazelcast.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.4'
+  version: '5.2.0'
   licenseKeySecret: hazelcast-license-key

--- a/config/samples/_v1alpha1_hazelcast_expose_externally.yaml
+++ b/config/samples/_v1alpha1_hazelcast_expose_externally.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.4'
+  version: '5.2.0'
   licenseKeySecret: hazelcast-license-key
   exposeExternally:
     type: Smart

--- a/config/samples/_v1alpha1_hazelcast_persistence.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.4'
+  version: '5.2.0'
   licenseKeySecret: hazelcast-license-key
   persistence:
     baseDir: "/data/hot-restart/"

--- a/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '5.1.4'
+  version: '5.2.0'
   licenseKeySecret: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent

--- a/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: "docker.io/hazelcast/hazelcast-enterprise"
-  version: "5.1.4"
+  version: "5.2.0"
   licenseKeySecret: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent

--- a/config/samples/_v1alpha1_managementcenter.yaml
+++ b/config/samples/_v1alpha1_managementcenter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  version: '5.1.4'
+  version: '5.2.0'
   licenseKeySecret: hazelcast-license-key
   externalConnectivity:
     type: LoadBalancer

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -65,7 +65,7 @@ func NewHazelcastReconciler(c client.Client, log logr.Logger, s *runtime.Scheme,
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get;list,namespace=system
 // ClusterRole related to Reconcile()
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=watch;
 
 func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast", req.NamespacedName)

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -65,6 +65,7 @@ func NewHazelcastReconciler(c client.Client, log logr.Logger, s *runtime.Scheme,
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get;list,namespace=system
 // ClusterRole related to Reconcile()
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete;
 
 func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast", req.NamespacedName)

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -178,13 +178,20 @@ func (r *HazelcastReconciler) reconcileClusterRole(ctx context.Context, h *hazel
 		},
 	}
 
+	if h.Spec.Persistence.IsEnabled() {
+		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"statefulsets"},
+			Verbs:     []string{"watch"},
+		})
+	}
+
 	if platform.GetType() == platform.OpenShift {
 		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"security.openshift.io"},
 			Resources: []string{"securitycontextconstraints"},
 			Verbs:     []string{"use"},
-		},
-		)
+		})
 	}
 
 	opResult, err := util.CreateOrUpdate(ctx, r.Client, clusterRole, func() error {

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -77,7 +77,7 @@ const (
 	// HazelcastEERepo image repository for Hazelcast EE
 	HazelcastEERepo = "docker.io/hazelcast/hazelcast-enterprise"
 	// HazelcastVersion version of Hazelcast image
-	HazelcastVersion = "5.1.4"
+	HazelcastVersion = "5.2.0"
 	// HazelcastImagePullPolicy pull policy for Hazelcast Platform image
 	HazelcastImagePullPolicy = corev1.PullIfNotPresent
 )
@@ -87,7 +87,7 @@ const (
 	// MCRepo image repository for Management Center
 	MCRepo = "docker.io/hazelcast/management-center"
 	// MCVersion version of Management Center image
-	MCVersion = "5.1.4"
+	MCVersion = "5.2.0"
 	// MCImagePullPolicy pull policy for Management Center image
 	MCImagePullPolicy = corev1.PullIfNotPresent
 )

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -716,7 +716,7 @@ var _ = Describe("Hazelcast controller", func() {
 				Delete(hz)
 			})
 
-			FIt("should add RBAC PolicyRule for watch statefulsets", Label("fast"), func() {
+			It("should add RBAC PolicyRule for watch statefulsets", Label("fast"), func() {
 				s := test.HazelcastSpec(defaultSpecValues, ee)
 				s.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
 					BaseDir:                   "/data/hot-restart/",

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -715,6 +715,39 @@ var _ = Describe("Hazelcast controller", func() {
 				)
 				Delete(hz)
 			})
+
+			FIt("should add RBAC PolicyRule for watch statefulsets", Label("fast"), func() {
+				s := test.HazelcastSpec(defaultSpecValues, ee)
+				s.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+					BaseDir:                   "/data/hot-restart/",
+					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
+					Pvc: hazelcastv1alpha1.PersistencePvcConfiguration{
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						RequestStorage:   &[]resource.Quantity{resource.MustParse("8Gi")}[0],
+						StorageClassName: &[]string{"standard"}[0],
+					},
+				}
+				hz := &hazelcastv1alpha1.Hazelcast{
+					ObjectMeta: GetRandomObjectMeta(),
+					Spec:       s,
+				}
+
+				Create(hz)
+				EnsureStatus(hz)
+
+				By("checking ClusterRole", func() {
+					rbac := &rbacv1.ClusterRole{}
+					Expect(k8sClient.Get(
+						context.Background(), client.ObjectKey{Name: hz.ClusterScopedName()}, rbac)).
+						Should(Succeed())
+
+					Expect(rbac.Rules).Should(ContainElement(rbacv1.PolicyRule{
+						APIGroups: []string{"apps"},
+						Resources: []string{"statefulsets"},
+						Verbs:     []string{"watch"},
+					}))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
allow watch verb on StatefulSets resources, so Hazelcast can monitor StatefulSet spec & status changes and make informed decisions about member/cluster shutdown and startup