### PR TITLE
[CN-652]-Add focused tests validator into PR builder

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,7 @@ permissions:
 
 env:
   GO_VERSION: '1.19.0'
+  GOBIN: ${{ github.workspace }}/bin
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -61,6 +62,15 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           config_file: hack/yamllint.yaml
+
+      - name: Check if tests are unfocused
+        if: ${{ !cancelled() }}
+        run: |
+           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+           if [[ $($GOBIN/ginkgo unfocus | wc -l) -gt 1 ]]; then
+             echo "Some tests have 'F' before the test name. Run the 'ginkgo unfocus' command against your branch '${{ github.event.pull_request.head.ref }}' and push the changes."
+             exit 1
+           fi
 
       - name: Check if bundle.yaml is updated
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check if tests are unfocused
         if: ${{ !cancelled() }}
         run: |
-           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+           make ginkgo
            if [[ $($GOBIN/ginkgo unfocus | wc -l) -gt 1 ]]; then
              echo "Some tests have 'F' before the test name. Run the 'ginkgo unfocus' command against your branch '${{ github.event.pull_request.head.ref }}' and push the changes."
              exit 1


### PR DESCRIPTION
## Description

Added focused test validation into PR builder. The PR builder immediately fails if one of the tests has an 'F' leftover.

## User Impact

No more focused tests in the codebase. 