### PR TITLE
[CN-647] Add Wan Replication configuration into generated Hazelcast ConfigMap

### DIFF
--- a/api/v1alpha1/data_structure.go
+++ b/api/v1alpha1/data_structure.go
@@ -40,7 +40,7 @@ const (
 	DataStructureFailed  DataStructureConfigState = "Failed"
 	DataStructureSuccess DataStructureConfigState = "Success"
 	DataStructurePending DataStructureConfigState = "Pending"
-	// The config is added into all members but waiting for the config to be persisten into ConfigMap
+	// The config is added into all members but waiting for the config to be persisted into ConfigMap
 	DataStructurePersisting  DataStructureConfigState = "Persisting"
 	DataStructureTerminating DataStructureConfigState = "Terminating"
 )

--- a/api/v1alpha1/wanreplication_types.go
+++ b/api/v1alpha1/wanreplication_types.go
@@ -121,9 +121,11 @@ const (
 type WanStatus string
 
 const (
-	WanStatusFailed      WanStatus = "Failed"
-	WanStatusPending     WanStatus = "Pending"
-	WanStatusSuccess     WanStatus = "Success"
+	WanStatusFailed  WanStatus = "Failed"
+	WanStatusPending WanStatus = "Pending"
+	WanStatusSuccess WanStatus = "Success"
+	// The config is added into all members but waiting for the config to be persisted into ConfigMap
+	WanStatusPersisting  WanStatus = "Persisting"
 	WanStatusTerminating WanStatus = "Terminating"
 )
 

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -3,6 +3,7 @@ package hazelcast
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -354,6 +355,17 @@ func (r *HazelcastReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &hazelcastv1alpha1.Cache{}, "hazelcastResourceName", func(rawObj client.Object) []string {
 		m := rawObj.(*hazelcastv1alpha1.Cache)
 		return []string{m.Spec.HazelcastResourceName}
+	}); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &hazelcastv1alpha1.WanReplication{}, "hazelcastResourceName", func(rawObj client.Object) []string {
+		wr := rawObj.(*hazelcastv1alpha1.WanReplication)
+		hzResources := []string{}
+		for k := range wr.Status.WanReplicationMapsStatus {
+			hzName := strings.Split(k, "_")[0]
+			hzResources = append(hzResources, hzName)
+		}
+		return hzResources
 	}); err != nil {
 		return err
 	}

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -3,7 +3,6 @@ package hazelcast
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -362,7 +361,7 @@ func (r *HazelcastReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		wr := rawObj.(*hazelcastv1alpha1.WanReplication)
 		hzResources := []string{}
 		for k := range wr.Status.WanReplicationMapsStatus {
-			hzName := strings.Split(k, "_")[0]
+			hzName, _ := splitWanMapKey(k)
 			hzResources = append(hzResources, hzName)
 		}
 		return hzResources

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -531,16 +531,19 @@ func hazelcastConfigMapData(ctx context.Context, c client.Client, h *hazelcastv1
 	fillHazelcastConfigWithProperties(&cfg, h)
 	fillHazelcastConfigWithExecutorServices(&cfg, h)
 
-	mapList := &hazelcastv1alpha1.MapList{}
-	if err := c.List(ctx, mapList, client.MatchingFields{"hazelcastResourceName": h.Name}); err != nil {
+	ml, err := filterPersistedMaps(ctx, c, h.Name)
+	if err != nil {
 		return nil, err
 	}
-
-	ml := filterPersistedMaps(mapList.Items)
-
 	if err := fillHazelcastConfigWithMaps(ctx, c, &cfg, h, ml); err != nil {
 		return nil, err
 	}
+
+	wrl, err := filterPersistedWanReplications(ctx, c, h.Name)
+	if err != nil {
+		return nil, err
+	}
+	fillHazelcastConfigWithWanReplications(ctx, c, &cfg, wrl)
 
 	dataStructures := []client.ObjectList{
 		&hazelcastv1alpha1.MultiMapList{},
@@ -618,7 +621,7 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 		cfg.Network.Join.Kubernetes.UseNodeNameAsExternalAddress = pointer.Bool(true)
 	}
 
-	if h.Spec.ExposeExternally.IsEnabled() {
+	if h.Spec.ExposeExternally.IsSmart() {
 		cfg.Network.Join.Kubernetes.ServicePerPodLabelName = n.ServicePerPodLabelName
 		cfg.Network.Join.Kubernetes.ServicePerPodLabelValue = n.LabelValueTrue
 	}
@@ -666,10 +669,15 @@ func filterProperties(p map[string]string) map[string]string {
 	return filteredProperties
 }
 
-func filterPersistedMaps(ml []hazelcastv1alpha1.Map) []hazelcastv1alpha1.Map {
+func filterPersistedMaps(ctx context.Context, c client.Client, hzName string) ([]hazelcastv1alpha1.Map, error) {
+	mapList := &hazelcastv1alpha1.MapList{}
+	if err := c.List(ctx, mapList, client.MatchingFields{"hazelcastResourceName": hzName}); err != nil {
+		return nil, err
+	}
+
 	l := make([]hazelcastv1alpha1.Map, 0)
 
-	for _, mp := range ml {
+	for _, mp := range mapList.Items {
 		switch mp.Status.State {
 		case hazelcastv1alpha1.MapPersisting, hazelcastv1alpha1.MapSuccess:
 			l = append(l, mp)
@@ -686,7 +694,7 @@ func filterPersistedMaps(ml []hazelcastv1alpha1.Map) []hazelcastv1alpha1.Map {
 		default:
 		}
 	}
-	return l
+	return l, nil
 }
 
 func filterPersistedDS(ctx context.Context, c client.Client, hzResourceName string, objList client.ObjectList) ([]client.Object, error) {
@@ -698,6 +706,29 @@ func filterPersistedDS(ctx context.Context, c client.Client, hzResourceName stri
 		if isDSPersisted(obj) {
 			l = append(l, obj)
 		}
+	}
+	return l, nil
+}
+
+func filterPersistedWanReplications(ctx context.Context, c client.Client, hzResourceName string) (map[string]hazelcastv1alpha1.WanReplication, error) {
+	wrList := &hazelcastv1alpha1.WanReplicationList{}
+	if err := c.List(ctx, wrList, client.MatchingFields{"hazelcastResourceName": hzResourceName}); err != nil {
+		return nil, err
+	}
+
+	l := make(map[string]hazelcastv1alpha1.WanReplication, 0)
+	for _, wr := range wrList.Items {
+		for wanKey, mapStatus := range wr.Status.WanReplicationMapsStatus {
+			if s := strings.Split(wanKey, "_"); s[0] != hzResourceName {
+				continue
+			}
+			switch mapStatus.Status {
+			case hazelcastv1alpha1.WanStatusPersisting, hazelcastv1alpha1.WanStatusSuccess:
+				l[wanKey] = wr
+			default: // TODO, might want to do something for the other cases
+			}
+		}
+
 	}
 	return l, nil
 }
@@ -720,6 +751,18 @@ func fillHazelcastConfigWithMaps(ctx context.Context, c client.Client, cfg *conf
 		}
 	}
 	return nil
+}
+
+func fillHazelcastConfigWithWanReplications(ctx context.Context, c client.Client, cfg *config.Hazelcast, wrl map[string]hazelcastv1alpha1.WanReplication) {
+	if len(wrl) != 0 {
+		cfg.WanReplication = map[string]config.WanReplicationConfig{}
+		for wanKey, wan := range wrl {
+			mapName := strings.Split(wanKey, "_")[1]
+			mapStatus := wan.Status.WanReplicationMapsStatus[wanKey]
+			wanConfig := createWanReplicationConfig(mapStatus.PublisherId, wan)
+			cfg.WanReplication[hazelcastWanReplicationName(mapName)] = wanConfig
+		}
+	}
 }
 
 func fillHazelcastConfigWithMultiMaps(cfg *config.Hazelcast, mml []client.Object) {
@@ -996,6 +1039,24 @@ func createReplicatedMapConfig(rm *hazelcastv1alpha1.ReplicatedMap) config.Repli
 			BatchSize: n.DefaultReplicatedMapMergeBatchSize,
 		},
 	}
+}
+
+func createWanReplicationConfig(publisherId string, wr hazelcastv1alpha1.WanReplication) config.WanReplicationConfig {
+	cfg := config.WanReplicationConfig{
+		BatchPublisher: map[string]config.BatchPublisherConfig{
+			publisherId: {
+				ClusterName:           wr.Spec.Endpoints,
+				TargetEndpoints:       wr.Spec.Endpoints,
+				QueueCapacity:         wr.Spec.Queue.Capacity,
+				QueueFullBehavior:     string(wr.Spec.Queue.FullBehavior),
+				BatchSize:             wr.Spec.Batch.Size,
+				BatchMaxDelayMillis:   wr.Spec.Batch.MaximumDelay,
+				ResponseTimeoutMillis: wr.Spec.Acknowledgement.Timeout,
+				AcknowledgementType:   string(wr.Spec.Acknowledgement.Type),
+			},
+		},
+	}
+	return cfg
 }
 
 func (r *HazelcastReconciler) reconcileStatefulset(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -621,7 +621,7 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 		cfg.Network.Join.Kubernetes.UseNodeNameAsExternalAddress = pointer.Bool(true)
 	}
 
-	if h.Spec.ExposeExternally.IsSmart() {
+	if h.Spec.ExposeExternally.IsEnabled() {
 		cfg.Network.Join.Kubernetes.ServicePerPodLabelName = n.ServicePerPodLabelName
 		cfg.Network.Join.Kubernetes.ServicePerPodLabelValue = n.LabelValueTrue
 	}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -719,7 +719,8 @@ func filterPersistedWanReplications(ctx context.Context, c client.Client, hzReso
 	l := make(map[string]hazelcastv1alpha1.WanReplication, 0)
 	for _, wr := range wrList.Items {
 		for wanKey, mapStatus := range wr.Status.WanReplicationMapsStatus {
-			if s := strings.Split(wanKey, "_"); s[0] != hzResourceName {
+			hzName, _ := splitWanMapKey(wanKey)
+			if hzName != hzResourceName {
 				continue
 			}
 			switch mapStatus.Status {
@@ -757,10 +758,10 @@ func fillHazelcastConfigWithWanReplications(ctx context.Context, c client.Client
 	if len(wrl) != 0 {
 		cfg.WanReplication = map[string]config.WanReplicationConfig{}
 		for wanKey, wan := range wrl {
-			mapName := strings.Split(wanKey, "_")[1]
+			_, mapName := splitWanMapKey(wanKey)
 			mapStatus := wan.Status.WanReplicationMapsStatus[wanKey]
 			wanConfig := createWanReplicationConfig(mapStatus.PublisherId, wan)
-			cfg.WanReplication[hazelcastWanReplicationName(mapName)] = wanConfig
+			cfg.WanReplication[wanName(mapName)] = wanConfig
 		}
 	}
 }

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -13,10 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/config"
 	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
-	"github.com/hazelcast/hazelcast-platform-operator/internal/protocol/codec"
 	codecTypes "github.com/hazelcast/hazelcast-platform-operator/internal/protocol/types"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/util"
 )
@@ -48,7 +51,7 @@ func NewWanReplicationReconciler(
 func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.WithValues("name", req.Name, "namespace", req.NamespacedName)
 
-	wan := &hazelcastcomv1alpha1.WanReplication{}
+	wan := &hazelcastv1alpha1.WanReplication{}
 	if err := r.Get(ctx, req.NamespacedName, wan); err != nil {
 		if kerrors.IsNotFound(err) {
 			logger.V(util.DebugLevel).Info("Could not find WanReplication, it is probably already deleted")
@@ -85,7 +88,7 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if !util.IsApplied(wan) {
 		if err := r.Update(ctx, insertLastAppliedSpec(wan)); err != nil {
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		} else {
 			return updateWanStatus(ctx, r.Client, wan, wanPendingStatus())
 		}
@@ -93,7 +96,7 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	HZClientMap, err := r.getMapsGroupByHazelcastName(ctx, wan)
 	if err != nil {
-		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
 	s, createdBefore := wan.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]
@@ -102,7 +105,7 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		if err != nil {
 			err = fmt.Errorf("error marshaling WanReplication as JSON: %w", err)
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		}
 
 		if s == string(ms) {
@@ -110,21 +113,21 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return updateWanStatus(ctx, r.Client, wan, wanSuccessStatus())
 		}
 
-		lastSpec := &hazelcastcomv1alpha1.WanReplicationSpec{}
+		lastSpec := &hazelcastv1alpha1.WanReplicationSpec{}
 		err = json.Unmarshal([]byte(s), lastSpec)
 		if err != nil {
 			err = fmt.Errorf("error unmarshaling Last WanReplication Spec: %w", err)
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		}
 
 		err = validateNotUpdatableFields(&wan.Spec, lastSpec)
 		if err != nil {
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		}
 
 		err = stopWanRepForRemovedResources(ctx, wan, HZClientMap, r.clientRegistry)
 		if err != nil {
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		}
 
 	}
@@ -134,8 +137,18 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	if !isWanSuccessful(wan) {
-		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage("WAN replication is not successfully applied to some maps"))
+	requeue, err := updateWanStatus(ctx, r.Client, wan, wanPersistingStatus(retryAfter).withMessage("Persisting the applied map config."))
+	if err != nil {
+		return requeue, err
+	}
+
+	persisted, err := r.validateWanConfigPersistence(ctx, wan, HZClientMap)
+	if err != nil {
+		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
+	}
+
+	if !persisted {
+		return updateWanStatus(ctx, r.Client, wan, wanPersistingStatus(retryAfter).withMessage("Waiting for Wan Config to be persisted."))
 	}
 
 	if util.IsPhoneHomeEnabled() && !util.IsSuccessfullyApplied(wan) {
@@ -145,13 +158,13 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	err = r.updateLastSuccessfulConfiguration(ctx, wan)
 	if err != nil {
 		logger.Info("Could not save the current successful spec as annotation to the custom resource")
-		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus().withMessage(err.Error()))
+		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
 	return updateWanStatus(ctx, r.Client, wan, wanSuccessStatus())
 }
 
-func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan *hazelcastcomv1alpha1.WanReplication, HZClientMap map[string][]hazelcastcomv1alpha1.Map) error {
+func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, HZClientMap map[string][]hazelcastv1alpha1.Map) error {
 	log := getLogger(ctx)
 
 	mapWanStatus := make(map[string]wanOptionsBuilder)
@@ -167,9 +180,9 @@ func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan 
 			if wan.Status.WanReplicationMapsStatus[mapWanKey].PublisherId == "" {
 				log.Info("Applying WAN configuration for ", "mapKey", mapWanKey)
 				if publisherId, err := r.applyWanReplication(ctx, cl, wan, m.MapName(), mapWanKey); err != nil {
-					mapWanStatus[mapWanKey] = wanFailedStatus().withMessage(err.Error())
+					mapWanStatus[mapWanKey] = wanFailedStatus(err).withMessage(err.Error())
 				} else {
-					mapWanStatus[mapWanKey] = wanSuccessStatus().withPublisherId(publisherId)
+					mapWanStatus[mapWanKey] = wanPersistingStatus(0).withPublisherId(publisherId)
 				}
 
 			}
@@ -182,22 +195,77 @@ func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan 
 	return nil
 }
 
-func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Context, wan *hazelcastcomv1alpha1.WanReplication) (map[string][]hazelcastcomv1alpha1.Map, error) {
-	HZClientMap := make(map[string][]hazelcastcomv1alpha1.Map)
+func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, HZClientMap map[string][]hazelcastv1alpha1.Map) (bool, error) {
+	cmMap := map[string]config.WanReplicationConfig{}
+
+	// Fill map with Wan configs for each map wan key
+	for hz, mp := range HZClientMap {
+		cm := &corev1.ConfigMap{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: hz, Namespace: wan.Namespace}, cm)
+		if err != nil {
+			return false, fmt.Errorf("could not find ConfigMap for wan config persistence")
+		}
+
+		hzConfig := &config.HazelcastWrapper{}
+		err = yaml.Unmarshal([]byte(cm.Data["hazelcast.yaml"]), hzConfig)
+		if err != nil {
+			return false, fmt.Errorf("persisted ConfigMap is not formatted correctly")
+		}
+
+		for _, v := range hzConfig.Hazelcast.WanReplication {
+			cmMap[mapWanReplicationKey(hz, mp[0].MapName())] = v
+		}
+	}
+
+	mapWanStatus := make(map[string]wanOptionsBuilder)
+	for mapWanKey, v := range wan.Status.WanReplicationMapsStatus {
+		// Status is not equal to persisting, do nothing
+		if v.Status != hazelcastv1alpha1.WanStatusPersisting {
+			continue
+		}
+
+		// Wan is not in ConfigMap yet
+		wanRep, ok := cmMap[mapWanKey]
+		if !ok {
+			continue
+		}
+
+		// Wan is in ConfigMap but is not correct
+		realWan := createWanReplicationConfig(v.PublisherId, *wan)
+		if !reflect.DeepEqual(realWan, wanRep) {
+			continue
+		}
+
+		mapWanStatus[mapWanKey] = wanSuccessStatus().withPublisherId(v.PublisherId)
+	}
+
+	if err := putWanMapStatus(ctx, r.Client, wan, mapWanStatus); err != nil {
+		return false, err
+	}
+
+	if wan.Status.Status != hazelcastv1alpha1.WanStatusSuccess {
+		return false, nil
+	}
+
+	return true, nil
+
+}
+
+func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) (map[string][]hazelcastv1alpha1.Map, error) {
+	HZClientMap := make(map[string][]hazelcastv1alpha1.Map)
 	for _, resource := range wan.Spec.Resources {
 		switch resource.Kind {
-		case hazelcastcomv1alpha1.ResourceKindMap:
+		case hazelcastv1alpha1.ResourceKindMap:
 			m, err := r.getWanMap(ctx, types.NamespacedName{Name: resource.Name, Namespace: wan.Namespace}, true)
 			if err != nil {
 				return nil, err
 			}
 			mapList, ok := HZClientMap[m.Spec.HazelcastResourceName]
 			if !ok {
-				HZClientMap[m.Spec.HazelcastResourceName] = []hazelcastcomv1alpha1.Map{*m}
+				HZClientMap[m.Spec.HazelcastResourceName] = []hazelcastv1alpha1.Map{*m}
 			}
 			HZClientMap[m.Spec.HazelcastResourceName] = append(mapList, *m)
-		case hazelcastcomv1alpha1.ResourceKindHZ:
-			fmt.Println(resource.Name)
+		case hazelcastv1alpha1.ResourceKindHZ:
 			maps, err := r.getAllMapsInHazelcast(ctx, resource.Name, wan.Namespace)
 			if err != nil {
 				return nil, err
@@ -212,11 +280,11 @@ func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Conte
 	return HZClientMap, nil
 }
 
-func (r *WanReplicationReconciler) getAllMapsInHazelcast(ctx context.Context, hazelcastResourceName string, wanNamespace string) ([]hazelcastcomv1alpha1.Map, error) {
+func (r *WanReplicationReconciler) getAllMapsInHazelcast(ctx context.Context, hazelcastResourceName string, wanNamespace string) ([]hazelcastv1alpha1.Map, error) {
 	fieldMatcher := client.MatchingFields{"hazelcastResourceName": hazelcastResourceName}
 	nsMatcher := client.InNamespace(wanNamespace)
 
-	wrl := &hazelcastcomv1alpha1.MapList{}
+	wrl := &hazelcastv1alpha1.MapList{}
 
 	if err := r.Client.List(ctx, wrl, fieldMatcher, nsMatcher); err != nil {
 		return nil, fmt.Errorf("could not get Map resources dependent under given Hazelcast %w", err)
@@ -224,7 +292,7 @@ func (r *WanReplicationReconciler) getAllMapsInHazelcast(ctx context.Context, ha
 	return wrl.Items, nil
 }
 
-func validateNotUpdatableFields(current *hazelcastcomv1alpha1.WanReplicationSpec, last *hazelcastcomv1alpha1.WanReplicationSpec) error {
+func validateNotUpdatableFields(current *hazelcastv1alpha1.WanReplicationSpec, last *hazelcastv1alpha1.WanReplicationSpec) error {
 	if current.TargetClusterName != last.TargetClusterName {
 		return fmt.Errorf("targetClusterName cannot be updated")
 	}
@@ -243,8 +311,8 @@ func validateNotUpdatableFields(current *hazelcastcomv1alpha1.WanReplicationSpec
 	return nil
 }
 
-func (r *WanReplicationReconciler) getWanMap(ctx context.Context, lk types.NamespacedName, checkSuccess bool) (*hazelcastcomv1alpha1.Map, error) {
-	m := &hazelcastcomv1alpha1.Map{}
+func (r *WanReplicationReconciler) getWanMap(ctx context.Context, lk types.NamespacedName, checkSuccess bool) (*hazelcastv1alpha1.Map, error) {
+	m := &hazelcastv1alpha1.Map{}
 	if err := r.Client.Get(ctx, lk, m); err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil, err
@@ -252,7 +320,7 @@ func (r *WanReplicationReconciler) getWanMap(ctx context.Context, lk types.Names
 		return nil, fmt.Errorf("failed to get Map CR from WanReplication: %w", err)
 	}
 
-	if checkSuccess && m.Status.State != hazelcastcomv1alpha1.MapSuccess {
+	if checkSuccess && m.Status.State != hazelcastv1alpha1.MapSuccess {
 		return nil, fmt.Errorf("status of map %s is not success", m.Name)
 	}
 
@@ -260,30 +328,29 @@ func (r *WanReplicationReconciler) getWanMap(ctx context.Context, lk types.Names
 
 }
 
-func (r *WanReplicationReconciler) applyWanReplication(ctx context.Context, client hzclient.Client, wan *hazelcastcomv1alpha1.WanReplication, mapName, mapWanKey string) (string, error) {
+func (r *WanReplicationReconciler) applyWanReplication(ctx context.Context, cli hzclient.Client, wan *hazelcastv1alpha1.WanReplication, mapName, mapWanKey string) (string, error) {
 	publisherId := wan.Name + "-" + mapWanKey
 
-	req := &addBatchPublisherRequest{
-		hazelcastWanReplicationName(mapName),
-		wan.Spec.TargetClusterName,
-		publisherId,
-		wan.Spec.Endpoints,
-		wan.Spec.Queue.Capacity,
-		wan.Spec.Batch.Size,
-		wan.Spec.Batch.MaximumDelay,
-		wan.Spec.Acknowledgement.Timeout,
-		convertAckType(wan.Spec.Acknowledgement.Type),
-		convertQueueBehavior(wan.Spec.Queue.FullBehavior),
+	req := &hzclient.AddBatchPublisherRequest{
+		TargetCluster:         wan.Spec.TargetClusterName,
+		Endpoints:             wan.Spec.Endpoints,
+		QueueCapacity:         wan.Spec.Queue.Capacity,
+		BatchSize:             wan.Spec.Batch.Size,
+		BatchMaxDelayMillis:   wan.Spec.Batch.MaximumDelay,
+		ResponseTimeoutMillis: wan.Spec.Acknowledgement.Timeout,
+		AckType:               wan.Spec.Acknowledgement.Type,
+		QueueFullBehavior:     wan.Spec.Queue.FullBehavior,
 	}
 
-	err := addBatchPublisherConfig(ctx, client, req)
+	ws := hzclient.NewWanService(cli, hazelcastWanReplicationName(mapName), publisherId)
+	err := ws.AddBatchPublisherConfig(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to apply WAN configuration: %w", err)
 	}
 	return publisherId, nil
 }
 
-func (r *WanReplicationReconciler) stopWanReplication(ctx context.Context, wan *hazelcastcomv1alpha1.WanReplication) error {
+func (r *WanReplicationReconciler) stopWanReplication(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) error {
 	HZClientMap, err := r.getMapsGroupByHazelcastName(ctx, wan)
 	if err != nil {
 		return err
@@ -306,22 +373,12 @@ func (r *WanReplicationReconciler) stopWanReplication(ctx context.Context, wan *
 				log.V(util.DebugLevel).Info("publisherId is empty, will skip stopping WAN replication", "mapKey", mapWanKey)
 				continue
 			}
-			req := &changeWanStateRequest{
-				name:        hazelcastWanReplicationName(m.MapName()),
-				publisherId: publisherId,
-				state:       codecTypes.WanReplicationStateStopped,
-			}
+			ws := hzclient.NewWanService(cli, hazelcastWanReplicationName(m.MapName()), publisherId)
 
-			if err := changeWanState(ctx, cli, req); err != nil {
+			if err := ws.ChangeWanState(ctx, codecTypes.WanReplicationStateStopped); err != nil {
 				return err
 			}
-
-			qreq := &clearWanQueueRequest{
-				name:        hazelcastWanReplicationName(m.MapName()),
-				publisherId: publisherId,
-			}
-
-			if err := clearWanQueue(ctx, cli, qreq); err != nil {
+			if err := ws.ClearWanQueue(ctx); err != nil {
 				return err
 			}
 			delete(wan.Status.WanReplicationMapsStatus, mapWanKey)
@@ -330,8 +387,8 @@ func (r *WanReplicationReconciler) stopWanReplication(ctx context.Context, wan *
 	return nil
 }
 
-func stopWanRepForRemovedResources(ctx context.Context, wan *hazelcastcomv1alpha1.WanReplication, HZClientMap map[string][]hazelcastcomv1alpha1.Map, cs hzclient.ClientRegistry) error {
-	tempMapSet := make(map[string]hazelcastcomv1alpha1.Map)
+func stopWanRepForRemovedResources(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, HZClientMap map[string][]hazelcastv1alpha1.Map, cs hzclient.ClientRegistry) error {
+	tempMapSet := make(map[string]hazelcastv1alpha1.Map)
 	for hzName, maps := range HZClientMap {
 		for _, m := range maps {
 			tempMapSet[mapWanReplicationKey(hzName, m.MapName())] = m
@@ -343,17 +400,15 @@ func stopWanRepForRemovedResources(ctx context.Context, wan *hazelcastcomv1alpha
 		if ok {
 			continue
 		}
-		req := &changeWanStateRequest{
-			name:        hazelcastWanReplicationName(m.MapName()),
-			publisherId: status.PublisherId,
-			state:       codecTypes.WanReplicationStateStopped,
-		}
-
 		cli, err := GetHazelcastClient(cs, &m)
 		if err != nil {
 			return err
 		}
-		if err = changeWanState(ctx, cli, req); err != nil {
+		ws := hzclient.NewWanService(cli, hazelcastWanReplicationName(m.MapName()), status.PublisherId)
+		if err := ws.ChangeWanState(ctx, codecTypes.WanReplicationStateStopped); err != nil {
+			return err
+		}
+		if err := ws.ClearWanQueue(ctx); err != nil {
 			return err
 		}
 		delete(wan.Status.WanReplicationMapsStatus, mapWanKey)
@@ -369,113 +424,7 @@ func hazelcastWanReplicationName(mapName string) string {
 	return mapName + "-default"
 }
 
-type addBatchPublisherRequest struct {
-	name                  string
-	targetCluster         string
-	publisherId           string
-	endpoints             string
-	queueCapacity         int32
-	batchSize             int32
-	batchMaxDelayMillis   int32
-	responseTimeoutMillis int32
-	ackType               int32
-	queueFullBehavior     int32
-}
-
-func addBatchPublisherConfig(
-	ctx context.Context,
-	client hzclient.Client,
-	request *addBatchPublisherRequest,
-) error {
-
-	req := codec.EncodeMCAddWanBatchPublisherConfigRequest(
-		request.name,
-		request.targetCluster,
-		request.publisherId,
-		request.endpoints,
-		request.queueCapacity,
-		request.batchSize,
-		request.batchMaxDelayMillis,
-		request.responseTimeoutMillis,
-		request.ackType,
-		request.queueFullBehavior,
-	)
-
-	_, err := client.InvokeOnRandomTarget(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-type changeWanStateRequest struct {
-	name        string
-	publisherId string
-	state       codecTypes.WanReplicationState
-}
-
-func changeWanState(ctx context.Context, client hzclient.Client, request *changeWanStateRequest) error {
-	req := codec.EncodeMCChangeWanReplicationStateRequest(
-		request.name,
-		request.publisherId,
-		request.state,
-	)
-
-	for _, member := range client.OrderedMembers() {
-		_, err := client.InvokeOnMember(ctx, req, member.UUID, nil)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type clearWanQueueRequest struct {
-	name        string
-	publisherId string
-}
-
-func clearWanQueue(ctx context.Context, client hzclient.Client, request *clearWanQueueRequest) error {
-	req := codec.EncodeMCClearWanQueuesRequest(
-		request.name,
-		request.publisherId,
-	)
-
-	for _, member := range client.OrderedMembers() {
-		_, err := client.InvokeOnMember(ctx, req, member.UUID, nil)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func convertAckType(ackType hazelcastcomv1alpha1.AcknowledgementType) int32 {
-	switch ackType {
-	case hazelcastcomv1alpha1.AckOnReceipt:
-		return 0
-	case hazelcastcomv1alpha1.AckOnOperationComplete:
-		return 1
-	default:
-		return -1
-	}
-}
-
-func convertQueueBehavior(behavior hazelcastcomv1alpha1.FullBehaviorSetting) int32 {
-	switch behavior {
-	case hazelcastcomv1alpha1.DiscardAfterMutation:
-		return 0
-	case hazelcastcomv1alpha1.ThrowException:
-		return 1
-	case hazelcastcomv1alpha1.ThrowExceptionOnlyIfReplicationActive:
-		return 2
-	default:
-		return -1
-	}
-}
-
-func insertLastAppliedSpec(wan *hazelcastcomv1alpha1.WanReplication) *hazelcastcomv1alpha1.WanReplication {
+func insertLastAppliedSpec(wan *hazelcastv1alpha1.WanReplication) *hazelcastv1alpha1.WanReplication {
 	b, _ := json.Marshal(wan.Spec)
 	if wan.Annotations == nil {
 		wan.Annotations = make(map[string]string)
@@ -484,7 +433,7 @@ func insertLastAppliedSpec(wan *hazelcastcomv1alpha1.WanReplication) *hazelcastc
 	return wan
 }
 
-func (r *WanReplicationReconciler) updateLastSuccessfulConfiguration(ctx context.Context, wan *hazelcastcomv1alpha1.WanReplication) error {
+func (r *WanReplicationReconciler) updateLastSuccessfulConfiguration(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) error {
 	ms, err := json.Marshal(wan.Spec)
 	if err != nil {
 		return err
@@ -494,6 +443,7 @@ func (r *WanReplicationReconciler) updateLastSuccessfulConfiguration(ctx context
 		if wan.ObjectMeta.Annotations == nil {
 			wan.ObjectMeta.Annotations = map[string]string{}
 		}
+
 		wan.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation] = string(ms)
 		return nil
 	})
@@ -514,6 +464,6 @@ func getLogger(ctx context.Context) logr.Logger {
 // SetupWithManager sets up the controller with the Manager.
 func (r *WanReplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&hazelcastcomv1alpha1.WanReplication{}).
+		For(&hazelcastv1alpha1.WanReplication{}).
 		Complete(r)
 }

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -270,6 +270,10 @@ func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Conte
 			if err != nil {
 				return nil, err
 			}
+			// If no map is present for the Hazelcast resource
+			if len(maps) == 0 {
+				continue
+			}
 			mapList, ok := HZClientMap[resource.Name]
 			if !ok {
 				HZClientMap[resource.Name] = maps

--- a/controllers/hazelcast/wanreplication_status.go
+++ b/controllers/hazelcast/wanreplication_status.go
@@ -62,11 +62,7 @@ func wanStatus(statuses map[string]hazelcastv1alpha1.WanReplicationMapStatus) ha
 		return hazelcastv1alpha1.WanStatusSuccess
 	}
 
-	if successOk && persistingOk && len(set) == 2 {
-		return hazelcastv1alpha1.WanStatusPersisting
-	}
-
-	if persistingOk && len(set) == 1 {
+	if persistingOk {
 		return hazelcastv1alpha1.WanStatusPersisting
 	}
 

--- a/controllers/hazelcast/wanreplication_status.go
+++ b/controllers/hazelcast/wanreplication_status.go
@@ -2,6 +2,7 @@ package hazelcast
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -12,13 +13,16 @@ import (
 
 type wanOptionsBuilder struct {
 	publisherId string
+	err         error
 	status      hazelcastv1alpha1.WanStatus
 	message     string
+	retryAfter  time.Duration
 }
 
-func wanFailedStatus() wanOptionsBuilder {
+func wanFailedStatus(err error) wanOptionsBuilder {
 	return wanOptionsBuilder{
 		status: hazelcastv1alpha1.WanStatusFailed,
+		err:    err,
 	}
 }
 
@@ -34,14 +38,57 @@ func wanSuccessStatus() wanOptionsBuilder {
 	}
 }
 
+func wanPersistingStatus(retryAfter time.Duration) wanOptionsBuilder {
+	return wanOptionsBuilder{
+		status:     hazelcastv1alpha1.WanStatusPersisting,
+		retryAfter: retryAfter,
+	}
+}
+
 func wanTerminatingStatus() wanOptionsBuilder {
 	return wanOptionsBuilder{
 		status: hazelcastv1alpha1.WanStatusTerminating,
 	}
 }
 
-func (o wanOptionsBuilder) withPublisherId(id string) wanOptionsBuilder {
-	o.publisherId = id
+func wanStatus(statuses map[string]hazelcastv1alpha1.WanReplicationMapStatus) hazelcastv1alpha1.WanStatus {
+	set := wanStatusSet(statuses, hazelcastv1alpha1.WanStatusSuccess)
+
+	_, successOk := set[hazelcastv1alpha1.WanStatusSuccess]
+	_, failOk := set[hazelcastv1alpha1.WanStatusFailed]
+	_, persistingOk := set[hazelcastv1alpha1.WanStatusPersisting]
+
+	if successOk && len(set) == 1 {
+		return hazelcastv1alpha1.WanStatusSuccess
+	}
+
+	if successOk && persistingOk && len(set) == 2 {
+		return hazelcastv1alpha1.WanStatusPersisting
+	}
+
+	if persistingOk && len(set) == 1 {
+		return hazelcastv1alpha1.WanStatusPersisting
+	}
+
+	if failOk {
+		return hazelcastv1alpha1.WanStatusFailed
+	}
+
+	return hazelcastv1alpha1.WanStatusPending
+
+}
+
+func wanStatusSet(statusMap map[string]hazelcastv1alpha1.WanReplicationMapStatus, checkStatuses ...hazelcastv1alpha1.WanStatus) map[hazelcastv1alpha1.WanStatus]struct{} {
+	statusSet := map[hazelcastv1alpha1.WanStatus]struct{}{}
+
+	for _, v := range statusMap {
+		statusSet[v.Status] = struct{}{}
+	}
+	return statusSet
+}
+
+func (o wanOptionsBuilder) withPublisherId(hz string) wanOptionsBuilder {
+	o.publisherId = hz
 	return o
 }
 
@@ -61,6 +108,12 @@ func updateWanStatus(ctx context.Context, c client.Client, wan *hazelcastv1alpha
 		return ctrl.Result{}, err
 	}
 
+	if options.status == hazelcastv1alpha1.WanStatusFailed {
+		return ctrl.Result{}, options.err
+	}
+	if options.status == hazelcastv1alpha1.WanStatusPending || options.status == hazelcastv1alpha1.WanStatusPersisting {
+		return ctrl.Result{Requeue: true, RequeueAfter: options.retryAfter}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -77,6 +130,8 @@ func putWanMapStatus(ctx context.Context, c client.Client, wan *hazelcastv1alpha
 		}
 	}
 
+	wan.Status.Status = wanStatus(wan.Status.WanReplicationMapsStatus)
+
 	if err := c.Status().Update(ctx, wan); err != nil {
 		if errors.IsConflict(err) {
 			return nil
@@ -85,13 +140,4 @@ func putWanMapStatus(ctx context.Context, c client.Client, wan *hazelcastv1alpha
 	}
 
 	return nil
-}
-
-func isWanSuccessful(wan *hazelcastv1alpha1.WanReplication) bool {
-	for _, mapStatus := range wan.Status.WanReplicationMapsStatus {
-		if mapStatus.Status != hazelcastv1alpha1.WanStatusSuccess {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/config/hazelcast.go
+++ b/internal/config/hazelcast.go
@@ -14,6 +14,7 @@ type Hazelcast struct {
 	DurableExecutorService   map[string]DurableExecutorService   `yaml:"durable-executor-service,omitempty"`
 	ScheduledExecutorService map[string]ScheduledExecutorService `yaml:"scheduled-executor-service,omitempty"`
 	UserCodeDeployment       UserCodeDeployment                  `yaml:"user-code-deployment,omitempty"`
+	WanReplication           map[string]WanReplicationConfig     `yaml:"wan-replication,omitempty"`
 	Properties               map[string]string                   `yaml:"properties,omitempty"`
 	MultiMap                 map[string]MultiMap                 `yaml:"multimap,omitempty"`
 	Topic                    map[string]Topic                    `yaml:"topic,omitempty"`
@@ -212,6 +213,22 @@ type ReplicatedMap struct {
 	AsyncFillup       bool        `yaml:"async-fillup"`
 	StatisticsEnabled bool        `yaml:"statistics-enabled"`
 	MergePolicy       MergePolicy `yaml:"merge-policy"`
+}
+
+type WanReplicationConfig struct {
+	BatchPublisher map[string]BatchPublisherConfig `yaml:"batch-publisher,omitempty"`
+}
+
+type BatchPublisherConfig struct {
+	ClusterName           string `yaml:"cluster-name,omitempty"`
+	BatchSize             int32  `yaml:"batch-size,omitempty"`
+	BatchMaxDelayMillis   int32  `yaml:"batch-max-delay-millis,omitempty"`
+	ResponseTimeoutMillis int32  `yaml:"response-timeout-millis,omitempty"`
+	AcknowledgementType   string `yaml:"acknowledge-type,omitempty"`
+	InitialPublisherState string `yaml:"initial-publisher-state,omitempty"`
+	QueueFullBehavior     string `yaml:"queue-full-behavior,omitempty"`
+	QueueCapacity         int32  `yaml:"queue-capacity,omitempty"`
+	TargetEndpoints       string `yaml:"target-endpoints,omitempty"`
 }
 
 func (hz Hazelcast) HazelcastConfigForcingRestart() Hazelcast {

--- a/internal/hazelcast-client/wan_service.go
+++ b/internal/hazelcast-client/wan_service.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"context"
+
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/protocol/codec"
+	codecTypes "github.com/hazelcast/hazelcast-platform-operator/internal/protocol/types"
+)
+
+type WanService interface {
+	AddBatchPublisherConfig(ctx context.Context, request *AddBatchPublisherRequest) error
+	ChangeWanState(ctx context.Context, state codecTypes.WanReplicationState) error
+	ClearWanQueue(ctx context.Context) error
+}
+
+type AddBatchPublisherRequest struct {
+	TargetCluster         string
+	Endpoints             string
+	QueueCapacity         int32
+	BatchSize             int32
+	BatchMaxDelayMillis   int32
+	ResponseTimeoutMillis int32
+	AckType               hazelcastv1alpha1.AcknowledgementType
+	QueueFullBehavior     hazelcastv1alpha1.FullBehaviorSetting
+}
+
+type HzWanService struct {
+	client      Client
+	name        string
+	publisherId string
+}
+
+func NewWanService(cl Client, name, pubId string) *HzWanService {
+	return &HzWanService{
+		client:      cl,
+		name:        name,
+		publisherId: pubId,
+	}
+}
+
+func (ws *HzWanService) AddBatchPublisherConfig(ctx context.Context, request *AddBatchPublisherRequest) error {
+
+	req := codec.EncodeMCAddWanBatchPublisherConfigRequest(
+		ws.name,
+		request.TargetCluster,
+		ws.publisherId,
+		request.Endpoints,
+		request.QueueCapacity,
+		request.BatchSize,
+		request.BatchMaxDelayMillis,
+		request.ResponseTimeoutMillis,
+		convertAckType(request.AckType),
+		convertQueueBehavior(request.QueueFullBehavior),
+	)
+
+	_, err := ws.client.InvokeOnRandomTarget(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ws *HzWanService) ChangeWanState(ctx context.Context, state codecTypes.WanReplicationState) error {
+	req := codec.EncodeMCChangeWanReplicationStateRequest(
+		ws.name,
+		ws.publisherId,
+		state,
+	)
+
+	for _, member := range ws.client.OrderedMembers() {
+		_, err := ws.client.InvokeOnMember(ctx, req, member.UUID, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ws *HzWanService) ClearWanQueue(ctx context.Context) error {
+	req := codec.EncodeMCClearWanQueuesRequest(
+		ws.name,
+		ws.publisherId,
+	)
+
+	for _, member := range ws.client.OrderedMembers() {
+		_, err := ws.client.InvokeOnMember(ctx, req, member.UUID, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func convertAckType(ackType hazelcastv1alpha1.AcknowledgementType) int32 {
+	switch ackType {
+	case hazelcastv1alpha1.AckOnReceipt:
+		return 0
+	case hazelcastv1alpha1.AckOnOperationComplete:
+		return 1
+	default:
+		return -1
+	}
+}
+
+func convertQueueBehavior(behavior hazelcastv1alpha1.FullBehaviorSetting) int32 {
+	switch behavior {
+	case hazelcastv1alpha1.DiscardAfterMutation:
+		return 0
+	case hazelcastv1alpha1.ThrowException:
+		return 1
+	case hazelcastv1alpha1.ThrowExceptionOnlyIfReplicationActive:
+		return 2
+	default:
+		return -1
+	}
+}

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -2,18 +2,23 @@ package e2e
 
 import (
 	"context"
+	"strconv"
 	. "time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
 	hazelcastconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/hazelcast"
 )
 
 var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
+	localPort := strconv.Itoa(8900 + GinkgoParallelProcess())
+
 	waitForLBAddress := func(name types.NamespacedName) string {
 		By("waiting for load balancer address")
 		hz := &hazelcastcomv1alpha1.Hazelcast{}
@@ -103,5 +108,99 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 
 		By("checking the size of the map in the target cluster")
 		WaitForMapSize(context.Background(), hzTrgLookupKey, m.Name, mapSize, 1*Minute)
+	})
+
+	It("should replicate multiple maps to target cluster ", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		setLabelAndCRName("hw-2")
+		source1LookupKey := types.NamespacedName{Name: hzSrcLookupKey.Name + "1", Namespace: hzSrcLookupKey.Namespace}
+		source2LookupKey := types.NamespacedName{Name: hzSrcLookupKey.Name + "2", Namespace: hzSrcLookupKey.Namespace}
+
+		By("creating first source Hazelcast cluster")
+		source1 := hazelcastconfig.Default(source1LookupKey, ee, labels)
+		source1.Spec.ClusterName = "source1"
+		source1.Spec.ClusterSize = pointer.Int32(1)
+		CreateHazelcastCR(source1)
+
+		By("creating second source Hazelcast cluster")
+		source2 := hazelcastconfig.Default(source2LookupKey, ee, labels)
+		source2.Spec.ClusterName = "source2"
+		source2.Spec.ClusterSize = pointer.Int32(1)
+		CreateHazelcastCR(source2)
+
+		By("creating target Hazelcast cluster")
+		target1 := hazelcastconfig.Default(hzTrgLookupKey, ee, labels)
+		target1.Spec.ClusterName = "target"
+		target1.Spec.ClusterSize = pointer.Int32(1)
+		CreateHazelcastCR(target1)
+
+		evaluateReadyMembers(source1LookupKey)
+		evaluateReadyMembers(source2LookupKey)
+		evaluateReadyMembers(hzTrgLookupKey)
+
+		By("creating first map for first source Hazelcast cluster")
+		source1_map1 := hazelcastconfig.DefaultMap(mapLookupKey, source1.Name, labels)
+		source1_map1.Name = "source1-map1"
+		Expect(k8sClient.Create(context.Background(), source1_map1)).Should(Succeed())
+		_ = assertMapStatus(source1_map1, hazelcastcomv1alpha1.MapSuccess)
+
+		By("creating second map for first source Hazelcast cluster")
+		source1_map2 := hazelcastconfig.DefaultMap(mapLookupKey, source1.Name, labels)
+		source1_map2.Name = "source1-map2"
+		Expect(k8sClient.Create(context.Background(), source1_map2)).Should(Succeed())
+		_ = assertMapStatus(source1_map2, hazelcastcomv1alpha1.MapSuccess)
+
+		By("creating first map for second source Hazelcast cluster")
+		source2_map1 := hazelcastconfig.DefaultMap(mapLookupKey, source2.Name, labels)
+		source2_map1.Name = "source2-map1"
+		Expect(k8sClient.Create(context.Background(), source2_map1)).Should(Succeed())
+		_ = assertMapStatus(source2_map1, hazelcastcomv1alpha1.MapSuccess)
+
+		By("creating first WAN configuration")
+		wan := hazelcastconfig.DefaultWanReplication(
+			wanLookupKey,
+			source1_map1.Name,
+			target1.Spec.ClusterName,
+			hzclient.HazelcastUrl(target1),
+			labels,
+		)
+
+		wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+			{Name: source1_map1.Name},
+			{Name: source2.Name, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+		}
+
+		Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
+		assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+
+		By("creating second WAN configuration")
+		wlk := types.NamespacedName{Namespace: wan.Namespace, Name: "second-wan"}
+		wan2 := hazelcastconfig.DefaultWanReplication(
+			wlk,
+			source1_map1.Name,
+			target1.Spec.ClusterName,
+			hzclient.HazelcastUrl(target1),
+			labels,
+		)
+
+		wan2.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+			{Name: source1_map2.Name},
+		}
+
+		Expect(k8sClient.Create(context.Background(), wan2)).Should(Succeed())
+		assertWanStatus(wan2, hazelcastcomv1alpha1.WanStatusSuccess)
+
+		By("filling the maps in the source clusters")
+		mapSize := 10
+		fillTheMapDataPortForward(context.Background(), source1, localPort, source1_map1.Name, mapSize)
+		fillTheMapDataPortForward(context.Background(), source1, localPort, source1_map2.Name, mapSize)
+		fillTheMapDataPortForward(context.Background(), source2, localPort, source2_map1.Name, mapSize)
+
+		By("checking the size of the maps in the target cluster")
+		waitForMapSizePortForward(context.Background(), target1, localPort, source1_map1.Name, mapSize, 1*Minute)
+		waitForMapSizePortForward(context.Background(), target1, localPort, source1_map2.Name, mapSize, 1*Minute)
+		waitForMapSizePortForward(context.Background(), target1, localPort, source2_map1.Name, mapSize, 1*Minute)
 	})
 })

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -467,6 +467,23 @@ func assertMapStatus(m *hazelcastcomv1alpha1.Map, st hazelcastcomv1alpha1.MapCon
 	return checkMap
 }
 
+func assertWanStatus(wr *hazelcastcomv1alpha1.WanReplication, st hazelcastcomv1alpha1.WanStatus) *hazelcastcomv1alpha1.WanReplication {
+	checkWan := &hazelcastcomv1alpha1.WanReplication{}
+	By("waiting for Wan CR status", func() {
+		Eventually(func() hazelcastcomv1alpha1.WanStatus {
+			err := k8sClient.Get(context.Background(), types.NamespacedName{
+				Name:      wr.Name,
+				Namespace: wr.Namespace,
+			}, checkWan)
+			if err != nil {
+				return ""
+			}
+			return checkWan.Status.Status
+		}, 40*Second, interval).Should(Equal(st))
+	})
+	return checkWan
+}
+
 func getMemberConfig(ctx context.Context, client *hzClient.Client) string {
 	ci := hzClient.NewClientInternal(client)
 	req := codec.EncodeMCGetMemberConfigRequest()


### PR DESCRIPTION
## Description

Changes:
- Added `persisting` state to WanReplication status and implemented ConfigMap persistence logic to WanReplication.
- Created WanService and refactored the controller and status logic.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->

Wan Replication configurations will be stored in Hazelcast ConfigMap. When member containers restart, they will be able to continue replication.  