### PR TITLE
[CN-659] Use podManagementPolicy to improve cluster setup time

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1083,7 +1083,8 @@ func (r *HazelcastReconciler) reconcileStatefulset(ctx context.Context, h *hazel
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls,
 			},
-			ServiceName: h.Name,
+			ServiceName:         h.Name,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: ls,


### PR DESCRIPTION
```
$ k get pod -w
NAME          READY   STATUS    RESTARTS   AGE
hazelcast-0   0/1     Running   0          2s
hazelcast-1   0/1     Running   0          2s
hazelcast-2   0/1     Running   0          2s
hazelcast-0   1/1     Running   0          10s
hazelcast-1   1/1     Running   0          10s
hazelcast-2   1/1     Running   0          10s
```