### PR TITLE
Reverse incorrect condition in Wan Replication Controller

### DIFF
--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -246,7 +246,7 @@ func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Cont
 		return false, err
 	}
 
-	if wan.Status.Status != hazelcastv1alpha1.WanStatusFailed {
+	if wan.Status.Status == hazelcastv1alpha1.WanStatusFailed {
 		return false, fmt.Errorf("Wan replication for some maps failed")
 	}
 


### PR DESCRIPTION
## Description

Reverse incorrect equality check for failed Wan Status

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
