### PR TITLE
ci: add ocp restart mechanism

### DIFF
--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -144,7 +144,7 @@ jobs:
 
   report-generation:
     needs: ["create-gke-cluster","gke-e2e-backup-tests"]
-    if: always() && needs.gke-e2e-backup-tests.result != 'cancelled'
+    if: always() && ( needs.gke-e2e-backup-tests.result == 'success' || needs.gke-e2e-backup-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-e2e-aks.yaml
+++ b/.github/workflows/nightly-e2e-aks.yaml
@@ -183,7 +183,7 @@ jobs:
 
   report-generation:
     needs: ["prepare-env", "aks-e2e-tests"]
-    if: always() && needs.aks-e2e-tests.result != 'cancelled'
+    if: always() && (needs.aks-e2e-tests.result == 'success' || needs.aks-e2e-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -205,7 +205,7 @@ jobs:
 
   report-generation:
     needs: ["prepare-env", "eks-e2e-tests"]
-    if: always() && needs.eks-e2e-tests.result != 'cancelled'
+    if: always() && (needs.eks-e2e-tests.result == 'success' || needs.eks-e2e-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -165,7 +165,7 @@ jobs:
 
   report-generation:
     needs: ["gke-e2e-tests","create-gke-cluster"]
-    if: always() && needs.gke-e2e-tests.result != 'cancelled'
+    if: always() && (needs.gke-e2e-tests.result == 'success' || needs.gke-e2e-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-e2e-kind.yaml
+++ b/.github/workflows/nightly-e2e-kind.yaml
@@ -164,7 +164,7 @@ jobs:
 
   report-generation:
     needs: ["kind-e2e-tests"]
-    if: always() && needs.kind-e2e-tests.result != 'cancelled'
+    if: always() && (needs.kind-e2e-tests.result == 'success' || needs.kind-e2e-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-e2e-ocp.yaml
+++ b/.github/workflows/nightly-e2e-ocp.yaml
@@ -6,18 +6,43 @@ on:
 
 env:
   NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  AWS_REGION: us-east-1
   RESTART_OCP_NODE_TIMEOUT: 15
   OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
   OCP_USERNAME: ${{ secrets.OCP_USERNAME }}
   OCP_PASSWORD: ${{ secrets.OCP_PASSWORD }}
 
 jobs:
+  check-and-restart-nodes:
+    name: Check OCP nodes state
+    env:
+      NR_CLUSTER_NAME: ocp-operator
+      CLUSTER_NAME: api-demo-ocp4-hazelcast-com
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Restart Non-Ready Instances
+        run: |
+          source .github/scripts/utils.sh
+          oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
+          wait_for_instance_restarted $RESTART_OCP_NODE_TIMEOUT
+
   new-relic-setup:
     name: Setup New Relic agent
     env:
       NR_CLUSTER_NAME: ocp-operator
       CLUSTER_NAME: api-demo-ocp4-hazelcast-com
     runs-on: ubuntu-latest
+    needs: check-and-restart-nodes
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -91,11 +116,9 @@ jobs:
           make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
           make docker-push IMG=$IMG
 
-      - name: Restart Non-Ready Nodes
-        run: |
-          source .github/scripts/utils.sh
-          oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
-          wait_for_node_restarted $RESTART_OCP_NODE_TIMEOUT
+      - name: Update kubeconfig
+        run: |-
+            oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
 
       - name: Deploy Hazelcast-Platform-Operator to OCP
         run: |
@@ -165,7 +188,7 @@ jobs:
 
   report-generation:
     needs: ocp-e2e-tests
-    if: always() && needs.ocp-e2e-tests.result != 'cancelled'
+    if: always() && (needs.ocp-e2e-tests.result == 'success' || needs.ocp-e2e-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -148,7 +148,7 @@ jobs:
 
   report-generation:
     needs: ["create-gke-cluster", "gke-ph-tests"]
-    if: always() && needs.gke-ph-tests.result != 'cancelled'
+    if: always() && (needs.gke-ph-tests.result == 'success' || needs.gke-ph-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -191,7 +191,7 @@ jobs:
 
   report-generation:
     needs: ["create-gke-cluster", "wan-gke-tests"]
-    if: always() && needs.wan-gke-tests.result != 'cancelled'
+    if: always() && (needs.wan-gke-tests.result == 'success' || needs.wan-gke-tests.result == 'failure')
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
## Description
The old method which is restarting failed nodes doesn't work. The current method checks provider "instanceState" for all machines. If it's not 'running' then the EC2 instance will be **stopped** -> then wait until it returns stopped for all elements. It will poll every 15 seconds until a successful state has been reached. This will exit with a return code of 255 after 40 failed checks -> Afterward, it **start** the instance and waits until a successful state has been reached.

## User Impact
OCP nightly tests will be more stable and shouldn't fail if some of the nodes are not ready.
