### PR TITLE
[CN-636] add go-version 1.19 to deploy operator step

### DIFF
--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -101,6 +101,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
       - name: Authenticate To ${{ matrix.cluster }} GCP Cluster
         uses: 'google-github-actions/auth@v1.0.0'
         with:


### PR DESCRIPTION
## Description

Added go-version 1.19 setup to Operator Deploy step. Before this update, Nightly WAN tests failed.

## User Impact

WAN replication tests become stable