### PR TITLE
[CN-611] Add "release/" branch trigger for PR builder

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
     paths-ignore:
       - "**.md"
 


### PR DESCRIPTION
## Description
Added the possibility to run PR builder when something is going to be merged to the **"release/**"** branch.

## User Impact
PR builder job will be run not only against the "main" branch