### PR TITLE
Remove 'Cache Golang dependencies' step linters job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,23 +40,11 @@ jobs:
         with:
           go-version: ${{ format('>={0}', env.GO_VERSION) }}
 
-      - name: Cache Golang dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
         if: ${{ !cancelled() }}
         with:
           args: --timeout 3m --build-tags hazelcastinternal
-          skip-pkg-cache: true
-          skip-build-cache: true
 
       - name: Run yamllint
         uses: ibiqlik/action-yamllint@v3
@@ -82,6 +70,17 @@ jobs:
               echo "Please make sure your branch is up to date with main and run 'make generate-bundle-yaml'"
               exit 1
           fi
+
+      - name: Cache Golang dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
 
   unit-tests:
     name: Run unit and integration tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,6 +55,8 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           args: --timeout 3m --build-tags hazelcastinternal
+          skip-pkg-cache: true
+          skip-build-cache: true
 
       - name: Run yamllint
         uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,17 +71,6 @@ jobs:
               exit 1
           fi
 
-      - name: Cache Golang dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-
   unit-tests:
     name: Run unit and integration tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Fix golangci-lint issue when it throw the error
`
  Error: /usr/bin/tar: ../../../go/pkg/mod/k8s.io/apiextensions-apiserver@v0.25.4/pkg/apiserver/schema/cel/values.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/k8s.io/apiextensions-apiserver@v0.25.4/pkg/apiserver/schema/cel/maplist.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/k8s.io/apiextensions-apiserver@v0.25.4/pkg/apiserver/schema/cel/values_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/k8s.io/apiextensions-apiserver@v0.25.4/pkg/apiserver/schema/cel/maplist_test.go: Cannot open: File exists`

- This is because the "Cache Golang dependencies" in PR builder step restores the cache, then the lint action tries to restore the cache as well, and of course, it fails due to the files already existing. 

- **golangci-lint save and restore the cache itself.**

## User Impact

No more error about Cannot open: File exists