### PR TITLE
[CN-631]-add sync_tags function to fetch latest tag

### DIFF
--- a/.github/scripts/utils.sh
+++ b/.github/scripts/utils.sh
@@ -192,3 +192,20 @@ wait_for_instance_restarted()
       echo "All instances are in 'Ready' status."
    fi
 }
+
+#This function sync certification tags and add the latest tag to the published image
+sync_certificated_image_tags()
+{
+     local PROJECT_ID=$1
+     local CERT_IMAGE_ID=$2
+     local RHEL_API_KEY=$3
+     curl -X 'POST' \
+     "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${PROJECT_ID}/requests/images" \
+     -H 'accept: application/json' \
+     -H 'Content-Type: application/json' \
+     -d "{
+           \"image_id\": \"${CERT_IMAGE_ID}\",
+           \"operation\": \"sync-tags\"
+         }" \
+     -H "X-API-KEY: ${RHEL_API_KEY}"
+}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -120,12 +120,19 @@ jobs:
           --docker-config=/home/runner/.docker/config.json \
           --certification-project-id=$PROJECT_ID
           grep -E -q "Preflight result: PASSED\"( |$)" preflight.log || exit 1
+          CERT_IMAGE_ID=$(cat preflight.log | grep "The container's image id is:" | awk '{print $8}' | cut -d '.' -f1)
+          echo "CERT_IMAGE_ID=${CERT_IMAGE_ID}" >> $GITHUB_ENV
 
       - name: Publish the Hazelcast-Platform-Operator Image
         run: |
           source .github/scripts/utils.sh
           checking_image_grade "$PROJECT_ID" "$RELEASE_VERSION" "$PFLT_PYXIS_API_TOKEN" "$GRADE_CHECK_TIMEOUT_IN_MINS"
           wait_for_container_publish "$PROJECT_ID" "$RELEASE_VERSION" "$PFLT_PYXIS_API_TOKEN" "$PUBLISH_TIMEOUT_IN_MINS"
+
+      - name: Sync Latest Image
+        run: |
+          source .github/scripts/utils.sh
+          sync_certificated_image_tags "$PROJECT_ID" "$CERT_IMAGE_ID" "$PFLT_PYXIS_API_TOKEN"
 
   redhat_certified_operator_release:
     name: Create a PR in 'certified-operators' Repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY internal/ internal/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -tags hazelcastinternal -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf upgrade -y && \
     microdnf clean all


### PR DESCRIPTION
## Description

- Added sync_tag function that fetched and attached the latest tag to the published certificate image on Open Shift env
- Changed the tag for the ubi-minimal image to fix the vulnerability issue. Publishing with the current tag will get an index score of C instead of A, and it will cause the impossibility to publish our next image
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/8906445/209799520-d91b8a76-6d5f-4b61-9fba-1714e8e60767.png">

## User Impact

- No more needs to sync tags manually after publishing
- From now we should always get an index score of A for our subsequent releases

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/8906445/209799850-d9b2791e-6475-4a50-ac66-c0fd17646071.png">

