### PR TITLE
[CN-668] - Sync Hazelcast Operator repo with Hazelcast Charts repo

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,0 +1,26 @@
+name: Helm Chart Release
+
+on:
+  push:
+    paths:
+      - 'helm-chart/**'
+
+jobs:
+  push-new-chart-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+
+      - name: Commit And Push Changes To 'Hazelcast Charts' Repository
+        run: |
+          echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
+          git config user.email "devopshelm@hazelcast.com"
+          git config user.name "devOpsHelm"
+          git subtree add --prefix=charts https://github.com/hazelcast/charts.git master --squash
+          cp -rf helm-chart/hazelcast-platform-operator/* charts/stable/hazelcast-platform-operator
+          git add charts/
+          git commit --signoff -m "${{github.event.head_commit.message}}"
+          git subtree push --prefix=charts https://github.com/hazelcast/charts.git master

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -20,7 +20,7 @@ jobs:
           git config user.email "devopshelm@hazelcast.com"
           git config user.name "devOpsHelm"
           git subtree add --prefix=charts https://github.com/hazelcast/charts.git master --squash
-          cp -rf helm-chart/hazelcast-platform-operator/* charts/stable/hazelcast-platform-operator
+          cp -rf helm-charts/hazelcast-platform-operator/* charts/stable/hazelcast-platform-operator
           git add charts/
           git commit --signoff -m "${{github.event.head_commit.message}}"
           git subtree push --prefix=charts https://github.com/hazelcast/charts.git master

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -3,7 +3,7 @@ name: Helm Chart Release
 on:
   push:
     paths:
-      - 'helm-chart/**'
+      - 'helm-charts/**'
 
 jobs:
   push-new-chart-version:

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,4 +1,4 @@
-name: Helm Chart Release
+name: Helm Chart Update
 
 on:
   push:


### PR DESCRIPTION
## Description

Added a new workflow that allows pushing helm chart directly into https://github.com/hazelcast/charts.git based on changes in helm-chart/ folder in current repo
