### PR TITLE
Fix error hiding in startBackup function

### DIFF
--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -135,8 +135,12 @@ func (r *HotBackupReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 		return result, err
 	}
 	r.lockBackup(req.NamespacedName)
-	go r.startBackup(cancelCtx, req.NamespacedName, hb.Spec.IsExternal(), hazelcastName, logger) //nolint:errcheck
-
+	go func() {
+		_, err := r.startBackup(cancelCtx, req.NamespacedName, hb.Spec.IsExternal(), hazelcastName, logger)
+		if err != nil {
+			logger.Error(err, "Error taking backup")
+		}
+	}()
 	return
 }
 
@@ -260,7 +264,11 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 		g.Go(func() error {
 			if err := m.Wait(groupCtx); err != nil {
 				// cancel cluster backup
-				return b.Cancel(ctx)
+				cancelErr := b.Cancel(ctx)
+				if cancelErr != nil {
+					return cancelErr
+				}
+				return fmt.Errorf("Backup error for member %s: %w", m.UUID, err)
 			}
 			return nil
 		})
@@ -326,7 +334,11 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
 					// notify agent so we can cleanup if needed
-					return u.Cancel(ctx)
+					cancelErr := u.Cancel(ctx)
+					if cancelErr != nil {
+						return cancelErr
+					}
+					return fmt.Errorf("Upload error for member %s: %w", m.UUID, err)
 				}
 				return err
 			}


### PR DESCRIPTION
startBackup function was returning no errors when one of the members failed with an error if the return value of the cancel function was nil. This resulted in backup process to continue with the next steps