### PR TITLE
[CN-703] Validate if cluster size is not more than 300 in hazelcast cr

### DIFF
--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"strings"
 )
 
@@ -10,9 +11,6 @@ var BlackListProperties = map[string]struct{}{
 	// TODO: Add properties which should not be exposed.
 	"": {},
 }
-
-const ClusterSizeLimit = 300
-const ClusterSizeLimitErrStr = "cluster size limit is exceeded. Requested: %d, Limit: %d"
 
 func ValidateNotUpdatableHazelcastFields(current *HazelcastSpec, last *HazelcastSpec) error {
 	if current.HighAvailabilityMode != last.HighAvailabilityMode {
@@ -42,8 +40,8 @@ func ValidateHazelcastSpec(h *Hazelcast) error {
 }
 
 func validateClusterSize(h *Hazelcast) error {
-	if *h.Spec.ClusterSize > ClusterSizeLimit {
-		return fmt.Errorf(ClusterSizeLimitErrStr, *h.Spec.ClusterSize, ClusterSizeLimit)
+	if *h.Spec.ClusterSize > naming.ClusterSizeLimit {
+		return fmt.Errorf(naming.ClusterSizeLimitErrStr, *h.Spec.ClusterSize, naming.ClusterSizeLimit)
 	}
 	return nil
 }

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	"github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 	"strings"
+
+	"github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 )
 
 var BlackListProperties = map[string]struct{}{
@@ -41,7 +42,7 @@ func ValidateHazelcastSpec(h *Hazelcast) error {
 
 func validateClusterSize(h *Hazelcast) error {
 	if *h.Spec.ClusterSize > naming.ClusterSizeLimit {
-		return fmt.Errorf(naming.ClusterSizeLimitErrStr, *h.Spec.ClusterSize, naming.ClusterSizeLimit)
+		return fmt.Errorf("cluster size limit is exceeded. Requested: %d, Limit: %d", *h.Spec.ClusterSize, naming.ClusterSizeLimit)
 	}
 	return nil
 }

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -11,7 +11,8 @@ var BlackListProperties = map[string]struct{}{
 	"": {},
 }
 
-const clusterSizeLimit = 300
+const ClusterSizeLimit = 300
+const ClusterSizeLimitErrStr = "cluster size limit is exceeded. Requested: %d, Limit: %d"
 
 func ValidateNotUpdatableHazelcastFields(current *HazelcastSpec, last *HazelcastSpec) error {
 	if current.HighAvailabilityMode != last.HighAvailabilityMode {
@@ -41,8 +42,8 @@ func ValidateHazelcastSpec(h *Hazelcast) error {
 }
 
 func validateClusterSize(h *Hazelcast) error {
-	if *h.Spec.ClusterSize > clusterSizeLimit {
-		return errors.New(fmt.Sprintf("cluster size limit is exceeded. Requested: %d, Limit: %d", *h.Spec.ClusterSize, clusterSizeLimit))
+	if *h.Spec.ClusterSize > ClusterSizeLimit {
+		return fmt.Errorf(ClusterSizeLimitErrStr, *h.Spec.ClusterSize, ClusterSizeLimit)
 	}
 	return nil
 }

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -9,6 +10,8 @@ var BlackListProperties = map[string]struct{}{
 	// TODO: Add properties which should not be exposed.
 	"": {},
 }
+
+const clusterSizeLimit = 300
 
 func ValidateNotUpdatableHazelcastFields(current *HazelcastSpec, last *HazelcastSpec) error {
 	if current.HighAvailabilityMode != last.HighAvailabilityMode {
@@ -30,6 +33,17 @@ func ValidateHazelcastSpec(h *Hazelcast) error {
 		return err
 	}
 
+	if err := validateClusterSize(h); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateClusterSize(h *Hazelcast) error {
+	if *h.Spec.ClusterSize > clusterSizeLimit {
+		return errors.New(fmt.Sprintf("cluster size limit is exceeded. Requested: %d, Limit: %d", *h.Spec.ClusterSize, clusterSizeLimit))
+	}
 	return nil
 }
 

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -184,3 +184,9 @@ const (
 	// merge policy in WAN reference config
 	DefaultMergePolicyClassName = "PassThroughMergePolicy"
 )
+
+// Cluster Size Limit constants
+const (
+	ClusterSizeLimit       = 300
+	ClusterSizeLimitErrStr = "cluster size limit is exceeded. Requested: %d, Limit: %d"
+)

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -187,6 +187,5 @@ const (
 
 // Cluster Size Limit constants
 const (
-	ClusterSizeLimit       = 300
-	ClusterSizeLimitErrStr = "cluster size limit is exceeded. Requested: %d, Limit: %d"
+	ClusterSizeLimit = 300
 )

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -112,8 +112,8 @@ var _ = Describe("Hazelcast webhook", func() {
 				Spec:       spec,
 			}
 
-			expectedErrStr := fmt.Sprintf(n.ClusterSizeLimitErrStr, requestedClusterSize, n.ClusterSizeLimit)
-			Expect(k8sClient.Create(context.Background(), hz)).Should(MatchError(ContainSubstring(expectedErrStr)))
+			Expect(k8sClient.Create(context.Background(), hz)).
+				Should(MatchError(ContainSubstring("cluster size limit is exceeded")))
 		})
 	})
 

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Hazelcast webhook", func() {
 	Context("Hazelcast Cluster Size", func() {
 		It(fmt.Sprintf("should validate cluster size is not more than %d", hazelcastv1alpha1.ClusterSizeLimit), Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultSpecValues, ee)
-			requestedClusterSize := int32(400)
+			requestedClusterSize := int32(hazelcastv1alpha1.ClusterSizeLimit + 1)
 			spec.ClusterSize = &requestedClusterSize
 
 			hz := &hazelcastv1alpha1.Hazelcast{

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -101,6 +101,22 @@ var _ = Describe("Hazelcast webhook", func() {
 		})
 	})
 
+	Context("Hazelcast Cluster Size", func() {
+		It(fmt.Sprintf("should validate cluster size is not more than %d", hazelcastv1alpha1.ClusterSizeLimit), Label("fast"), func() {
+			spec := test.HazelcastSpec(defaultSpecValues, ee)
+			requestedClusterSize := int32(400)
+			spec.ClusterSize = &requestedClusterSize
+
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: GetRandomObjectMeta(),
+				Spec:       spec,
+			}
+
+			expectedErrStr := fmt.Sprintf(hazelcastv1alpha1.ClusterSizeLimitErrStr, requestedClusterSize, hazelcastv1alpha1.ClusterSizeLimit)
+			Expect(k8sClient.Create(context.Background(), hz)).Should(MatchError(ContainSubstring(expectedErrStr)))
+		})
+	})
+
 	Context("Hazelcast Expose externaly", func() {
 		It("should validate MemberAccess for unisocket", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultSpecValues, ee)

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -102,9 +102,9 @@ var _ = Describe("Hazelcast webhook", func() {
 	})
 
 	Context("Hazelcast Cluster Size", func() {
-		It(fmt.Sprintf("should validate cluster size is not more than %d", hazelcastv1alpha1.ClusterSizeLimit), Label("fast"), func() {
+		It(fmt.Sprintf("should validate cluster size is not more than %d", n.ClusterSizeLimit), Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultSpecValues, ee)
-			requestedClusterSize := int32(hazelcastv1alpha1.ClusterSizeLimit + 1)
+			requestedClusterSize := int32(n.ClusterSizeLimit + 1)
 			spec.ClusterSize = &requestedClusterSize
 
 			hz := &hazelcastv1alpha1.Hazelcast{
@@ -112,7 +112,7 @@ var _ = Describe("Hazelcast webhook", func() {
 				Spec:       spec,
 			}
 
-			expectedErrStr := fmt.Sprintf(hazelcastv1alpha1.ClusterSizeLimitErrStr, requestedClusterSize, hazelcastv1alpha1.ClusterSizeLimit)
+			expectedErrStr := fmt.Sprintf(n.ClusterSizeLimitErrStr, requestedClusterSize, n.ClusterSizeLimit)
 			Expect(k8sClient.Create(context.Background(), hz)).Should(MatchError(ContainSubstring(expectedErrStr)))
 		})
 	})


### PR DESCRIPTION
## Description

This PR adds a validation to admission web-hook to check if request cluster size is not more than 300.

## User Impact

User won't be able to request a cluster size more than 300 members.
Fixes https://github.com/hazelcast/hazelcast-platform-operator/issues/11