### PR TITLE
[CN-648] rm h.Spec.Persistence.DataLoadTimeoutSec

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -634,13 +634,11 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 			BackupDir:                 path.Join(h.Spec.Persistence.BaseDir, "hot-backup"),
 			Parallelism:               1,
 			ValidationTimeoutSec:      120,
-			DataLoadTimeoutSec:        900,
 			ClusterDataRecoveryPolicy: clusterDataRecoveryPolicy(h.Spec.Persistence.ClusterDataRecoveryPolicy),
 			AutoRemoveStaleData:       &[]bool{h.Spec.Persistence.AutoRemoveStaleData()}[0],
 		}
 		if h.Spec.Persistence.DataRecoveryTimeout != 0 {
 			cfg.Persistence.ValidationTimeoutSec = h.Spec.Persistence.DataRecoveryTimeout
-			cfg.Persistence.DataLoadTimeoutSec = h.Spec.Persistence.DataRecoveryTimeout
 		}
 	}
 	return cfg

--- a/internal/config/hazelcast.go
+++ b/internal/config/hazelcast.go
@@ -42,7 +42,6 @@ type Persistence struct {
 	BackupDir                 string `yaml:"backup-dir,omitempty"`
 	Parallelism               int32  `yaml:"parallelism"`
 	ValidationTimeoutSec      int32  `yaml:"validation-timeout-seconds"`
-	DataLoadTimeoutSec        int32  `yaml:"data-load-timeout-seconds"`
 	ClusterDataRecoveryPolicy string `yaml:"cluster-data-recovery-policy"`
 	AutoRemoveStaleData       *bool  `yaml:"auto-remove-stale-data"`
 }


### PR DESCRIPTION
## Description

data-load-timeout-seconds is deprecated here [hazelcast/hazelcast-full-example.yaml at master · hazelcast/hazelcast](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/resources/hazelcast-full-example.yaml#L2630)

## User Impact

`hazelcast.Spec.Persistence.DataLoadTimeoutSec` parameter won't be settable anymore.
