### PR TITLE
[CN-634] Add client recreation logic for times client cannot access the cluster

### DIFF
--- a/controllers/hazelcast/fakes_test.go
+++ b/controllers/hazelcast/fakes_test.go
@@ -68,10 +68,11 @@ func (cr *fakeHzClientRegistry) Get(ns types.NamespacedName) (hzclient.Client, b
 	return nil, false
 }
 
-func (cr *fakeHzClientRegistry) Delete(ctx context.Context, ns types.NamespacedName) {
+func (cr *fakeHzClientRegistry) Delete(ctx context.Context, ns types.NamespacedName) error {
 	if c, ok := cr.Clients.LoadAndDelete(ns); ok {
-		c.(hzclient.Client).Shutdown(ctx) //nolint:errcheck
+		return c.(hzclient.Client).Shutdown(ctx) //nolint:errcheck
 	}
+	return nil
 }
 
 type fakeHzClient struct {

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -97,7 +97,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			return r.update(ctx, h, terminatingPhase(err).withMessage(err.Error()))
 		}
-		logger.V(2).Info("Finalizer's pre-delete function executed successfully and the finalizer removed from custom resource", "Name:", n.Finalizer)
+		logger.V(util.DebugLevel).Info("Finalizer's pre-delete function executed successfully and the finalizer removed from custom resource", "Name:", n.Finalizer)
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -57,7 +57,10 @@ func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcast
 	}
 	lk := types.NamespacedName{Name: h.Name, Namespace: h.Namespace}
 	r.statusServiceRegistry.Delete(lk)
-	r.clientRegistry.Delete(ctx, lk)
+
+	if err := r.clientRegistry.Delete(ctx, lk); err != nil {
+		return fmt.Errorf("Hazelcast client could not be deleted:  %w", err)
+	}
 
 	controllerutil.RemoveFinalizer(h, n.Finalizer)
 	err := r.Update(ctx, h)

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -77,7 +77,7 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if err != nil {
 			return updateMapStatus(ctx, r.Client, m, terminatingStatus(err).withMessage(err.Error()))
 		}
-		logger.V(2).Info("Finalizer's pre-delete function executed successfully and the finalizer removed from custom resource", "Name:", n.Finalizer)
+		logger.V(util.DebugLevel).Info("Finalizer's pre-delete function executed successfully and the finalizer removed from custom resource", "Name:", n.Finalizer)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/hazelcast-client/client_registry.go
+++ b/internal/hazelcast-client/client_registry.go
@@ -11,7 +11,7 @@ import (
 type ClientRegistry interface {
 	Create(ctx context.Context, h *hazelcastv1alpha1.Hazelcast) (Client, error)
 	Get(ns types.NamespacedName) (Client, bool)
-	Delete(ctx context.Context, ns types.NamespacedName)
+	Delete(ctx context.Context, ns types.NamespacedName) error
 }
 
 type HazelcastClientRegistry struct {
@@ -39,8 +39,9 @@ func (cr *HazelcastClientRegistry) Get(ns types.NamespacedName) (Client, bool) {
 	return nil, false
 }
 
-func (cr *HazelcastClientRegistry) Delete(ctx context.Context, ns types.NamespacedName) {
+func (cr *HazelcastClientRegistry) Delete(ctx context.Context, ns types.NamespacedName) error {
 	if c, ok := cr.clients.LoadAndDelete(ns); ok {
-		c.(Client).Shutdown(ctx) //nolint:errcheck
+		return c.(Client).Shutdown(ctx) //nolint:errcheck
 	}
+	return nil
 }

--- a/internal/hazelcast-client/status_service.go
+++ b/internal/hazelcast-client/status_service.go
@@ -16,6 +16,7 @@ import (
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/protocol/codec"
 	codecTypes "github.com/hazelcast/hazelcast-platform-operator/internal/protocol/types"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/util"
 )
 
 type StatusService interface {
@@ -139,11 +140,12 @@ func (ss *HzStatusService) UpdateMembers(ctx context.Context) {
 	newClusterHotRestartStatus := &codecTypes.ClusterHotRestartStatus{}
 
 	for _, memberInfo := range activeMemberList {
-		activeMembers[memberInfo.UUID] = newMemberData(memberInfo)
 		state, err := fetchTimedMemberState(ctx, ss.client, memberInfo.UUID)
 		if err != nil {
-			ss.log.V(2).Info("Error fetching timed member state", "CR", ss.namespacedName, "error:", err)
+			ss.log.V(util.DebugLevel).Info("Error fetching timed member state", "CR", ss.namespacedName, "error:", err)
+			continue
 		}
+		activeMembers[memberInfo.UUID] = newMemberData(memberInfo)
 		activeMembers[memberInfo.UUID].enrichMemberData(state.TimedMemberState)
 		newClusterHotRestartStatus = &state.TimedMemberState.MemberState.ClusterHotRestartStatus
 	}

--- a/internal/hazelcast-client/status_service.go
+++ b/internal/hazelcast-client/status_service.go
@@ -133,7 +133,7 @@ func (ss *HzStatusService) UpdateMembers(ctx context.Context) {
 	if ss.client == nil {
 		return
 	}
-	ss.log.V(2).Info("Updating Hazelcast status", "CR", ss.namespacedName)
+	ss.log.V(util.DebugLevel).Info("Updating Hazelcast status", "CR", ss.namespacedName)
 
 	activeMemberList := ss.client.OrderedMembers()
 	activeMembers := make(map[hztypes.UUID]*MemberData, len(activeMemberList))


### PR DESCRIPTION
## Description

Changes:
- Added client recreation logic for times client cannot access the cluster
- Fixed the nil pointer bug in UpdateMembers function 

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->

Operator will restart the Hazelcast client when the cluster is inaccessible. 