### PR TITLE
Fix wrong variable assignment in WanRep ConfigMap

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1061,7 +1061,7 @@ func createWanReplicationConfig(publisherId string, wr hazelcastv1alpha1.WanRepl
 	cfg := config.WanReplicationConfig{
 		BatchPublisher: map[string]config.BatchPublisherConfig{
 			publisherId: {
-				ClusterName:           wr.Spec.Endpoints,
+				ClusterName:           wr.Spec.TargetClusterName,
 				TargetEndpoints:       wr.Spec.Endpoints,
 				QueueCapacity:         wr.Spec.Queue.Capacity,
 				QueueFullBehavior:     string(wr.Spec.Queue.FullBehavior),


### PR DESCRIPTION
## Description

## User Impact

After members restart they will be able to continue replicating the map entries using Wan Replication
