### PR TITLE
[CN-655] set Hazelcast resource message on non-existing hotbackup

### DIFF
--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -182,7 +182,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if errors.IsConflict(err) {
 			return ctrl.Result{}, nil
 		} else {
-			return r.update(ctx, h, failedPhase(err))
+			return r.update(ctx, h, failedPhase(err).withMessage(err.Error()))
 		}
 	}
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1263,6 +1263,10 @@ func getRestoreContainerFromHotBackupResource(ctx context.Context, cl client.Cli
 		return corev1.Container{}, err
 	}
 
+	if hb.Status.State != hazelcastv1alpha1.HotBackupSuccess {
+		return corev1.Container{}, fmt.Errorf("restore hotbackup '%s' status is not %s", hb.Name, hazelcastv1alpha1.HotBackupSuccess)
+	}
+
 	var cont corev1.Container
 	if hb.Spec.IsExternal() {
 		bucketURI := hb.Status.GetBucketURI()


### PR DESCRIPTION
## Description

When a Hazelcast resource with restore is applied, It set status to Failed without message If given hot-backup resource is not existing. This PR set Hazelcast resource message on non-existing hotbackup.

**Another scenario**

When creating a Hazelcast cluster with restore enabled and referring to a failed hot-backup resource, Hazelcast resource gets stack in pending state and there is no message about it.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
