### PR TITLE
Disable PVC removal for PVC based tests

### DIFF
--- a/test/e2e/hazelcast_backup_slow_test.go
+++ b/test/e2e/hazelcast_backup_slow_test.go
@@ -77,7 +77,6 @@ var _ = Describe("Hazelcast Backup", Label("backup_slow"), func() {
 
 		By("deleting Hazelcast cluster")
 		RemoveHazelcastCR(hazelcast)
-		deletePVCs(hzLookupKey)
 
 		By("creating a new Hazelcast cluster")
 		t := Now()
@@ -188,7 +187,6 @@ var _ = Describe("Hazelcast Backup", Label("backup_slow"), func() {
 
 		By("deleting Hazelcast cluster")
 		RemoveHazelcastCR(hazelcast)
-		deletePVCs(hzLookupKey)
 
 		By("creating new Hazelcast cluster from the existing backup")
 		baseDir += "/hot-backup/backup-" + seq


### PR DESCRIPTION
Fix the issue when the Backup test fails.