### PR TITLE
Revert 5.4 version to latest-snapshot in Dockerfile, Makefile, kustomization.yaml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 RUN microdnf upgrade -y && \
     microdnf clean all
 
-ARG version="5.4"
+ARG version="latest-snapshot"
 ARG pardotID="dockerhub"
 ENV OPERATOR_VERSION=${version}
 ENV PARDOT_ID=${pardotID}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 5.4
+VERSION ?= latest-snapshot
 
 BUNDLE_VERSION := $(VERSION)
 VERSION_PARTS := $(subst ., ,$(VERSION))

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3816,7 +3816,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: hazelcast/hazelcast-platform-operator:5.4
+        image: hazelcast/hazelcast-platform-operator:latest-snapshot
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,7 +7,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: hazelcast/hazelcast-platform-operator
-  newTag: "5.4"
+  newTag: latest-snapshot
 patches:
 - path: remove_security_context.yaml
   target:


### PR DESCRIPTION
After the previous release 5.4, the release branch was merged to the main branch without the changes in several files like Dockerfile, Makefile and kustomization file. It was merged 5.4 version instead of latest-version in some properties. This is became the reason why the correct bundle can't be created using the workflow file Create Release.