### PR TITLE
[CN-594] Add list statefulset permission for member role [5.5]

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3414,6 +3414,7 @@ rules:
   resources:
   - statefulsets
   verbs:
+  - list
   - watch
 - apiGroups:
   - hazelcast.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,7 @@ rules:
   resources:
   - statefulsets
   verbs:
+  - list
   - watch
 - apiGroups:
   - hazelcast.com

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -65,7 +65,7 @@ func NewHazelcastReconciler(c client.Client, log logr.Logger, s *runtime.Scheme,
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get;list,namespace=system
 // ClusterRole related to Reconcile()
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=watch;
+//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=watch;list
 
 func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast", req.NamespacedName)

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -182,7 +182,7 @@ func (r *HazelcastReconciler) reconcileClusterRole(ctx context.Context, h *hazel
 		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"apps"},
 			Resources: []string{"statefulsets"},
-			Verbs:     []string{"watch"},
+			Verbs:     []string{"watch,list"},
 		})
 	}
 


### PR DESCRIPTION
Currently members are getting the following error:

```
Exception in thread "hz-k8s-sts-monitor" com.hazelcast.spi.exception.RestClientException: Failure executing: GET at: https://kubernetes.default.svc/apis/apps/v1/namespaces/test-operator-nightly-ee/statefulsets. Message: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"statefulsets.apps is forbidden: User \"system:serviceaccount:test-operator-nightly-ee:hp-7-y6cier\" cannot list resource \"statefulsets\" in API group \"apps\" in the namespace \"test-operator-nightly-ee\"","reason":"Forbidden","details":{"group":"apps","kind":"statefulsets"},"code":403}. HTTP Error Code: 403
```