### PR TITLE
[CN-646] Webhook support for OLM

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -115,8 +115,8 @@ resources:
   path: github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
-  validation: true
-  webhookVersion: v1
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/internal/webhookca/ca_generator.go
+++ b/internal/webhookca/ca_generator.go
@@ -1,0 +1,67 @@
+package webhookca
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	core "k8s.io/api/core/v1"
+)
+
+func generateCA(name, namespace string) (map[string][]byte, error) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().Unix()),
+		Subject: pkix.Name{
+			Organization: []string{"Hazelcast"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		DNSNames: []string{
+			fmt.Sprintf("%s.%s.svc", name, namespace),
+			fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
+		},
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, err
+	}
+
+	rawCrt, err := x509.CreateCertificate(rand.Reader, ca, ca, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var crtPEM bytes.Buffer
+	err = pem.Encode(&crtPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: rawCrt,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var keyPEM bytes.Buffer
+	err = pem.Encode(&keyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]byte{
+		core.TLSCertKey:       crtPEM.Bytes(),
+		core.TLSPrivateKeyKey: keyPEM.Bytes(),
+	}, nil
+}

--- a/internal/webhookca/ca_injector.go
+++ b/internal/webhookca/ca_injector.go
@@ -22,7 +22,7 @@ const (
 	webhookServerPath     = "/tmp/k8s-webhook-server/serving-certs"
 )
 
-func maybeInjectWebhook(mgr *manager.Manager, setupLog logr.Logger, namespace, deploymentName string) error {
+func injectWebhook(mgr *manager.Manager, setupLog logr.Logger, namespace, deploymentName string) error {
 	webhookName := types.NamespacedName{
 		Name:      strings.ReplaceAll(deploymentName, "controller-manager", "validating-webhook-configuration"),
 		Namespace: namespace,

--- a/internal/webhookca/injector.go
+++ b/internal/webhookca/injector.go
@@ -12,7 +12,7 @@ func MaybeInject(mgr *manager.Manager, setupLog logr.Logger, namespace, deployme
 	}
 
 	if !injected {
-		maybeInjectWebhook(mgr, setupLog, namespace, deploymentName)
+		err = maybeInjectWebhook(mgr, setupLog, namespace, deploymentName)
 		if err != nil {
 			return err
 		}

--- a/internal/webhookca/injector.go
+++ b/internal/webhookca/injector.go
@@ -6,7 +6,7 @@ import (
 )
 
 func MaybeInject(mgr *manager.Manager, setupLog logr.Logger, namespace, deploymentName string) error {
-	injected, err := MaybeInjectCAForOLM(mgr)
+	injected, err := maybeInjectCAForOLM(mgr)
 	if err != nil {
 		return err
 	}

--- a/internal/webhookca/injector.go
+++ b/internal/webhookca/injector.go
@@ -5,14 +5,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-func MaybeInject(mgr *manager.Manager, setupLog logr.Logger, namespace, deploymentName string) error {
-	injected, err := maybeInjectCAForOLM(mgr)
+func Inject(mgr *manager.Manager, setupLog logr.Logger, namespace, deploymentName string) error {
+	injected, err := injectCAForOLM(mgr)
 	if err != nil {
 		return err
 	}
 
 	if !injected {
-		err = maybeInjectWebhook(mgr, setupLog, namespace, deploymentName)
+		err = injectWebhook(mgr, setupLog, namespace, deploymentName)
 		if err != nil {
 			return err
 		}

--- a/internal/webhookca/injector.go
+++ b/internal/webhookca/injector.go
@@ -1,0 +1,22 @@
+package webhookca
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func MaybeInject(mgr *manager.Manager, setupLog logr.Logger, namespace, deploymentName string) error {
+	injected, err := MaybeInjectCAForOLM(mgr)
+	if err != nil {
+		return err
+	}
+
+	if !injected {
+		maybeInjectWebhook(mgr, setupLog, namespace, deploymentName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/webhookca/olm_ca_injector.go
+++ b/internal/webhookca/olm_ca_injector.go
@@ -31,7 +31,6 @@ func injectCAForOLM(mgr *manager.Manager) (bool, error) {
 	srv.CertDir = webhookServerPathForOLM
 	srv.CertName = core.TLSCertKey
 	srv.KeyName = core.TLSPrivateKeyKey
-	// srv.Port = WebhookPort
 
 	return true, nil
 }

--- a/internal/webhookca/olm_ca_injector.go
+++ b/internal/webhookca/olm_ca_injector.go
@@ -1,0 +1,37 @@
+package webhookca
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// For more info, read the following:
+// https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
+// https://github.com/sruthakeerthikotla/memcachedwebhook/blob/main/webhookWithOLM.md
+
+const (
+	webhookServerPathForOLM = "/tmp/k8s-webhook-server/serving-certs/"
+)
+
+func MaybeInjectCAForOLM(mgr *manager.Manager) (bool, error) {
+	certPathForOLM := filepath.Join(webhookServerPathForOLM, core.TLSCertKey)
+	if _, err := os.Stat(certPathForOLM); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			// if the OLM generated certificate does not exist, it is not an error, it means it is not the OLM case
+			return false, nil
+		}
+		return false, err
+	}
+
+	srv := (*mgr).GetWebhookServer()
+	srv.CertDir = webhookServerPathForOLM
+	srv.CertName = core.TLSCertKey
+	srv.KeyName = core.TLSPrivateKeyKey
+	// srv.Port = WebhookPort
+
+	return true, nil
+}

--- a/internal/webhookca/olm_ca_injector.go
+++ b/internal/webhookca/olm_ca_injector.go
@@ -17,7 +17,7 @@ const (
 	webhookServerPathForOLM = "/tmp/k8s-webhook-server/serving-certs/"
 )
 
-func MaybeInjectCAForOLM(mgr *manager.Manager) (bool, error) {
+func maybeInjectCAForOLM(mgr *manager.Manager) (bool, error) {
 	certPathForOLM := filepath.Join(webhookServerPathForOLM, core.TLSCertKey)
 	if _, err := os.Stat(certPathForOLM); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {

--- a/internal/webhookca/olm_ca_injector.go
+++ b/internal/webhookca/olm_ca_injector.go
@@ -17,7 +17,7 @@ const (
 	webhookServerPathForOLM = "/tmp/k8s-webhook-server/serving-certs/"
 )
 
-func maybeInjectCAForOLM(mgr *manager.Manager) (bool, error) {
+func injectCAForOLM(mgr *manager.Manager) (bool, error) {
 	certPathForOLM := filepath.Join(webhookServerPathForOLM, core.TLSCertKey)
 	if _, err := os.Stat(certPathForOLM); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {

--- a/internal/webhookca/olm_ca_injector.go
+++ b/internal/webhookca/olm_ca_injector.go
@@ -20,7 +20,7 @@ const (
 func injectCAForOLM(mgr *manager.Manager) (bool, error) {
 	certPathForOLM := filepath.Join(webhookServerPathForOLM, core.TLSCertKey)
 	if _, err := os.Stat(certPathForOLM); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) {
 			// if the OLM generated certificate does not exist, it is not an error, it means it is not the OLM case
 			return false, nil
 		}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/hazelcast/hazelcast-platform-operator/internal/mtls"
@@ -112,28 +111,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	webhookName := types.NamespacedName{
-		Name:      strings.ReplaceAll(deploymentName, "controller-manager", "validating-webhook-configuration"),
-		Namespace: namespace,
-	}
-
-	serviceName := types.NamespacedName{
-		Name:      strings.ReplaceAll(deploymentName, "controller-manager", "webhook-service"),
-		Namespace: namespace, // service namespace is also hardcoded in webhook manifest
-	}
-
-	setupLog.Info("Starting CA injector", "webhook", webhookName, "service", serviceName)
-
-	webhookCAInjector, err := webhookca.NewCAInjector(mgr.GetClient(), webhookName, serviceName)
-	if err != nil {
-		setupLog.Error(err, "unable to create webhook ca injector")
-		// we can continue without ca injector, no need to exit
-	}
-
-	if err := mgr.Add(webhookCAInjector); err != nil {
-		setupLog.Error(err, "unable to run webhook ca injector")
-		os.Exit(1)
-	}
+	webhookca.MaybeInject(&mgr, setupLog, namespace, deploymentName)
 
 	var metrics *phonehome.Metrics
 	var phoneHomeTrigger chan struct{}

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = webhookca.MaybeInject(&mgr, setupLog, namespace, deploymentName)
+	err = webhookca.Inject(&mgr, setupLog, namespace, deploymentName)
 	if err != nil {
 		setupLog.Error(err, "unable to inject webhook ca")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -111,7 +111,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	webhookca.MaybeInject(&mgr, setupLog, namespace, deploymentName)
+	err = webhookca.MaybeInject(&mgr, setupLog, namespace, deploymentName)
+	if err != nil {
+		setupLog.Error(err, "unable to inject webhook ca")
+		os.Exit(1)
+	}
 
 	var metrics *phonehome.Metrics
 	var phoneHomeTrigger chan struct{}


### PR DESCRIPTION
## Description

While adding admission webhook, we ignored the OLM case. Applied a solution by following two documents:
- https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
- https://github.com/sruthakeerthikotla/memcachedwebhook/blob/main/webhookWithOLM.md

## User Impact

- Webhook support for OLM.
