### PR TITLE
[CN-637] fixing expose externally tests on EKS

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -723,24 +723,17 @@ func getQueueConfigFromMemberConfig(memberConfigXML string, queueName string) *c
 	return nil
 }
 
-func DnsLookup(ctx context.Context, host string) (string, error) {
-	r := &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{
-				Timeout: 10 * Second,
-			}
-			return d.DialContext(ctx, network, address)
-		},
-	}
-	IPs, err := r.LookupHost(ctx, host)
+func DnsLookupAddressMatched(ctx context.Context, host, addr string) (bool, error) {
+	IPs, err := net.DefaultResolver.LookupHost(ctx, host)
 	if err != nil {
-		return "", err
+		return false, err
 	}
-	if len(IPs) == 0 {
-		return "", fmt.Errorf("host '%s' cannot be resolved", host)
+	for _, IP := range IPs {
+		if IP == addr {
+			return true, nil
+		}
 	}
-	return IPs[0], nil
+	return false, nil
 }
 
 func getCacheConfigFromMemberConfig(memberConfigXML string, cacheName string) *codecTypes.CacheConfigInput {


### PR DESCRIPTION
## Description

It fixes the failing expose externally tests on EKS.

Fixed tests:

- `[It] should create Hazelcast cluster exposed with LoadBalancer services and allow connecting with Hazelcast smart client` 

The reason why this test gets failed is that the hostname of the service created by EKS has more than one public IP addresses.

## User Impact