### PR TITLE
[CN-661] Add clusterIDs to phone home data

### DIFF
--- a/controllers/hazelcast/fakes_test.go
+++ b/controllers/hazelcast/fakes_test.go
@@ -83,6 +83,7 @@ type fakeHzClient struct {
 	tInvokeOnMember          func(ctx context.Context, req *proto.ClientMessage, uuid hztypes.UUID, opts *proto.InvokeOptions) (*proto.ClientMessage, error)
 	tInvokeOnRandomTarget    func(ctx context.Context, req *proto.ClientMessage, opts *proto.InvokeOptions) (*proto.ClientMessage, error)
 	tShutDown                error
+	tUUID                    hztypes.UUID
 }
 
 func (cl *fakeHzClient) OrderedMembers() []cluster.MemberInfo {
@@ -113,6 +114,10 @@ func (cl *fakeHzClient) InvokeOnRandomTarget(ctx context.Context, req *proto.Cli
 
 func (cl *fakeHzClient) Running() bool {
 	return cl.tRunning
+}
+
+func (cl *fakeHzClient) ClusterId() hztypes.UUID {
+	return cl.tUUID
 }
 
 func (cl *fakeHzClient) Shutdown(ctx context.Context) error {

--- a/internal/hazelcast-client/client.go
+++ b/internal/hazelcast-client/client.go
@@ -15,6 +15,7 @@ type Client interface {
 	IsClientConnected() bool
 	AreAllMembersAccessible() bool
 
+	ClusterId() hztypes.UUID
 	OrderedMembers() []cluster.MemberInfo
 	InvokeOnMember(ctx context.Context, req *proto.ClientMessage, uuid hztypes.UUID, opts *proto.InvokeOptions) (*proto.ClientMessage, error)
 	InvokeOnRandomTarget(ctx context.Context, req *proto.ClientMessage, opts *proto.InvokeOptions) (*proto.ClientMessage, error)
@@ -103,6 +104,15 @@ func (cl *HazelcastClient) InvokeOnRandomTarget(ctx context.Context, req *proto.
 
 func (cl *HazelcastClient) Running() bool {
 	return cl.client != nil && cl.client.Running()
+}
+
+func (cl *HazelcastClient) ClusterId() hztypes.UUID {
+	if cl.client == nil {
+		return hztypes.UUID{}
+	}
+
+	ci := hazelcast.NewClientInternal(cl.client)
+	return ci.ClusterID()
 }
 
 func (c *HazelcastClient) Shutdown(ctx context.Context) error {

--- a/internal/phonehome/phonehome.go
+++ b/internal/phonehome/phonehome.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/util"
 )
@@ -26,6 +27,7 @@ type Metrics struct {
 	K8sDistibution string
 	K8sVersion     string
 	Trigger        chan struct{}
+	ClientRegistry hzclient.ClientRegistry
 }
 
 func Start(cl client.Client, m *Metrics) {
@@ -80,6 +82,7 @@ type PhoneHomeData struct {
 	CreatedEnterpriseClusterCount int                `json:"cecc"`
 	CreatedMCcount                int                `json:"cmcc"`
 	CreatedMemberCount            int                `json:"cmc"`
+	ClusterUUIDs                  []string           `json:"cuids"`
 	ExposeExternally              ExposeExternally   `json:"xe"`
 	Map                           Map                `json:"m"`
 	WanReplicationCount           int                `json:"wrc"`
@@ -135,7 +138,7 @@ func newPhoneHomeData(cl client.Client, m *Metrics) PhoneHomeData {
 		K8sVersion:     m.K8sVersion,
 	}
 
-	phd.fillHazelcastMetrics(cl)
+	phd.fillHazelcastMetrics(cl, m.ClientRegistry)
 	phd.fillMCMetrics(cl)
 	phd.fillMapMetrics(cl)
 	phd.fillWanReplicationMetrics(cl)
@@ -152,11 +155,12 @@ func upTime(t time.Time) time.Duration {
 	return now.Sub(t)
 }
 
-func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client) {
+func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client, hzClientRegistry hzclient.ClientRegistry) {
 	createdEnterpriseClusterCount := 0
 	createdClusterCount := 0
 	createdMemberCount := 0
 	executorServiceCount := 0
+	clusterUUIDs := []string{}
 
 	hzl := &hazelcastv1alpha1.HazelcastList{}
 	err := cl.List(context.Background(), hzl, client.InNamespace(os.Getenv(n.NamespaceEnv)))
@@ -176,11 +180,32 @@ func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client) {
 		phm.UserCodeDeployment.addUsageMetrics(&hz.Spec.UserCodeDeployment)
 		createdMemberCount += int(*hz.Spec.ClusterSize)
 		executorServiceCount += len(hz.Spec.ExecutorServices) + len(hz.Spec.DurableExecutorServices) + len(hz.Spec.ScheduledExecutorServices)
+
+		cid, ok := ClusterUUID(hzClientRegistry, hz.Name, hz.Namespace)
+		if !ok {
+			continue
+		}
+		clusterUUIDs = append(clusterUUIDs, cid)
 	}
 	phm.CreatedClusterCount = createdClusterCount
 	phm.CreatedEnterpriseClusterCount = createdEnterpriseClusterCount
 	phm.CreatedMemberCount = createdMemberCount
 	phm.ExecutorServiceCount = executorServiceCount
+	phm.ClusterUUIDs = clusterUUIDs
+}
+
+func ClusterUUID(reg hzclient.ClientRegistry, hzName, hzNamespace string) (string, bool) {
+	hzcl, ok := reg.Get(types.NamespacedName{Name: hzName, Namespace: hzNamespace})
+	// If client not present continue
+	if !ok {
+		return "", false
+	}
+	cid := hzcl.ClusterId()
+	// If cid is empty continue
+	if cid.Default() {
+		return "", false
+	}
+	return cid.String(), true
 }
 
 func (xe *ExposeExternally) addUsageMetrics(e *hazelcastv1alpha1.ExposeExternallyConfiguration) {

--- a/internal/phonehome/phonehome.go
+++ b/internal/phonehome/phonehome.go
@@ -196,12 +196,10 @@ func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client, hzClientRegistr
 
 func ClusterUUID(reg hzclient.ClientRegistry, hzName, hzNamespace string) (string, bool) {
 	hzcl, ok := reg.Get(types.NamespacedName{Name: hzName, Namespace: hzNamespace})
-	// If client not present continue
 	if !ok {
 		return "", false
 	}
 	cid := hzcl.ClusterId()
-	// If cid is empty continue
 	if cid.Default() {
 		return "", false
 	}

--- a/internal/phonehome/phonehome.go
+++ b/internal/phonehome/phonehome.go
@@ -182,10 +182,9 @@ func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client, hzClientRegistr
 		executorServiceCount += len(hz.Spec.ExecutorServices) + len(hz.Spec.DurableExecutorServices) + len(hz.Spec.ScheduledExecutorServices)
 
 		cid, ok := ClusterUUID(hzClientRegistry, hz.Name, hz.Namespace)
-		if !ok {
-			continue
+		if ok {
+			clusterUUIDs = append(clusterUUIDs, cid)
 		}
-		clusterUUIDs = append(clusterUUIDs, cid)
 	}
 	phm.CreatedClusterCount = createdClusterCount
 	phm.CreatedEnterpriseClusterCount = createdEnterpriseClusterCount

--- a/main.go
+++ b/main.go
@@ -135,6 +135,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	cr := &hzclient.HazelcastClientRegistry{}
+	ssm := &hzclient.HzStatusServiceRegistry{}
+
 	var metrics *phonehome.Metrics
 	var phoneHomeTrigger chan struct{}
 	if util.IsPhoneHomeEnabled() {
@@ -147,11 +150,9 @@ func main() {
 			K8sDistibution: platform.GetDistribution(),
 			K8sVersion:     platform.GetVersion(),
 			Trigger:        phoneHomeTrigger,
+			ClientRegistry: cr,
 		}
 	}
-
-	cr := &hzclient.HazelcastClientRegistry{}
-	ssm := &hzclient.HzStatusServiceRegistry{}
 
 	if err = hazelcast.NewHazelcastReconciler(
 		mgr.GetClient(),


### PR DESCRIPTION
## Description

Phone home data will also include the UUIDs of the created Hazelcast clusters.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
Cluster UUIDs will be collected in the Phone Home data