### PR TITLE
ci: Remove 'test/*' path from release drafter labeling config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-<!--- Provide a general summary of your changes in the Title above -->
-
 ## Description
 
 <!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -54,9 +54,6 @@ autolabeler:
   - label: 'ci'
     files:
       - '.github/workflows/*'
-  - label: 'test'
-    files:
-      - 'test/*'
   - label: 'documentation'
     files:
       - '*.md'


### PR DESCRIPTION
## Description
Currently, when new features develop, we almost always add new tests. Release drafter automatically sets the tag “tests” to the 'feature' PR.

## User Impact

Now, if the developer adds a new test and feature at the same time, such PR won't mark it as a "test" automatically.  