### PR TITLE
[CN-561] Add security context to all containers for hostPath permissions

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1625,11 +1625,13 @@ func labels(h *hazelcastv1alpha1.Hazelcast) map[string]string {
 }
 
 func statefulSetAnnotations(h *hazelcastv1alpha1.Hazelcast) map[string]string {
-	var ans map[string]string
-	if h.Spec.ExposeExternally.IsSmart() {
-		ans[n.ServicePerPodCountAnnotation] = strconv.Itoa(int(*h.Spec.ClusterSize))
+	if !h.Spec.ExposeExternally.IsSmart() {
+		return nil
 	}
-	return ans
+
+	return map[string]string{
+		n.ServicePerPodCountAnnotation: strconv.Itoa(int(*h.Spec.ClusterSize)),
+	}
 }
 
 func podAnnotations(annotations map[string]string, h *hazelcastv1alpha1.Hazelcast) (map[string]string, error) {

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -12,6 +12,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
@@ -237,18 +238,18 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 							FailureThreshold:    10,
 						},
 						SecurityContext: &v1.SecurityContext{
-							RunAsNonRoot:             &[]bool{true}[0],
-							RunAsUser:                &[]int64{65534}[0],
-							Privileged:               &[]bool{false}[0],
-							ReadOnlyRootFilesystem:   &[]bool{false}[0],
-							AllowPrivilegeEscalation: &[]bool{false}[0],
+							RunAsNonRoot:             pointer.Bool(true),
+							RunAsUser:                pointer.Int64(65534),
+							Privileged:               pointer.Bool(false),
+							ReadOnlyRootFilesystem:   pointer.Bool(false),
+							AllowPrivilegeEscalation: pointer.Bool(false),
 							Capabilities: &v1.Capabilities{
 								Drop: []v1.Capability{"ALL"},
 							},
 						},
 					}},
 					SecurityContext: &v1.PodSecurityContext{
-						FSGroup: &[]int64{65534}[0],
+						FSGroup: pointer.Int64(65534),
 					},
 				},
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

PR also contains addition of some field default values into containers because they triggered an update to statefulset every time the reconciler got triggered due to fields being overridden by the operator.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
