### PR TITLE
[CN-606][CN-607] Introduce highAvailabilityMode is configuration to create clusters are resilient to node and zone failures

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -127,7 +127,21 @@ type HazelcastSpec struct {
 	// +kubebuilder:default:="INFO"
 	// +optional
 	LoggingLevel LoggingLevel `json:"loggingLevel,omitempty"`
+
+	// Configuration to create clusters are resilient to node and zone failures
+	// +optional
+	// +kubebuilder:default:={}
+	HighAvailabilityMode HighAvailabilityMode `json:"highAvailabilityMode,omitempty"`
 }
+
+// +kubebuilder:validation:Enum=NODE;ZONE
+type HighAvailabilityMode string
+
+const (
+	HighAvailabilityNodeMode HighAvailabilityMode = "NODE"
+
+	HighAvailabilityZoneMode HighAvailabilityMode = "ZONE"
+)
 
 type JetEngineConfiguration struct {
 	// When false, disables Jet Engine.

--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -128,7 +128,7 @@ type HazelcastSpec struct {
 	// +optional
 	LoggingLevel LoggingLevel `json:"loggingLevel,omitempty"`
 
-	// Configuration to create clusters are resilient to node and zone failures
+	// Configuration to create clusters resilient to node and zone failures
 	// +optional
 	// +kubebuilder:default:={}
 	HighAvailabilityMode HighAvailabilityMode `json:"highAvailabilityMode,omitempty"`

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -10,6 +10,13 @@ var BlackListProperties = map[string]struct{}{
 	"": {},
 }
 
+func ValidateNotUpdatableHazelcastFields(current *HazelcastSpec, last *HazelcastSpec) error {
+	if current.HighAvailabilityMode != last.HighAvailabilityMode {
+		return errors.New("highAvailabilityMode cannot be updated")
+	}
+	return nil
+}
+
 func ValidateHazelcastSpec(h *Hazelcast) error {
 	if err := validateExposeExternally(h); err != nil {
 		return err

--- a/api/v1alpha1/hazelcast_webhook.go
+++ b/api/v1alpha1/hazelcast_webhook.go
@@ -1,13 +1,14 @@
 package v1alpha1
 
 import (
-	"encoding/json"
-	"fmt"
-	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"encoding/json"
+	"fmt"
+	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 )
 
 // log is for logging in this package.

--- a/api/v1alpha1/hazelcast_webhook.go
+++ b/api/v1alpha1/hazelcast_webhook.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+	"fmt"
+	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,7 +34,21 @@ func (r *Hazelcast) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Hazelcast) ValidateUpdate(old runtime.Object) error {
 	hazelcastlog.Info("validate update", "name", r.Name)
-	return ValidateHazelcastSpec(r)
+
+	// use last successfully applied spec
+	if last, ok := r.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]; ok {
+		var parsed HazelcastSpec
+		if err := json.Unmarshal([]byte(last), &parsed); err != nil {
+			return fmt.Errorf("error parsing last Hazelcast spec: %w", err)
+		}
+		return ValidateNotUpdatableHazelcastFields(&r.Spec, &parsed)
+	}
+
+	if err := ValidateHazelcastSpec(r); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/map_validation.go
+++ b/api/v1alpha1/map_validation.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-func ValidateNotUpdatableFields(current *MapSpec, last *MapSpec) error {
+func ValidateNotUpdatableMapFields(current *MapSpec, last *MapSpec) error {
 	if current.Name != last.Name {
 		return errors.New("name cannot be updated")
 	}

--- a/api/v1alpha1/map_webhook.go
+++ b/api/v1alpha1/map_webhook.go
@@ -42,7 +42,7 @@ func (m *Map) ValidateUpdate(old runtime.Object) error {
 			return fmt.Errorf("error parsing last map spec: %w", err)
 		}
 
-		return ValidateNotUpdatableFields(&m.Spec, &parsed)
+		return ValidateNotUpdatableMapFields(&m.Spec, &parsed)
 	}
 
 	return nil

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -397,8 +397,8 @@ spec:
                     type: string
                 type: object
               highAvailabilityMode:
-                description: Configuration to create clusters are resilient to node
-                  and zone failures
+                description: Configuration to create clusters resilient to node and
+                  zone failures
                 enum:
                 - NODE
                 - ZONE

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -396,6 +396,13 @@ spec:
                     - Unisocket
                     type: string
                 type: object
+              highAvailabilityMode:
+                description: Configuration to create clusters are resilient to node
+                  and zone failures
+                enum:
+                - NODE
+                - ZONE
+                type: string
               imagePullPolicy:
                 default: IfNotPresent
                 description: Pull policy for the Hazelcast Platform image
@@ -4618,6 +4625,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: DEVELOPER_MODE_ENABLED
+          value: "true"
         image: hazelcast/hazelcast-platform-operator:latest-snapshot
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4625,8 +4625,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: DEVELOPER_MODE_ENABLED
-          value: "true"
         image: hazelcast/hazelcast-platform-operator:latest-snapshot
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -160,6 +160,13 @@ spec:
                     - Unisocket
                     type: string
                 type: object
+              highAvailabilityMode:
+                description: Configuration to create clusters are resilient to node
+                  and zone failures
+                enum:
+                - NODE
+                - ZONE
+                type: string
               imagePullPolicy:
                 default: IfNotPresent
                 description: Pull policy for the Hazelcast Platform image

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -161,8 +161,8 @@ spec:
                     type: string
                 type: object
               highAvailabilityMode:
-                description: Configuration to create clusters are resilient to node
-                  and zone failures
+                description: Configuration to create clusters resilient to node and
+                  zone failures
                 enum:
                 - NODE
                 - ZONE

--- a/config/samples/_v1alpha1_hazelcast_high_availability.yaml
+++ b/config/samples/_v1alpha1_hazelcast_high_availability.yaml
@@ -1,0 +1,10 @@
+apiVersion: hazelcast.com/v1alpha1
+kind: Hazelcast
+metadata:
+  name: hazelcast
+spec:
+  clusterSize: 3
+  repository: 'docker.io/hazelcast/hazelcast-enterprise'
+  version: '5.2.1-slim'
+  highAvailabilityMode: ZONE
+  licenseKeySecret: hazelcast-license-key

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -2,7 +2,6 @@ package hazelcast
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -167,21 +166,8 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var newExecutorServices map[string]interface{}
 	if createdBefore {
-		hs, err := json.Marshal(h.Spec)
+		lastSpec, err := r.unmarshalHazelcastSpec(h, s)
 		if err != nil {
-			err = fmt.Errorf("error marshaling Hazelcast as JSON: %w", err)
-			return r.update(ctx, h, failedPhase(err))
-		}
-		if s == string(hs) {
-			return r.update(ctx, h,
-				runningPhase().
-					withMessage(fmt.Sprintf("hazelcast Config was already applied. name: %s , namespace: %s", h.Name, h.Namespace)))
-		}
-
-		lastSpec := &hazelcastv1alpha1.HazelcastSpec{}
-		err = json.Unmarshal([]byte(s), lastSpec)
-		if err != nil {
-			err = fmt.Errorf("error unmarshaling last Hazelcast Spec: %w", err)
 			return r.update(ctx, h, failedPhase(err))
 		}
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -653,7 +653,7 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 				Enabled:   pointer.Bool(true),
 				GroupType: "NODE_AWARE",
 			}
-		case "ZONE":
+		case hazelcastv1alpha1.HighAvailabilityZoneMode:
 			cfg.PartitionGroup = config.PartitionGroup{
 				Enabled:   pointer.Bool(true),
 				GroupType: "ZONE_AWARE",

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -648,7 +648,7 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 
 	if h.Spec.HighAvailabilityMode != "" {
 		switch h.Spec.HighAvailabilityMode {
-		case "NODE":
+		case hazelcastv1alpha1.HighAvailabilityNodeMode:
 			cfg.PartitionGroup = config.PartitionGroup{
 				Enabled:   pointer.Bool(true),
 				GroupType: "NODE_AWARE",

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -101,7 +101,6 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	if createdBefore {
 		ms, err := json.Marshal(m.Spec)
-
 		if err != nil {
 			err = fmt.Errorf("error marshaling Map as JSON: %w", err)
 			return updateMapStatus(ctx, r.Client, m, failedStatus(err).withMessage(err.Error()))
@@ -117,7 +116,7 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return updateMapStatus(ctx, r.Client, m, failedStatus(err).withMessage(err.Error()))
 		}
 
-		err = hazelcastv1alpha1.ValidateNotUpdatableFields(&m.Spec, lastSpec)
+		err = hazelcastv1alpha1.ValidateNotUpdatableMapFields(&m.Spec, lastSpec)
 		if err != nil {
 			return updateMapStatus(ctx, r.Client, m, failedStatus(err).withMessage(err.Error()))
 		}

--- a/internal/config/hazelcast.go
+++ b/internal/config/hazelcast.go
@@ -25,7 +25,7 @@ type Hazelcast struct {
 }
 
 type PartitionGroup struct {
-	Enabled   bool   `yaml:"enabled,omitempty"`
+	Enabled   *bool  `yaml:"enabled,omitempty"`
 	GroupType string `yaml:"group-type,omitempty"`
 }
 

--- a/internal/config/hazelcast.go
+++ b/internal/config/hazelcast.go
@@ -21,6 +21,12 @@ type Hazelcast struct {
 	ReplicatedMap            map[string]ReplicatedMap            `yaml:"replicatedmap,omitempty"`
 	Queue                    map[string]Queue                    `yaml:"queue,omitempty"`
 	Cache                    map[string]Cache                    `yaml:"cache,omitempty"`
+	PartitionGroup           PartitionGroup                      `yaml:"partition-group,omitempty"`
+}
+
+type PartitionGroup struct {
+	Enabled   bool   `yaml:"enabled,omitempty"`
+	GroupType string `yaml:"group-type,omitempty"`
 }
 
 type Jet struct {

--- a/internal/phonehome/phonehome.go
+++ b/internal/phonehome/phonehome.go
@@ -93,6 +93,7 @@ type PhoneHomeData struct {
 	ReplicatedMapCount            int                `json:"rmc"`
 	CronHotBackupCount            int                `json:"chbc"`
 	TopicCount                    int                `json:"tc"`
+	HighAvailabilityMode          []string           `json:"ha"`
 }
 
 type ExposeExternally struct {
@@ -161,6 +162,7 @@ func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client, hzClientRegistr
 	createdMemberCount := 0
 	executorServiceCount := 0
 	clusterUUIDs := []string{}
+	highAvailabilityModes := []string{}
 
 	hzl := &hazelcastv1alpha1.HazelcastList{}
 	err := cl.List(context.Background(), hzl, client.InNamespace(os.Getenv(n.NamespaceEnv)))
@@ -180,6 +182,7 @@ func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client, hzClientRegistr
 		phm.UserCodeDeployment.addUsageMetrics(&hz.Spec.UserCodeDeployment)
 		createdMemberCount += int(*hz.Spec.ClusterSize)
 		executorServiceCount += len(hz.Spec.ExecutorServices) + len(hz.Spec.DurableExecutorServices) + len(hz.Spec.ScheduledExecutorServices)
+		highAvailabilityModes = append(highAvailabilityModes, string(hz.Spec.HighAvailabilityMode))
 
 		cid, ok := ClusterUUID(hzClientRegistry, hz.Name, hz.Namespace)
 		if ok {
@@ -191,6 +194,7 @@ func (phm *PhoneHomeData) fillHazelcastMetrics(cl client.Client, hzClientRegistr
 	phm.CreatedMemberCount = createdMemberCount
 	phm.ExecutorServiceCount = executorServiceCount
 	phm.ClusterUUIDs = clusterUUIDs
+	phm.HighAvailabilityMode = highAvailabilityModes
 }
 
 func ClusterUUID(reg hzclient.ClientRegistry, hzName, hzNamespace string) (string, bool) {

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Hazelcast webhook", func() {
 				Spec:       zoneHASpec,
 			}
 
-			k8sClient.Create(context.Background(), hz)
+			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 			test.CheckHazelcastCR(hz, defaultSpecValues, ee)
 
 			hz.Spec.HighAvailabilityMode = hazelcastv1alpha1.HighAvailabilityNodeMode

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -132,6 +132,9 @@ var _ = Describe("Hazelcast webhook", func() {
 			hz.Spec.HighAvailabilityMode = hazelcastv1alpha1.HighAvailabilityNodeMode
 			Expect(k8sClient.Update(context.Background(), hz)).
 				Should(MatchError(ContainSubstring("highAvailabilityMode cannot be updated")))
+
+			deleteIfExists(lookupKey(hz), hz)
+			assertDoesNotExist(lookupKey(hz), hz)
 		})
 	})
 })

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -2,8 +2,8 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +35,17 @@ var _ = Describe("Hazelcast webhook", func() {
 		return metav1.ObjectMeta{
 			Name:      fmt.Sprintf("hazelcast-test-%s", uuid.NewUUID()),
 			Namespace: namespace,
+		}
+	}
+
+	GetRandomObjectMetaWithAnnotation := func(spec *hazelcastv1alpha1.HazelcastSpec) metav1.ObjectMeta {
+		hs, _ := json.Marshal(spec)
+		return metav1.ObjectMeta{
+			Name:      fmt.Sprintf("hazelcast-test-%s", uuid.NewUUID()),
+			Namespace: namespace,
+			Annotations: map[string]string{
+				n.LastSuccessfulSpecAnnotation: string(hs),
+			},
 		}
 	}
 
@@ -102,6 +113,25 @@ var _ = Describe("Hazelcast webhook", func() {
 			}
 			Expect(k8sClient.Create(context.Background(), hz)).
 				Should(MatchError(ContainSubstring("when exposeExternally.type is set to \"Unisocket\", exposeExternally.memberAccess must not be set")))
+		})
+	})
+
+	Context("Hazelcast HighAvailabilityMode", func() {
+		It("should fail to update", Label("fast"), func() {
+			zoneHASpec := test.HazelcastSpec(defaultSpecValues, ee)
+			zoneHASpec.HighAvailabilityMode = "ZONE"
+
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: GetRandomObjectMetaWithAnnotation(&zoneHASpec),
+				Spec:       zoneHASpec,
+			}
+
+			k8sClient.Create(context.Background(), hz)
+			test.CheckHazelcastCR(hz, defaultSpecValues, ee)
+
+			hz.Spec.HighAvailabilityMode = hazelcastv1alpha1.HighAvailabilityNodeMode
+			Expect(k8sClient.Update(context.Background(), hz)).
+				Should(MatchError(ContainSubstring("highAvailabilityMode cannot be updated")))
 		})
 	})
 })


### PR DESCRIPTION
Other changes:
- implemented webhook to validate(prevent) highAvailabilityMode update.
- renamed ValidateNotUpdatableFields to ValidateNotUpdatableMapFields which belongs to Map CR webhook.
- implemented integration tests for feature itself and webhook.
- phone home for highAvailabilityMode param

## User Impact

Introduce highAvailabilityMode is a configuration to create clusters that are resilient to node and zone failures.
