### PR TITLE
[CN-614] Add additional port to the LB discovery service

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -317,6 +317,16 @@ func (r *HazelcastReconciler) reconcileService(ctx context.Context, h *hazelcast
 			Ports:    hazelcastPort(),
 		},
 	}
+
+	if h.ExternalAddressEnabled() && !h.Spec.ExposeExternally.IsSmart() {
+		service.Spec.Ports = append(service.Spec.Ports, corev1.ServicePort{
+			Name:       "hazelcast-port-ex",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       5702,
+			TargetPort: intstr.FromInt(5702),
+		})
+	}
+
 	err := controllerutil.SetControllerReference(h, service, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to set owner reference on Service: %w", err)


### PR DESCRIPTION
This is a temporary fix for Hazelcast discovery plugin where the first member tries to assume the address of the discovery service load balancer, because there are no members running at that time. With the additional IP it can no longer assume the IP address.