### PR TITLE
[CN-633] ci/fix metallb installation on KinD

### DIFF
--- a/.github/workflows/nightly-e2e-kind.yaml
+++ b/.github/workflows/nightly-e2e-kind.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   kind-e2e-tests:
     name: Run E2E tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -67,34 +67,39 @@ jobs:
             newrelic/nri-bundle
 
       - name: Install metallb
-        run: |
-          kubectl create namespace ${NAMESPACE}
-          kubectl config set-context --current --namespace=$NAMESPACE
-          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml
-          kubectl wait --for=condition=ready --timeout=60s -n metallb-system pod -l app=metallb
-          HOST_MIN=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.200/p')
-          HOST_MAX=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.250/p')
-          IP_RANGE=$HOST_MIN-$HOST_MAX
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+              kubectl create namespace ${NAMESPACE}
+              kubectl config set-context --current --namespace=$NAMESPACE
+              kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
+              kubectl wait --for=condition=ready --timeout=60s -n metallb-system pod -l app=metallb
+              HOST_MIN=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.200/p')
+              HOST_MAX=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.250/p')
+              IP_RANGE=$HOST_MIN-$HOST_MAX
 
-          cat <<EOF | kubectl apply -f -
-          apiVersion: metallb.io/v1beta1
-          kind: IPAddressPool
-          metadata:
-            name: kind-pool
-            namespace: metallb-system
-          spec:
-            addresses:
-            - $IP_RANGE
-          ---
-          apiVersion: metallb.io/v1beta1
-          kind: L2Advertisement
-          metadata:
-            name: l2
-            namespace: metallb-system
-          spec:
-            ipAddressPools:
-            - kind-pool
-          EOF
+              cat <<EOF | kubectl apply -f -
+              apiVersion: metallb.io/v1beta1
+              kind: IPAddressPool
+              metadata:
+                name: kind-pool
+                namespace: metallb-system
+              spec:
+                addresses:
+                - $IP_RANGE
+              ---
+              apiVersion: metallb.io/v1beta1
+              kind: L2Advertisement
+              metadata:
+                name: l2
+                namespace: metallb-system
+              spec:
+                ipAddressPools:
+                - kind-pool
+              EOF
 
       - name: Create Secrets
         if: matrix.edition == 'ee'

--- a/.github/workflows/nightly-e2e-kind.yaml
+++ b/.github/workflows/nightly-e2e-kind.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Install metallb
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 10
+          timeout_minutes: 5
           max_attempts: 3
           retry_on: error
           command: |


### PR DESCRIPTION
## Description

From time to time metallb installation failed, and it causes the Nightly KinD test suite to fail. The solution is: to use VM Ubuntu-22.04, update metallb version to v0.13.7, and added a retry installation step in case of step failed (3 attempts with a 5-minute timeout for the whole setup operation). 
## User Impact

KinD nightly tests become stable.