### PR TITLE
Fix API doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,4 +390,4 @@ bundle-ocp-validate: ocp-olm-catalog-validator
 
 api-ref-doc: 
 	@go build -o bin/docgen  ./apidocgen/main.go 
-	@./bin/docgen ./api/v1alpha1/*_types.go
+	@./bin/docgen ./api/v1alpha1/*.go


### PR DESCRIPTION
## Description
Fix the generation of the API doc for the nested inline data structs.
Instead of generating the docs file by file, the changes tend to generate it for the entire package making the data structs located in a different file accessible
## User Impact
The API ref doc will be generated correctly
