### PR TITLE
Fix WAN replication and PH workflows

### DIFF
--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Create GKE cluster
         id: set-cluster-name
         run: |-
-          CLUSTER_NAME="operator-e2e-backup-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-backup-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \

--- a/.github/workflows/generate-test-report.yaml
+++ b/.github/workflows/generate-test-report.yaml
@@ -76,11 +76,11 @@ jobs:
 
       - name: Update Permission
         run: |
-          sudo chown -R $USER:$USER allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}
+          sudo chown -R $USER:$USER allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}
 
       - name: Update Test Files
         run: |-
-          cd allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}/data/test-cases
+          cd allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}/data/test-cases
           BEGIN_TIME=$(date +%s000 -d "- 3 hours")
           END_TIME=$(date +%s000 -d "+ 1 hours")
           for i in $(ls); do
@@ -132,19 +132,19 @@ jobs:
 
       - name: Update environment.properties
         run: |-
-          cd allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}/widgets
+          cd allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}/widgets
           cat <<< $(jq -e 'del(.[] | select(has("name") and (.name | select(contains("URL")))))' environment.json) > environment.json
 
       - name: Update Summary Report
         run: |-
-          cd allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}/widgets
+          cd allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}/widgets
           cat <<< $(jq -e '.reportName="${{ github.workflow }}"' summary.json) > summary.json
 
       - name: Update Hazelcast Logo
         run: |-
-          sed -i "s/>Allure</></g" allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}/app.js
-          sed -i "s/Allure Report/Hazelcast Operator Test Report/g" allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}/index.html
-          mv -f test-report-pages/styles.css allure-history/${{ inputs.WORKFLOW_ID }}/${GITHUB_RUN_NUMBER}
+          sed -i "s/>Allure</></g" allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}/app.js
+          sed -i "s/Allure Report/Hazelcast Operator Test Report/g" allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}/index.html
+          mv -f test-report-pages/styles.css allure-history/${{ inputs.WORKFLOW_ID }}/${{ github.run_number }}
 
       - name: Update The 'test-report-pages' Branch
         run: |
@@ -164,7 +164,7 @@ jobs:
         if: always()
         run: |
           source .github/scripts/utils.sh
-          cleanup_page_publish_runs ${GITHUB_REPOSITORY} "pages-build-deployment" ${GITHUB_RUN_NUMBER} $CLEANUP_TIMEOUT
+          cleanup_page_publish_runs ${GITHUB_REPOSITORY} "pages-build-deployment" ${{ github.run_number }} $CLEANUP_TIMEOUT
 
       - name: Delete Test Artifact
         uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/nightly-e2e-aks.yaml
+++ b/.github/workflows/nightly-e2e-aks.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           azcliversion: 2.31.0
           inlineScript: |
-            CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+            CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
             echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
             az aks create --resource-group ${AZURE_RESOURCE_GROUP} --name "${CLUSTER_NAME}" \
               --node-count 3 --generate-ssh-keys
@@ -127,7 +127,7 @@ jobs:
 
       - name: Update kubeconfig
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           az aks get-credentials --resource-group "${AZURE_RESOURCE_GROUP}" --name "${CLUSTER_NAME}"
 
       - name: Deploy Operator to EKS
@@ -205,7 +205,7 @@ jobs:
         with:
           azcliversion: 2.31.0
           inlineScript: |
-            CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+            CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
             az aks delete --name "${CLUSTER_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" -y
 
   slack_notify:

--- a/.github/workflows/nightly-e2e-eks.yaml
+++ b/.github/workflows/nightly-e2e-eks.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Create EKS cluster
         id: create-cluster
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           eksctl create cluster --name "${CLUSTER_NAME}" \
             --zones ${AWS_REGION}a \
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install New Relic agent
         run: |
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           kubectl create namespace newrelic
           helm install --namespace=newrelic newrelic-bundle -f .github/newrelic/newrelic-values.yaml \
             --set "global.cluster=aws-operator" \
@@ -148,7 +148,7 @@ jobs:
 
       - name: Update kubeconfig
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           aws eks update-kubeconfig --name "${CLUSTER_NAME}"
 
       - name: Deploy Operator to EKS
@@ -233,7 +233,7 @@ jobs:
 
       - name: Delete EKS cluster
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           eksctl delete addon --name aws-ebs-csi-driver --cluster "${CLUSTER_NAME}"
           eksctl delete nodegroup --cluster "${CLUSTER_NAME}" --name node-group-1
           eksctl delete cluster "${CLUSTER_NAME}" --wait

--- a/.github/workflows/nightly-e2e-gke.yaml
+++ b/.github/workflows/nightly-e2e-gke.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Create GKE cluster
         id: set-cluster-name
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Create GKE cluster
         id: set-cluster-name
         run: |-
-          CLUSTER_NAME="operator-ph-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-ph-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \
@@ -107,10 +107,11 @@ jobs:
           credentials_json: ${{ secrets.GKE_SA_KEY }}
 
       - name: Connect to the GKE cluster
-        run: |
-          gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} \
-            --zone ${{ env.GKE_ZONE }} \
-            --project ${{ env.GCP_PROJECT_ID }}
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ env.CLUSTER_NAME }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          location: ${{ env.GKE_ZONE }}
 
       - name: Deploy Operator to GKE
         run: |

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -175,14 +175,14 @@ jobs:
       - name: Connect To The Second GKE Cluster
         uses: 'google-github-actions/get-gke-credentials@v1'
         with:
-          cluster_name: $SECOND_CLUSTER_NAME
+          cluster_name: trg-wan-cluster-${{ github.run_number }}
           project_id: ${{ env.GCP_PROJECT_ID }}
           location: ${{ env.GKE_ZONE }}
 
       - name: Connect To The First GKE Cluster
         uses: 'google-github-actions/get-gke-credentials@v1'
         with:
-          cluster_name: $FIRST_CLUSTER_NAME
+          cluster_name: src-wan-cluster-${{ github.run_number }}
           project_id: ${{ env.GCP_PROJECT_ID }}
           location: ${{ env.GKE_ZONE }}
 

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   get-image:
     name: Get Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       IMG: ${{ steps.build-img.outputs.IMG }}
     steps:
@@ -36,7 +36,7 @@ jobs:
 
   create-gke-cluster:
     name: Create GKE Cluster
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -52,6 +52,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
       - name: Authenticate To ${{ matrix.cluster }} GCP Cluster
         uses: 'google-github-actions/auth@v1.0.0'
         with:
@@ -60,24 +61,23 @@ jobs:
       - name: Create ${{ matrix.cluster }} GKE Cluster
         id: set-cluster-data
         run: |-
-          gcloud container clusters create ${{ matrix.cluster }}-wan-cluster-${GITHUB_RUN_NUMBER} \
+          gcloud container clusters create ${{ matrix.cluster }}-wan-cluster-${{ github.run_number }} \
             --zone=${{ env.GKE_ZONE }} \
             --project=${{ env.GCP_PROJECT_ID }} \
             --network=${{ env.GCP_NETWORK }} \
             --machine-type=n1-standard-16 \
             --num-nodes=${{ env.NUMBER_OF_NODES }}
-          sleep 10
+          sleep 20
 
   new-relic-setup:
-    needs: [ create-gke-cluster ]
+    needs: create-gke-cluster
     uses: ./.github/workflows/newrelic-gke.yaml
     secrets: inherit
     strategy:
-      fail-fast: true
       matrix:
         cluster: ["src", "trg"]
     with:
-      cluster_name: ${{ matrix.cluster }}-wan-cluster-${GITHUB_RUN_NUMBER}
+      cluster_name: ${{ matrix.cluster }}-wan-cluster-${{ github.run_number }}
       nr_cluster_name: wan-operator
       gh_run_id: ${{ github.run_id }}
       gh_run_number: ${{ github.run_number }}
@@ -86,7 +86,7 @@ jobs:
   deploy-operator:
     name: Deploy Hazelcast Operator
     needs: [create-gke-cluster, new-relic-setup, get-image]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -113,7 +113,7 @@ jobs:
       - name: Connect To The ${{ matrix.cluster }} GKE Cluster
         uses: 'google-github-actions/get-gke-credentials@v1'
         with:
-          cluster_name: ${{ matrix.cluster }}-wan-cluster-${GITHUB_RUN_NUMBER}
+          cluster_name: ${{ matrix.cluster }}-wan-cluster-${{ github.run_number }}
           project_id: ${{ env.GCP_PROJECT_ID }}
           location: ${{ env.GKE_ZONE }}
 
@@ -135,7 +135,7 @@ jobs:
 
   wan-gke-tests:
     name: Run Wan Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [deploy-operator]
     steps:
       - name: Checkout
@@ -152,6 +152,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
       - name: Authenticate to GCP
         uses: 'google-github-actions/auth@v1.0.0'
         with:
@@ -159,9 +160,9 @@ jobs:
 
       - name: Set Cluster And Context Name Variables
         run: |
-          FIRST_CLUSTER_NAME="src-wan-cluster-${GITHUB_RUN_NUMBER}"
+          FIRST_CLUSTER_NAME="src-wan-cluster-${{ github.run_number }}"
           echo "FIRST_CLUSTER_NAME=${FIRST_CLUSTER_NAME}" >> $GITHUB_ENV
-          SECOND_CLUSTER_NAME="trg-wan-cluster-${GITHUB_RUN_NUMBER}"
+          SECOND_CLUSTER_NAME="trg-wan-cluster-${{ github.run_number }}"
           echo "SECOND_CLUSTER_NAME=${SECOND_CLUSTER_NAME}" >> $GITHUB_ENV
           FIRST_CONTEXT_NAME="gke_${{ env.GCP_PROJECT_ID }}_${{ env.GKE_ZONE }}_${FIRST_CLUSTER_NAME}"
           echo "FIRST_CONTEXT_NAME=${FIRST_CONTEXT_NAME}" >> $GITHUB_ENV
@@ -172,16 +173,18 @@ jobs:
           echo "targetNamespace="trg-ns"" >> $GITHUB_ENV
 
       - name: Connect To The Second GKE Cluster
-        run: |-
-          gcloud container clusters get-credentials $SECOND_CLUSTER_NAME \
-          --zone ${{ env.GKE_ZONE }} \
-          --project ${{ env.GCP_PROJECT_ID }}
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: $SECOND_CLUSTER_NAME
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          location: ${{ env.GKE_ZONE }}
 
       - name: Connect To The First GKE Cluster
-        run: |-
-          gcloud container clusters get-credentials $FIRST_CLUSTER_NAME \
-          --zone ${{ env.GKE_ZONE }} \
-          --project ${{ env.GCP_PROJECT_ID }}
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: $FIRST_CLUSTER_NAME
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          location: ${{ env.GKE_ZONE }}
 
       - name: Run Wan Test
         run: |-
@@ -206,7 +209,7 @@ jobs:
     name: Cleanup Namespaces
     if: always()
     needs: [create-gke-cluster, wan-gke-tests]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -225,10 +228,11 @@ jobs:
           credentials_json: ${{ secrets.GKE_SA_KEY }}
 
       - name: Connect To ${{ matrix.cluster }} GCP Cluster
-        run: |-
-          gcloud container clusters get-credentials ${{ matrix.cluster }}-wan-cluster-${GITHUB_RUN_NUMBER} \
-          --zone ${{ env.GKE_ZONE }} \
-          --project ${{ env.GCP_PROJECT_ID }}
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ matrix.cluster }}-wan-cluster-${{ github.run_number }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          location: ${{ env.GKE_ZONE }}
 
       - name: Clean up after Tests on ${{ matrix.cluster }} Cluster and ${{ matrix.namespace }} Namespace
         if: always()
@@ -239,7 +243,7 @@ jobs:
     name: Delete GKE Cluster
     if: always()
     needs: [create-gke-cluster, wan-gke-tests, cleanup-namespaces]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -254,14 +258,15 @@ jobs:
           credentials_json: ${{ secrets.GKE_SA_KEY }}
 
       - name: Connect To ${{ matrix.cluster }} GCP Cluster
-        run: |-
-          gcloud container clusters get-credentials ${{ matrix.cluster }}-wan-cluster-${GITHUB_RUN_NUMBER} \
-          --zone ${{ env.GKE_ZONE }} \
-          --project ${{ env.GCP_PROJECT_ID }}
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ matrix.cluster }}-wan-cluster-${{ github.run_number }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          location: ${{ env.GKE_ZONE }}
 
       - name: Delete ${{ matrix.cluster }} GKE Cluster
         if: always()
         run: |-
-          gcloud container clusters delete ${{ matrix.cluster }}-wan-cluster-${GITHUB_RUN_NUMBER} \
+          gcloud container clusters delete ${{ matrix.cluster }}-wan-cluster-${{ github.run_number }} \
            --zone ${{ env.GKE_ZONE }} \
            --quiet

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Create GKE cluster
         id: set-cluster-name
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ docker-build: test docker-build-ci ## Build docker image with the manager.
 
 PARDOT_ID ?= "dockerhub"
 docker-build-ci: ## Build docker image with the manager without running tests.
-	docker build -t ${IMG} --build-arg version=${VERSION} --build-arg pardotID=${PARDOT_ID} .
+	DOCKER_BUILDKIT=1 docker build -t ${IMG} --build-arg version=${VERSION} --build-arg pardotID=${PARDOT_ID} .
 
 ##@ Deployment
 docker-push: ## Push docker image with the manager.
@@ -295,7 +295,7 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	DOCKER_BUILDKIT=1 docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -462,7 +462,7 @@ func assertMapStatus(m *hazelcastcomv1alpha1.Map, st hazelcastcomv1alpha1.MapCon
 				return ""
 			}
 			return checkMap.Status.State
-		}, 20*Second, interval).Should(Equal(st))
+		}, 40*Second, interval).Should(Equal(st))
 	})
 	return checkMap
 }
@@ -553,7 +553,7 @@ func assertHazelcastRestoreStatus(h *hazelcastcomv1alpha1.Hazelcast, st hazelcas
 				return ""
 			}
 			return checkHz.Status.Restore.State
-		}, 20*Second, interval).Should(Equal(st))
+		}, 40*Second, interval).Should(Equal(st))
 	})
 	return checkHz
 }


### PR DESCRIPTION
## Description

- Renamed ${GITHUB_RUN_NUMBER} to {{ github.run_number }}. The old format causes the error in certain workflows `Error: google-github-actions/get-gke-credentials failed with: not found:`
- Replaced method of getting credentials from "gcloud container clusters get-credentials" to "google-github-actions/get-gke-credentials" action
- Added _DOCKER_BUILDKIT=1_ property to the docker build command, which decreased the build time by more than 30%
- Increased timeout for checking map status in function assertMapStatus() that fix flakiness  some of the GKE tests

## User Impact

- WAN replication and PH workflows become more stable
- Build docker image time decreased by 30%
