### PR TITLE
[CN-563] Add unit tests for HotBackup Reconciler

### DIFF
--- a/controllers/hazelcast/fakes_test.go
+++ b/controllers/hazelcast/fakes_test.go
@@ -1,15 +1,181 @@
 package hazelcast
 
 import (
-	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/go-logr/logr"
+	proto "github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/cluster"
+	hztypes "github.com/hazelcast/hazelcast-go-client/types"
 	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
+	codecTypes "github.com/hazelcast/hazelcast-platform-operator/internal/protocol/types"
 )
 
-func fakeClient(initObjs ...client.Object) client.Client {
+func fakeK8sClient(initObjs ...client.Object) client.Client {
 	scheme, _ := hazelcastv1alpha1.SchemeBuilder.
 		Register(&hazelcastv1alpha1.Hazelcast{}, &hazelcastv1alpha1.HazelcastList{}, &v1.ClusterRole{}, &v1.ClusterRoleBinding{}).
 		Build()
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
+}
+
+func fakeHttpServer(url string, handler http.HandlerFunc) (*httptest.Server, error) {
+	l, err := net.Listen("tcp", url)
+	if err != nil {
+		return nil, err
+	}
+	ts := httptest.NewUnstartedServer(handler)
+	_ = ts.Listener.Close()
+	ts.Listener = l
+	ts.Start()
+	return ts, nil
+}
+
+type fakeHzClientRegistry struct {
+	Clients sync.Map
+}
+
+func (cr *fakeHzClientRegistry) Create(ctx context.Context, h *hazelcastv1alpha1.Hazelcast) (hzclient.Client, error) {
+	ns := types.NamespacedName{Namespace: h.Namespace, Name: h.Name}
+	client, ok := cr.Get(ns)
+	if !ok {
+		return client, fmt.Errorf("Fake client was not set before test")
+	}
+	return client, nil
+}
+
+func (ssr *fakeHzClientRegistry) Set(ns types.NamespacedName, cl hzclient.Client) {
+	ssr.Clients.Store(ns, cl)
+}
+
+func (cr *fakeHzClientRegistry) Get(ns types.NamespacedName) (hzclient.Client, bool) {
+	if v, ok := cr.Clients.Load(ns); ok {
+		return v.(hzclient.Client), true
+	}
+	return nil, false
+}
+
+func (cr *fakeHzClientRegistry) Delete(ctx context.Context, ns types.NamespacedName) {
+	if c, ok := cr.Clients.LoadAndDelete(ns); ok {
+		c.(hzclient.Client).Shutdown(ctx) //nolint:errcheck
+	}
+}
+
+type fakeHzClient struct {
+	tOrderedMembers          []cluster.MemberInfo
+	tIsClientConnected       bool
+	tAreAllMembersAccessible bool
+	tRunning                 bool
+	tInvokeOnMember          func(ctx context.Context, req *proto.ClientMessage, uuid hztypes.UUID, opts *proto.InvokeOptions) (*proto.ClientMessage, error)
+	tInvokeOnRandomTarget    func(ctx context.Context, req *proto.ClientMessage, opts *proto.InvokeOptions) (*proto.ClientMessage, error)
+	tShutDown                error
+}
+
+func (cl *fakeHzClient) OrderedMembers() []cluster.MemberInfo {
+	return cl.tOrderedMembers
+}
+
+func (cl *fakeHzClient) IsClientConnected() bool {
+	return cl.tIsClientConnected
+}
+
+func (cl *fakeHzClient) AreAllMembersAccessible() bool {
+	return cl.tAreAllMembersAccessible
+}
+
+func (cl *fakeHzClient) InvokeOnMember(ctx context.Context, req *proto.ClientMessage, uuid hztypes.UUID, opts *proto.InvokeOptions) (*proto.ClientMessage, error) {
+	if cl.tInvokeOnMember != nil {
+		return cl.tInvokeOnMember(ctx, req, uuid, opts)
+	}
+	return nil, nil
+}
+
+func (cl *fakeHzClient) InvokeOnRandomTarget(ctx context.Context, req *proto.ClientMessage, opts *proto.InvokeOptions) (*proto.ClientMessage, error) {
+	if cl.tInvokeOnRandomTarget != nil {
+		return cl.tInvokeOnRandomTarget(ctx, req, opts)
+	}
+	return nil, nil
+}
+
+func (cl *fakeHzClient) Running() bool {
+	return cl.tRunning
+}
+
+func (cl *fakeHzClient) Shutdown(ctx context.Context) error {
+	return cl.tShutDown
+}
+
+type fakeHzStatusServiceRegistry struct {
+	statusServices sync.Map
+}
+
+func (ssr *fakeHzStatusServiceRegistry) Create(ns types.NamespacedName, cl hzclient.Client, l logr.Logger, channel chan event.GenericEvent) hzclient.StatusService {
+	ss, ok := ssr.Get(ns)
+	if ok {
+		return ss
+	}
+	ssr.statusServices.Store(ns, ss)
+	ss.Start()
+	return ss
+}
+
+func (ssr *fakeHzStatusServiceRegistry) Set(ns types.NamespacedName, ss hzclient.StatusService) {
+	ssr.statusServices.Store(ns, ss)
+}
+
+func (ssr *fakeHzStatusServiceRegistry) Get(ns types.NamespacedName) (hzclient.StatusService, bool) {
+	if v, ok := ssr.statusServices.Load(ns); ok {
+		return v.(hzclient.StatusService), ok
+	}
+	return nil, false
+}
+
+func (ssr *fakeHzStatusServiceRegistry) Delete(ns types.NamespacedName) {
+	if ss, ok := ssr.statusServices.LoadAndDelete(ns); ok {
+		ss.(hzclient.StatusService).Stop()
+	}
+}
+
+type fakeHzStatusService struct {
+	Status              *hzclient.Status
+	timedMemberStateMap map[hztypes.UUID]*codecTypes.TimedMemberStateWrapper
+	tStart              func()
+	tUpdateMembers      func(ss *fakeHzStatusService, ctx context.Context)
+}
+
+func (ss *fakeHzStatusService) Start() {
+	if ss.tStart != nil {
+		ss.tStart()
+	}
+}
+
+func (ss *fakeHzStatusService) GetStatus() *hzclient.Status {
+	return ss.Status
+}
+
+func (ss *fakeHzStatusService) UpdateMembers(ctx context.Context) {
+	if ss.tUpdateMembers != nil {
+		ss.tUpdateMembers(ss, ctx)
+	}
+}
+
+func (ss *fakeHzStatusService) GetTimedMemberState(ctx context.Context, uuid hztypes.UUID) (*codecTypes.TimedMemberStateWrapper, error) {
+	if state, ok := ss.timedMemberStateMap[uuid]; ok {
+		return state, nil
+	}
+	return nil, nil
+}
+
+func (ss *fakeHzStatusService) Stop() {
 }

--- a/controllers/hazelcast/hazelcast_status.go
+++ b/controllers/hazelcast/hazelcast_status.go
@@ -62,7 +62,7 @@ func terminatingPhase(err error) optionsBuilder {
 }
 
 func (o optionsBuilder) withStatus(s *hzclient.Status) optionsBuilder {
-	o.readyMembers = s.MemberMap
+	o.readyMembers = s.MemberDataMap
 	o.restoreState = s.ClusterHotRestartStatus
 	return o
 }

--- a/controllers/hazelcast/hot_backup_controller_test.go
+++ b/controllers/hazelcast/hot_backup_controller_test.go
@@ -157,7 +157,7 @@ func TestHotBackupReconciler_shouldNotTriggerHotBackupTwice(t *testing.T) {
 	Expect(hotBackupTriggers).Should(Equal(int32(1)))
 }
 
-func TestHotBackupReconciler_shouldCancelContextIfHazelcastCRIsDeleted(t *testing.T) {
+func TestHotBackupReconciler_shouldCancelContextIfHotbackupCRIsDeleted(t *testing.T) {
 	RegisterFailHandler(fail(t))
 	nn, h, hb := defaultCRs()
 

--- a/controllers/hazelcast/hot_backup_controller_test.go
+++ b/controllers/hazelcast/hot_backup_controller_test.go
@@ -2,9 +2,19 @@ package hazelcast
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/cluster"
+	clientTypes "github.com/hazelcast/hazelcast-go-client/types"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -13,10 +23,269 @@ import (
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/mtls"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/protocol/codec"
+	codecTypes "github.com/hazelcast/hazelcast-platform-operator/internal/protocol/types"
 )
 
-func TestHotBackupReconciler_shouldSetStatusToFailedIfHazelcastCRNotFound(t *testing.T) {
+var (
+	defaultMemberIP = "127.0.0.1"
+)
+
+func TestHotBackupReconciler_shouldBeSuccessful(t *testing.T) {
 	RegisterFailHandler(fail(t))
+	nn := types.NamespacedName{
+		Name:      "hazelcast",
+		Namespace: "default",
+	}
+	h := &hazelcastv1alpha1.Hazelcast{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HazelcastSpec{
+			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "basedir",
+			},
+		},
+		Status: hazelcastv1alpha1.HazelcastStatus{
+			Phase: hazelcastv1alpha1.Running,
+		},
+	}
+	hb := &hazelcastv1alpha1.HotBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HotBackupSpec{
+			HazelcastResourceName: nn.Name,
+		},
+	}
+	fakeHzClient, fakeHzStatusService := defaultFakeClientAndService()
+	ts, err := fakeHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort), func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(200)
+		_, _ = writer.Write([]byte(`{"backups" : ["backup-123"]}`))
+	})
+	Expect(err).Should(BeNil())
+	defer ts.Close()
+
+	cr := &fakeHzClientRegistry{}
+	sr := &fakeHzStatusServiceRegistry{}
+	cr.Set(nn, &fakeHzClient)
+	sr.Set(nn, &fakeHzStatusService)
+
+	r := hotBackupReconcilerWithCRs(cr, sr, h, hb)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
+	Expect(err).Should(BeNil())
+
+	Eventually(func() hazelcastv1alpha1.HotBackupState {
+		_ = r.Client.Get(context.TODO(), nn, hb)
+		return hb.Status.State
+	}, 2*time.Second, 100*time.Millisecond).Should(Equal(hazelcastv1alpha1.HotBackupSuccess))
+}
+
+func TestHotBackupReconciler_shouldSetStatusToFailedWhenHbCallFails(t *testing.T) {
+	RegisterFailHandler(fail(t))
+	nn := types.NamespacedName{
+		Name:      "hazelcast",
+		Namespace: "default",
+	}
+	h := &hazelcastv1alpha1.Hazelcast{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HazelcastSpec{
+			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "basedir",
+			},
+		},
+		Status: hazelcastv1alpha1.HazelcastStatus{
+			Phase: hazelcastv1alpha1.Running,
+		},
+	}
+	hb := &hazelcastv1alpha1.HotBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HotBackupSpec{
+			HazelcastResourceName: nn.Name,
+		},
+	}
+	fakeHzClient, fakeHzStatusService := defaultFakeClientAndService()
+	fakeHzClient.tInvokeOnRandomTarget = func(ctx context.Context, req *hazelcast.ClientMessage, opts *hazelcast.InvokeOptions) (*hazelcast.ClientMessage, error) {
+		if req.Type() == codec.MCTriggerHotRestartBackupCodecRequestMessageType {
+			return nil, fmt.Errorf("Backup trigger request failed")
+		}
+		return nil, nil
+	}
+
+	ts, err := fakeHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort), func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(200)
+		_, _ = writer.Write([]byte(`{"backups" : ["backup-123"]}`))
+	})
+	Expect(err).Should(BeNil())
+	defer ts.Close()
+
+	sr := &fakeHzStatusServiceRegistry{}
+	cr := &fakeHzClientRegistry{}
+
+	sr.Set(nn, &fakeHzStatusService)
+	cr.Set(nn, &fakeHzClient)
+
+	r := hotBackupReconcilerWithCRs(cr, sr, h, hb)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
+	Expect(err).Should(BeNil())
+
+	Eventually(func() hazelcastv1alpha1.HotBackupState {
+		_ = r.Client.Get(context.TODO(), nn, hb)
+		return hb.Status.State
+	}, 2*time.Second, 100*time.Millisecond).Should(Equal(hazelcastv1alpha1.HotBackupFailure))
+}
+
+func TestHotBackupReconciler_shouldNotTriggerHotBackupTwice(t *testing.T) {
+	RegisterFailHandler(fail(t))
+	nn := types.NamespacedName{
+		Name:      "hazelcast",
+		Namespace: "default",
+	}
+	h := &hazelcastv1alpha1.Hazelcast{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HazelcastSpec{
+			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "basedir",
+			},
+		},
+		Status: hazelcastv1alpha1.HazelcastStatus{
+			Phase: hazelcastv1alpha1.Running,
+		},
+	}
+	hb := &hazelcastv1alpha1.HotBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HotBackupSpec{
+			HazelcastResourceName: nn.Name,
+		},
+	}
+
+	var restCallWg sync.WaitGroup
+	restCallWg.Add(1)
+	var hotBackupTriggers int32
+
+	fakeHzClient, fakeHzStatusService := defaultFakeClientAndService()
+	fakeHzClient.tInvokeOnRandomTarget = func(ctx context.Context, req *hazelcast.ClientMessage, opts *hazelcast.InvokeOptions) (*hazelcast.ClientMessage, error) {
+		if req.Type() == codec.MCTriggerHotRestartBackupCodecRequestMessageType {
+			atomic.AddInt32(&hotBackupTriggers, 1)
+			restCallWg.Wait()
+		}
+		return nil, nil
+	}
+
+	ts, err := fakeHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort), func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(200)
+		_, _ = writer.Write([]byte(`{"backups" : ["backup-123"]}`))
+	})
+	Expect(err).Should(BeNil())
+	defer ts.Close()
+
+	sr := &fakeHzStatusServiceRegistry{}
+	cr := &fakeHzClientRegistry{}
+	sr.Set(nn, &fakeHzStatusService)
+	cr.Set(nn, &fakeHzClient)
+
+	r := hotBackupReconcilerWithCRs(cr, sr, h, hb)
+	var reconcileWg sync.WaitGroup
+	reconcileWg.Add(1)
+	go func() {
+		defer reconcileWg.Done()
+		_, _ = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
+	}()
+
+	Eventually(func() hazelcastv1alpha1.HotBackupState {
+		_ = r.Client.Get(context.TODO(), nn, hb)
+		return hb.Status.State
+	}, 2*time.Second, 100*time.Millisecond).Should(Equal(hazelcastv1alpha1.HotBackupInProgress))
+
+	reconcileWg.Add(1)
+	go func() {
+		defer reconcileWg.Done()
+		_, _ = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
+	}()
+	restCallWg.Done()
+	reconcileWg.Wait()
+
+	Expect(hotBackupTriggers).Should(Equal(int32(1)))
+}
+
+func TestHotBackupReconciler_shouldCancelContextIfHazelcastCRIsDeleted(t *testing.T) {
+	RegisterFailHandler(fail(t))
+	nn := types.NamespacedName{
+		Name:      "hazelcast",
+		Namespace: "default",
+	}
+	h := &hazelcastv1alpha1.Hazelcast{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HazelcastSpec{
+			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "basedir",
+			},
+		},
+		Status: hazelcastv1alpha1.HazelcastStatus{
+			Phase: hazelcastv1alpha1.Running,
+		},
+	}
+	hb := &hazelcastv1alpha1.HotBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HotBackupSpec{
+			HazelcastResourceName: nn.Name,
+		},
+	}
+
+	fakeHzClient, fakeHzStatusService := defaultFakeClientAndService()
+	ts, err := fakeHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort), func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(200)
+		_, _ = writer.Write([]byte(`{"backups" : ["backup-123"]}`))
+	})
+	Expect(err).Should(BeNil())
+	defer ts.Close()
+
+	cr := &fakeHzClientRegistry{}
+	sr := &fakeHzStatusServiceRegistry{}
+	cr.Set(nn, &fakeHzClient)
+	sr.Set(nn, &fakeHzStatusService)
+
+	r := hotBackupReconcilerWithCRs(cr, sr, h, hb)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
+	Expect(err).Should(BeNil())
+
+	Expect(r.Client.Get(context.TODO(), nn, hb)).Should(Succeed())
+	Expect(r.cancelMap).Should(&matchers.HaveLenMatcher{Count: 1})
+
+	timeNow := metav1.Now()
+	hb.ObjectMeta.DeletionTimestamp = &timeNow
+	err = r.Client.Update(context.TODO(), hb)
+	Expect(err).Should(BeNil())
+
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
+	Expect(err).Should(BeNil())
+
+	Expect(r.cancelMap).Should(&matchers.HaveLenMatcher{Count: 0})
+}
+
+func TestHotBackupReconciler_shouldSetStatusToFailedIfHazelcastCRNotFound(t *testing.T) {
+	RegisterFailHandler(Fail)
 	n := types.NamespacedName{
 		Name:      "hazelcast",
 		Namespace: "default",
@@ -31,7 +300,7 @@ func TestHotBackupReconciler_shouldSetStatusToFailedIfHazelcastCRNotFound(t *tes
 		},
 	}
 
-	r := hotBackupReconcilerWithCRs(hb)
+	r := hotBackupReconcilerWithCRs(&fakeHzClientRegistry{}, &fakeHzStatusServiceRegistry{}, hb)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: n})
 	if err == nil {
 		t.Errorf("Error executing Reconcile to return error but returned nil")
@@ -48,14 +317,63 @@ func fail(t *testing.T) func(message string, callerSkip ...int) {
 	}
 }
 
-func hotBackupReconcilerWithCRs(initObjs ...client.Object) *HotBackupReconciler {
+func hotBackupReconcilerWithCRs(clientReg hzclient.ClientRegistry, serviceReg hzclient.StatusServiceRegistry, initObjs ...client.Object) *HotBackupReconciler {
 	return NewHotBackupReconciler(
-		fakeClient(initObjs...),
+		fakeK8sClient(initObjs...),
 		ctrl.Log.WithName("test").WithName("Hazelcast"),
 		nil,
-		nil,
-		&hzclient.HazelcastClientRegistry{},
-		&hzclient.HzStatusServiceRegistry{},
+		&mtls.Client{},
+		clientReg,
+		serviceReg,
 	)
 
+}
+
+func defaultFakeClientAndService() (fakeHzClient, fakeHzStatusService) {
+	defaultMemberAddress := cluster.Address(defaultMemberIP + ":5701")
+	mm := []cluster.MemberInfo{
+		{
+			Address: defaultMemberAddress,
+			UUID:    clientTypes.NewUUID(),
+		},
+		{
+			Address: defaultMemberAddress,
+			UUID:    clientTypes.NewUUID(),
+		},
+		{
+			Address: defaultMemberAddress,
+			UUID:    clientTypes.NewUUID(),
+		},
+	}
+
+	fakeHzClient := fakeHzClient{
+		tOrderedMembers:          mm,
+		tIsClientConnected:       true,
+		tAreAllMembersAccessible: true,
+		tRunning:                 true,
+	}
+
+	timedMemberState := &codecTypes.TimedMemberStateWrapper{}
+	timedMemberState.TimedMemberState.MemberState.HotRestartState.BackupTaskState = "SUCCESS"
+	fakeHzStatusService := fakeHzStatusService{
+		timedMemberStateMap: map[clientTypes.UUID]*codecTypes.TimedMemberStateWrapper{
+			mm[0].UUID: timedMemberState,
+			mm[1].UUID: timedMemberState,
+			mm[2].UUID: timedMemberState,
+		},
+		Status: &hzclient.Status{
+			MemberDataMap: map[clientTypes.UUID]*hzclient.MemberData{
+				mm[0].UUID: {
+					Address: mm[0].Address.String(),
+				},
+				mm[1].UUID: {
+					Address: mm[1].Address.String(),
+				},
+				mm[2].UUID: {
+					Address: mm[2].Address.String(),
+				},
+			},
+		},
+	}
+	return fakeHzClient, fakeHzStatusService
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -40,14 +40,14 @@ func NewClusterBackup(ss hzclient.StatusService, bs hzclient.BackupService) (*Cl
 		return nil, errBackupClientNoMembers
 	}
 
-	if status.MemberMap == nil {
+	if status.MemberDataMap == nil {
 		return nil, errBackupClientNoMembers
 	}
 
 	return &ClusterBackup{
 		statusService: ss,
 		backupService: bs,
-		members:       status.MemberMap,
+		members:       status.MemberDataMap,
 	}, nil
 }
 

--- a/internal/hazelcast-client/config.go
+++ b/internal/hazelcast-client/config.go
@@ -16,6 +16,10 @@ import (
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 )
 
+const (
+	AgentPort = 8443
+)
+
 func BuildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
 	config := hazelcast.Config{
 		Logger: logger.Config{
@@ -45,4 +49,8 @@ func RestUrl(h *hazelcastv1alpha1.Hazelcast) string {
 
 func HazelcastUrl(h *hazelcastv1alpha1.Hazelcast) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", h.Name, h.Namespace, n.DefaultHzPort)
+}
+
+func AgentUrl(host string) string {
+	return fmt.Sprintf("https://%s:%d", host, AgentPort)
 }

--- a/internal/hazelcast-client/config_local_run.go
+++ b/internal/hazelcast-client/config_local_run.go
@@ -7,19 +7,36 @@ package client
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/cluster"
 	"github.com/hazelcast/hazelcast-go-client/logger"
+	hztypes "github.com/hazelcast/hazelcast-go-client/types"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 )
 
-const localUrl = "127.0.0.1:8000"
+const (
+	localUrl  = "127.0.0.1:8000"
+	AgentPort = 8080
+)
 
 func BuildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
 	config := hazelcast.Config{
 		Logger: logger.Config{
 			Level: logger.OffLevel,
+		},
+		Cluster: cluster.Config{
+			ConnectionStrategy: cluster.ConnectionStrategyConfig{
+				Timeout:       hztypes.Duration(3 * time.Second),
+				ReconnectMode: cluster.ReconnectModeOn,
+				Retry: cluster.ConnectionRetryConfig{
+					InitialBackoff: hztypes.Duration(200 * time.Millisecond),
+					MaxBackoff:     hztypes.Duration(1 * time.Second),
+					Jitter:         0.25,
+				},
+			},
 		},
 	}
 	cc := &config.Cluster
@@ -35,4 +52,8 @@ func RestUrl(h *hazelcastv1alpha1.Hazelcast) string {
 
 func HazelcastUrl(_ *hazelcastv1alpha1.Hazelcast) string {
 	return localUrl
+}
+
+func AgentUrl(host string) string {
+	return fmt.Sprintf("http://%s:%d", host, AgentPort)
 }

--- a/internal/hazelcast-client/status_service.go
+++ b/internal/hazelcast-client/status_service.go
@@ -27,7 +27,7 @@ type StatusService interface {
 }
 
 type Status struct {
-	MemberMap               map[hztypes.UUID]*MemberData
+	MemberDataMap           map[hztypes.UUID]*MemberData
 	ClusterHotRestartStatus codecTypes.ClusterHotRestartStatus
 }
 
@@ -89,7 +89,7 @@ func NewStatusService(n types.NamespacedName, cl Client, l logr.Logger, channel 
 		client:               cl,
 		namespacedName:       n,
 		log:                  l,
-		status:               &Status{MemberMap: make(map[hztypes.UUID]*MemberData)},
+		status:               &Status{MemberDataMap: make(map[hztypes.UUID]*MemberData)},
 		triggerReconcileChan: channel,
 	}
 }
@@ -149,7 +149,7 @@ func (ss *HzStatusService) UpdateMembers(ctx context.Context) {
 	}
 
 	ss.statusLock.Lock()
-	ss.status.MemberMap = activeMembers
+	ss.status.MemberDataMap = activeMembers
 	ss.status.ClusterHotRestartStatus = *newClusterHotRestartStatus
 	ss.statusLock.Unlock()
 }

--- a/internal/local_backup/local_backup.go
+++ b/internal/local_backup/local_backup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/mtls"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/rest"
 )
@@ -26,7 +27,7 @@ func NewLocalBackup(config *Config) (*LocalBackup, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err := rest.NewLocalBackupService("https://"+host+":8443", &config.MTLSClient.Client)
+	s, err := rest.NewLocalBackupService(hzclient.AgentUrl(host), &config.MTLSClient.Client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Created unit tests are taken from the deleted tests in  #381
Also added unit test for the case where one member's timed member state returns failure, this case is created for the fixed issue #445