### PR TITLE
Add new feature to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Here is a short video to deploy a simple Hazelcast Platform cluster and Manageme
 
 ## Documentation
 
-1. [Get started](https://docs.hazelcast.com/operator/latest/get-started) with the Operator.
+1. [Get started](https://docs.hazelcast.com/operator/latest/get-started) with the Operator
 2. [Connect the cluster from outside Kubernetes](https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally)
-   from the outside.
+3. [Restore a Cluster from Cloud Storage with Hazelcast Platform Operator](https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-external-backup-restore)
+4. [Replicate Data between Two Hazelcast Clusters with Hazelcast Platform Operator](https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-wan-replication)
 
 ## Features
 
@@ -33,6 +34,12 @@ Hazelcast Platform Operator supports the features below:
 * Scale up and down Hazelcast clusters
 * Expose Hazelcast cluster to external
   clients ([Smart & Unisocket](https://docs.hazelcast.com/hazelcast/latest/clients/java#java-client-operation-modes))
+* Backup Hazelcast persistence data to cloud storage with the possibility of scheduling it and restoring the data accordingly
+* WAN Replication feature when you need to synchronize multiple Hazelcast clusters, which are connected by WANs
+* User Code Deployment feature, which allows you to deploy custom and domain classes from cloud storages to Hazelcast members
+* ExecutorService and EntryProcessor support
+* Support several data structures like Map, Topic, MultiMap, and ReplicatedMap, which can be created dynamically via specific Custom Resources
+* MapStore support for Map CR
 
 For Hazelcast Platform Enterprise, you can request a trial license key from [here](https://trialrequest.hazelcast.com).
 

--- a/config/manifests/bases/hazelcast-platform-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/hazelcast-platform-operator.clusterserviceversion.yaml
@@ -46,6 +46,8 @@ spec:
     1. [Get started](https://docs.hazelcast.com/operator/latest/get-started) with the Operator.
     2. [Connect to the cluster from outside Kubernetes](https://guides.hazelcast.org/hazelcast-platform-operator-expose-externally/main)
       from the outside.
+    3. [Restore a Cluster from Cloud Storage with Hazelcast Platform Operator](https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-external-backup-restore)
+    4. [Replicate Data between Two Hazelcast Clusters with Hazelcast Platform Operator](https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-wan-replication)
 
     ## Features
 
@@ -56,6 +58,12 @@ spec:
     * Scale up and down Hazelcast clusters
     * Expose Hazelcast cluster to external
       clients ([Smart & Unisocket](https://docs.hazelcast.com/hazelcast/latest/clients/java#java-client-operation-modes))
+    * Backup Hazelcast persistence data to cloud storage with the possibility of scheduling it and restoring the data accordingly
+    * WAN Replication feature when you need to synchronize multiple Hazelcast clusters, which are connected by WANs
+    * User Code Deployment feature, which allows you to deploy custom and domain classes from cloud storages to Hazelcast members
+    * ExecutorService and EntryProcessor support
+    * Support several data structures like Map, Topic, MultiMap, and ReplicatedMap, which can be created dynamically via specific Custom Resources
+    * MapStore support for Map CR
   displayName: Hazelcast Platform Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAACXBIWXMAABCcAAAQnAEmzTo0AAAHQ0lEQVR4nO3dgXHbRhAFUDiTAtSBnA6SDuwK0kLcQVxBJhUkHdguwRVYHVgdJOzAHSQjQpQEmqQE7AFY3L03owlHkukNd88kyAN+V9Ru92X/BWuYYf5+LPy/8brw/cEYxefPAqEmxefvh2L3tNv9fPI2LGGm+Su3QLruzZnbsIRZ5q/kAvn1zG1Ywizz96rIvex2d6/9/jn67k/d9fW/Re4fVpq/Us8gf7zwezCH2eYv/gxyevUeeBZhXjPPX4lnkA8TfwYlzDp/sQWy2/3+zDsGb+5/B8pbYP6mv8Tq32v++sLf/qW7vr6d/HfBSvM37RmkL27MnpcvPjykmAXnb/wzyGNxVyP/5Leu6956JiFk4fkbt0CmF3dgkTDdCvP38pdY/cHO10Bx3f2f/erAndFWmr/nn0H695k/lNzfcu+m67p3PifhopXn7/wC6Qu7+zTyt8KFHfvYdd2fFgoDSeZvuED613hv7jd7Lb0j925Ff97/1zFKmxLO36v7UxRfJzzZ6d/91/X12wS1MJfk81dyuztUx0ss8kj5EuscB+msKeVB+ine5mVNad/mPdZ/uPJXoeLed9fXfxe6L1qw0vzZasJ2rDB/NiuyLak3Kx6ML9LioJwF588JU2xT6hOm7vR/4fsX/OZ7i4PiFpq/Elc1+XLhLbgbW0WY1czzV2KrybuJP4MSZp2/+ALpP2j5eOInH30IyOxmnj+XHmX70l96tC/k5sl3biwOFjPj/JXc7v75zG1YwizzV3KB3Jy5DUvYwPztdv/tv6CS+SudUei4gzUVnz8LhJoUn7+2zkmX4x7T4OPXWgy0mOqY5vprgVDT4ycnfTI57jGN9relnHQ57jFN9relnHQ57jFN9reNzYo2U8Y03N9WctLluMc029/6c9LluMc03t8WctLluMc03d+6c9LluMfob8WX/XFZohj93aszJ12Oe4z+Pqjv0qMujRqjvwN1XbzaxbVj9Pc79eSky3GP0d+Tth+gI+AnRn8rzUkXERejvwcV5aQLGY3R39H15c9J78lxn0p/p5KTDs/xEqtkfdnp7+j6HKQ/z0F6TEUH6ad4G9DbvNNU/jbvsew56XLcY/T3JFtNhmw10d8BmxUf2azY6e+xOnPS5bjH6O8DJ0z1nDB1TH/36s1Jl+Meo7979eeky3GPaby/LeSky3GPabq/9eeky3GPaby/Lj3K9h8/OelBctxjttffWznp48lxj9lSfz+VutOWctLluMfob1j2nHQ57jEN9re1GGjHHTG3wcvuzE1OepAFEvPt/isrOelVk+OejhjoXF4n/xdaTnqQBRKjvhg56ZOpL0ZOepic9Bj1xchJD1JfjJz0yWxWjFFfjJz0MPXFyEmfTE56jPpi5KSHqS9GTvpkcrRj1BcjJz1AfTHq25OT3lPfU+p74NKjj9TXqe+Yi1cPqU99A3LSh9SnvgEBOuepL0ZOeiF1RrCp70BOeiHbD/FUX3X1yUmfTn0xctJh67zEUp/6LtTnIP156ouRkz6Rtylj1BcjJz1AfTFy0icWZquE+qaTk16A+mLUNyAnvae+p9T3wAlTPfUdU9+enHT1naa+PTnp6rtMTnqYnPQY9cXISQ9RX4yc9AJcOjNGfTFy0oPUF9NwfXLS81BfzCz1yUnPQ30xctLD1BcjJz1MDHRM9vrkpAcZwJjs9TWXk156gRDzkq0TLEgMdCZr7Lka5yr5Syw56UHZ68suX/zzkJz0ybLXl52c9DA533WTkx4k57tuctIns9mubjYrhsn5rpuc9MnkfNdNTnqYnO+6yUmfTI523fTXZX/uLV9fdvq7Jye9t2x92envA5cefbTs1Quz0t8BF68eanuR6O935KQPzVdfdvp7kgCd88rUl53+ykkPmlZfdvp7ICd9sfqy09/R9R1y0q8Sngxz++T857z1rX3x5ufo71T7+g4H6RlPo7w6czuLzKeeHtPf8fY1eYlVsr7s9Hd0fQ7Sn+cgPUZO+kTe5s1Af+WkT1C+vuz09yRbTYZsNdHfAZsVH9ms2OnvMTnpPYvjKf194ISpnhOmjunvnpz0terLTn/35KRn3yqyNjnpYXK+6yYnPUTOd93kpBfg0qN1c+nRIDnfddtef2/lpI+Xvb7sttTfT6XuVE46tTx+ctLDsteXnZz0MDHLdZOTHmSB1E1OeuXkkMc09/i1FQNtz1VM/sdPTjpcICcdlpy/lnLSqZucdFh6/trYrEjd5KTDOvNXf046dZOTDuvNX9056dRNTjqsO3915qRTNznpkGP+6rp4NXWTkw655m/7ATrUTU56pRFnxMhJ/872QzKJkZM+yjZyyIlJPn9byUmnbnLSX8BLrNbJST/JQTrfk5PubV5eQE465J0/W03YDjnpkGv+6sxJp25y0iHH/NWbk07d5KTD+vPXQk46dZOTDmvNn0uPsn1y0mHU/MlJhwvzJycdtjd/cshZk5x0uEhOOlxQdv66rvsfiJAAx8qfoToAAAAASUVORK5CYII=


### PR DESCRIPTION
Added the next feature to readme file and hazelcast-platform-operator.clusterserviceversion.yaml:

* User Code Deployment feature, which allows you to deploy custom and domain classes to Hazelcast members
* External Backup to cloud storage with a possibility to schedule it and restore the data accordingly
* WAN Replication feature when you need to synchronize multiple Hazelcast clusters, which are connected by WANs
* Support the several data structure like Map, Topic, MultiMap, and ReplicatedMap
* Executor Service and Entry Processor support