### PR TITLE
ci: Update restart machines method for Open Shift environment

### DIFF
--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -83,6 +83,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-e2e-aks.yaml
+++ b/.github/workflows/nightly-e2e-aks.yaml
@@ -108,6 +108,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -127,6 +127,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -87,6 +87,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-e2e-kind.yaml
+++ b/.github/workflows/nightly-e2e-kind.yaml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-e2e-ocp.yaml
+++ b/.github/workflows/nightly-e2e-ocp.yaml
@@ -70,6 +70,10 @@ jobs:
       - name: Checkout to hazelcast-operator
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:
@@ -87,11 +91,11 @@ jobs:
           make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
           make docker-push IMG=$IMG
 
-      - name: Restart Non-Ready Nodes
+      - name: Restart Non-Ready Machines
         run: |
           source .github/scripts/utils.sh
           oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
-          wait_for_node_restarted $RESTART_OCP_NODE_TIMEOUT
+          wait_for_machine_restarted $RESTART_OCP_NODE_TIMEOUT
 
       - name: Deploy Hazelcast-Platform-Operator to OCP
         run: |

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -89,6 +89,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -136,6 +136,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Cache Golang dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,5 @@
 name: Pull Request
+
 on:
   pull_request_target:
     types:
@@ -12,6 +13,9 @@ on:
       - main
     paths-ignore:
       - "**.md"
+
+permissions:
+  contents: read
 
 env:
   GCP_PROJECT_ID: hazelcast-33
@@ -38,9 +42,33 @@ jobs:
   linter:
     name: Run linters
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Decide which ref to checkout
+        id: decide-ref
+        run: |
+          if [[ "${{github.event_name}}" == "pull_request" ]]; then
+            echo "ref=${{github.ref}}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{steps.decide-ref.outputs.ref}}
+
+      - name: Cache Golang dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
@@ -67,9 +95,25 @@ jobs:
   unit-tests:
     name: Run unit and integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Decide which ref to checkout
+        id: decide-ref
+        run: |
+          if [[ "${{github.event_name}}" == "pull_request" ]]; then
+            echo "ref=${{github.ref}}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{steps.decide-ref.outputs.ref}}
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
 
       - name: Cache Golang dependencies
         uses: actions/cache@v3
@@ -89,7 +133,7 @@ jobs:
         run: make GO_TEST_FLAGS="-ee=true" test-it
 
   create-gke-cluster:
-    name: Create GKE cluster and push image
+    name: Create GKE cluster
     runs-on: ubuntu-latest
     needs: ['unit-tests']
     if: >-
@@ -107,7 +151,52 @@ jobs:
     env:
       GCP_NETWORK: operator-test-network
     steps:
-      - name: Decide which ref to checkout
+      - name: Authenticate to GCP
+        uses: "google-github-actions/auth@v1.0.0"
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Create GKE cluster
+        id: set-cluster-name
+        run: |-
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
+          gcloud container clusters create ${CLUSTER_NAME} \
+            --zone=${{ env.GKE_ZONE }} \
+            --project=${{ env.GCP_PROJECT_ID }} \
+            --network=${{ env.GCP_NETWORK }} \
+            --machine-type=n1-standard-2 \
+            --num-nodes=3
+          sleep 30
+
+  new-relic-setup:
+    name: Setup New Relic
+    needs: [ create-gke-cluster ]
+    uses: ./.github/workflows/newrelic-gke.yaml
+    secrets: inherit
+    with:
+      cluster_name: ${{ needs.create-gke-cluster.outputs.CLUSTER_NAME }}
+      nr_cluster_name: gke-operator-pull
+      gh_run_id: ${{ github.run_id }}
+      gh_run_number: ${{ github.run_number }}
+      gh_sha: ${{ github.sha }}
+
+  build-image:
+    name: Build image
+    runs-on: ubuntu-latest
+    if: >-
+      ( !cancelled()
+      && ((github.event_name == 'pull_request_target'
+            && github.event.action == 'labeled'
+            && github.event.label.name == 'safe-to-test'
+            && github.event.pull_request.head.repo.full_name != github.repository)
+          ||
+          (github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository)))
+    outputs:
+      IMG: ${{ steps.build-img.outputs.IMG }}
+    steps:
+      - name:  Decide which ref to checkout
         id: decide-ref
         run: |
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
@@ -129,57 +218,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Authenticate to GCP
-        uses: "google-github-actions/auth@v1.0.0"
-        with:
-          credentials_json: ${{ secrets.GKE_SA_KEY }}
-
-      - name: Create GKE cluster
-        id: set-cluster-name
-        run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
-          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
-          gcloud container clusters create ${CLUSTER_NAME} \
-            --zone=${{ env.GKE_ZONE }} \
-            --project=${{ env.GCP_PROJECT_ID }} \
-            --network=${{ env.GCP_NETWORK }} \
-            --machine-type=n1-standard-2 \
-            --num-nodes=3
-          sleep 30
-
-  new-relic-setup:
-    needs: [ create-gke-cluster ]
-    uses: ./.github/workflows/newrelic-gke.yaml
-    secrets: inherit
-    with:
-      cluster_name: ${{ needs.create-gke-cluster.outputs.CLUSTER_NAME }}
-      nr_cluster_name: gke-operator-pull
-      gh_run_id: ${{ github.run_id }}
-      gh_run_number: ${{ github.run_number }}
-      gh_sha: ${{ github.sha }}
-
-  get-image:
-    name: Get Image
-    runs-on: ubuntu-latest
-    outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Build and push image to ttl.sh
         id: build-img
         run: |
-            IMG=ttl.sh/$(uuidgen):2h
-            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
+          IMG=ttl.sh/$(uuidgen):2h
+          echo "IMG=${IMG}" >> $GITHUB_OUTPUT
 
-            make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-            make docker-push IMG=$IMG
+          make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
+          make docker-push IMG=$IMG
 
   gke-e2e-tests:
     name: Run E2E tests
     runs-on: ubuntu-latest
-    needs: [create-gke-cluster, get-image, new-relic-setup]
+    needs: [create-gke-cluster, build-image, new-relic-setup]
     if: (!cancelled() && needs.create-gke-cluster.result == 'success')
     strategy:
       fail-fast: false
@@ -189,7 +240,7 @@ jobs:
       NAMESPACE: test-operator-${{ matrix.edition }}
       CLUSTER_NAME: ${{ needs.create-gke-cluster.outputs.CLUSTER_NAME }}
       NAME_PREFIX: hp-${{ matrix.edition }}-${{ github.run_id }}-
-      IMG: ${{ needs.get-image.outputs.IMG }}
+      IMG: ${{ needs.build-image.outputs.IMG }}
     steps:
       - name: Decide which ref to checkout
         id: decide-ref
@@ -204,6 +255,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{steps.decide-ref.outputs.ref}}
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.0'
 
       - name: Cache Golang dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The old method which is restarting failed nodes doesn't work. The current method checks if the machine set has replicas, if not it will be scaled to 0 and then scale up again to 1. Afterward, it's checked if all machines (**not machine set**) are in ready status. 

## User Impact

OCP nightly tests will be more stable and shouldn't fail if some of the nodes is not ready. 
