### PR TITLE
[CN-381] Remove temporary codec solution with the fixed version

### DIFF
--- a/internal/protocol/types/event_journal_config.go
+++ b/internal/protocol/types/event_journal_config.go
@@ -1,9 +1,6 @@
 package types
 
 type EventJournalConfig struct {
-	// IsDefined is an interim solution. Although HotRestartConfig is nullable, core side returns an error.
-	// The reason for not using pointers is to using the heap at least as possible, it is a decision client team took.
-	IsDefined         bool
 	Enabled           bool
 	Capacity          int32
 	TimeToLiveSeconds int32

--- a/internal/protocol/types/hot_restart_config.go
+++ b/internal/protocol/types/hot_restart_config.go
@@ -1,9 +1,6 @@
 package types
 
 type HotRestartConfig struct {
-	// IsDefined is an interim solution. Although HotRestartConfig is nullable, core side returns an error.
-	// The reason for not using pointers is to using the heap at least as possible, it is a decision client team took.
-	IsDefined bool
-	Enabled   bool
-	Fsync     bool
+	Enabled bool
+	Fsync   bool
 }

--- a/internal/protocol/types/merkle_tree_config.go
+++ b/internal/protocol/types/merkle_tree_config.go
@@ -1,9 +1,6 @@
 package types
 
 type MerkleTreeConfig struct {
-	// IsDefined is an interim solution. Although HotRestartConfig is nullable, core side returns an error.
-	// The reason for not using pointers is to using the heap at least as possible, it is a decision client team took.
-	IsDefined  bool
 	Enabled    bool
 	Depth      int32
 	EnabledSet bool

--- a/internal/protocol/types/request_add_map_config.go
+++ b/internal/protocol/types/request_add_map_config.go
@@ -74,14 +74,9 @@ func DefaultAddMapConfigInput() *AddMapConfigInput {
 		StatisticsEnabled:       true,
 		// workaround for protocol definition and implementation discrepancy in core side
 		HotRestartConfig: HotRestartConfig{
-			IsDefined: true,
-			Enabled:   n.DefaultMapPersistenceEnabled,
-			Fsync:     false,
+			Enabled: n.DefaultMapPersistenceEnabled,
+			Fsync:   false,
 		},
-		// workaround for protocol definition and implementation discrepancy in core side
-		EventJournalConfig: EventJournalConfig{IsDefined: true, Enabled: false, Capacity: 1000},
-		// workaround for protocol definition and implementation discrepancy in core side
-		MerkleTreeConfig:     MerkleTreeConfig{IsDefined: true, Enabled: false, Depth: 2},
 		MetadataPolicy:       0,
 		PerEntryStatsEnabled: false,
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In `addMapConfig` method there were some nullable fields that returned error when given as null. Those were `HotRestartConfig`, `EvictionConfig` , `EventJournalConfig` and `MerkleTreeConfig`. The issue https://github.com/hazelcast/hazelcast/issues/21182 was fixed.

## User Impact

Removed temporary codec solution for fixed Hazelcast issue https://github.com/hazelcast/hazelcast/issues/21182.
