### PR TITLE
[CN-685] Add support for Wan replication control over map deletion

### DIFF
--- a/api/v1alpha1/wanreplication_types.go
+++ b/api/v1alpha1/wanreplication_types.go
@@ -144,6 +144,10 @@ type WanReplicationStatus struct {
 }
 
 type WanReplicationMapStatus struct {
+	// ResourceName is the name of the Map CR
+	// +optional
+	ResourceName string `json:"resourceName,omitempty"`
+
 	// PublisherId is the ID used for WAN publisher ID
 	// +optional
 	PublisherId string `json:"publisherId,omitempty"`

--- a/config/crd/bases/hazelcast.com_wanreplications.yaml
+++ b/config/crd/bases/hazelcast.com_wanreplications.yaml
@@ -166,6 +166,9 @@ spec:
                     publisherId:
                       description: PublisherId is the ID used for WAN publisher ID
                       type: string
+                    resourceName:
+                      description: ResourceName is the name of the Map CR
+                      type: string
                     status:
                       description: Status is the status of WAN replication
                       type: string

--- a/controllers/hazelcast/cronhotbackup_controller.go
+++ b/controllers/hazelcast/cronhotbackup_controller.go
@@ -169,7 +169,10 @@ func (r *CronHotBackupReconciler) deleteDependentHotBackups(ctx context.Context,
 	for i := 0; i < len(hbl.Items); i++ {
 		i := i
 		g.Go(func() error {
-			return util.DeleteObject(groupCtx, r.Client, &hbl.Items[i])
+			if hbl.Items[i].GetDeletionTimestamp() == nil {
+				return util.DeleteObject(groupCtx, r.Client, &hbl.Items[i])
+			}
+			return nil
 		})
 	}
 

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -93,7 +93,6 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Check if the Hazelcast CR is marked to be deleted
 	if h.GetDeletionTimestamp() != nil {
 		// Execute finalizer's pre-delete function to cleanup ClusterRole
-		r.update(ctx, h, terminatingPhase(nil)) //nolint:errcheck
 		err = r.executeFinalizer(ctx, h, logger)
 		if err != nil {
 			return r.update(ctx, h, terminatingPhase(err).withMessage(err.Error()))

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -109,7 +109,10 @@ func (r *HazelcastReconciler) deleteDependentCR(ctx context.Context, h *hazelcas
 	for i := 0; i < len(dsItems); i++ {
 		i := i
 		g.Go(func() error {
-			return util.DeleteObject(groupCtx, r.Client, dsItems[i])
+			if dsItems[i].GetDeletionTimestamp() == nil {
+				return util.DeleteObject(groupCtx, r.Client, dsItems[i])
+			}
+			return nil
 		})
 	}
 

--- a/controllers/hazelcast/hazelcast_status.go
+++ b/controllers/hazelcast/hazelcast_status.go
@@ -177,7 +177,7 @@ func (r *HazelcastReconciler) update(ctx context.Context, h *hazelcastv1alpha1.H
 		}
 		return ctrl.Result{}, err
 	}
-	if options.phase == hazelcastv1alpha1.Failed {
+	if options.err != nil {
 		return ctrl.Result{}, options.err
 	}
 	if options.phase == hazelcastv1alpha1.Pending {

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -122,7 +122,7 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
-	cl, err := GetHazelcastClient(ctx, r.clientRegistry, m.Spec.HazelcastResourceName, m.Namespace)
+	cl, err := getHazelcastClient(ctx, r.clientRegistry, m.Spec.HazelcastResourceName, m.Namespace)
 	if err != nil {
 		if errors.IsInternalError(err) {
 			return updateMapStatus(ctx, r.Client, m, failedStatus(err).
@@ -209,7 +209,7 @@ func ValidatePersistence(pe bool, h *hazelcastv1alpha1.Hazelcast) error {
 	return nil
 }
 
-func GetHazelcastClient(ctx context.Context, cs hzclient.ClientRegistry, hzName, hzNamespace string) (hzclient.Client, error) {
+func getHazelcastClient(ctx context.Context, cs hzclient.ClientRegistry, hzName, hzNamespace string) (hzclient.Client, error) {
 	hzcl, err := cs.GetOrCreate(ctx, types.NamespacedName{Name: hzName, Namespace: hzNamespace})
 	if err != nil {
 		return nil, errors.NewInternalError(fmt.Errorf("cannot connect to the cluster for %s", hzName))

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -122,7 +122,7 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
-	cl, err := GetHazelcastClient(ctx, r.clientRegistry, m)
+	cl, err := GetHazelcastClient(ctx, r.clientRegistry, m.Spec.HazelcastResourceName, m.Namespace)
 	if err != nil {
 		if errors.IsInternalError(err) {
 			return updateMapStatus(ctx, r.Client, m, failedStatus(err).
@@ -209,13 +209,13 @@ func ValidatePersistence(pe bool, h *hazelcastv1alpha1.Hazelcast) error {
 	return nil
 }
 
-func GetHazelcastClient(ctx context.Context, cs hzclient.ClientRegistry, m *hazelcastv1alpha1.Map) (hzclient.Client, error) {
-	hzcl, err := cs.GetOrCreate(ctx, types.NamespacedName{Name: m.Spec.HazelcastResourceName, Namespace: m.Namespace})
+func GetHazelcastClient(ctx context.Context, cs hzclient.ClientRegistry, hzName, hzNamespace string) (hzclient.Client, error) {
+	hzcl, err := cs.GetOrCreate(ctx, types.NamespacedName{Name: hzName, Namespace: hzNamespace})
 	if err != nil {
-		return nil, errors.NewInternalError(fmt.Errorf("cannot connect to the cluster for %s", m.Spec.HazelcastResourceName))
+		return nil, errors.NewInternalError(fmt.Errorf("cannot connect to the cluster for %s", hzName))
 	}
 	if !hzcl.Running() {
-		return nil, fmt.Errorf("trying to connect to the cluster %s", m.Spec.HazelcastResourceName)
+		return nil, fmt.Errorf("trying to connect to the cluster %s", hzName)
 	}
 
 	return hzcl, nil

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -3,7 +3,6 @@ package hazelcast
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -214,7 +213,7 @@ func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ct
 			}
 			if err := r.Get(ctx, nn, m); err != nil {
 				if kerrors.IsNotFound(err) {
-					logger.V(util.DebugLevel).Info("Could not find Map")
+					logger.V(util.DebugLevel).Info("Could not find Map ", nn.Name)
 				}
 				return err
 			}
@@ -226,7 +225,7 @@ func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ct
 			Name:      hzResourceName,
 		})
 		if !ok {
-			return errors.New("get Hazelcast Status Service failed")
+			return fmt.Errorf("get Hazelcast Status Service failed for Hazelcast CR %s", hzResourceName)
 		}
 
 		members := statusService.GetStatus().MemberDataMap

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -349,7 +349,24 @@ func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Conte
 			HZClientMap[resource.Name] = append(mapList, maps...)
 		}
 	}
+	for k, v := range HZClientMap {
+		HZClientMap[k] = removeDuplicate(v)
+	}
+
 	return HZClientMap, nil
+}
+
+func removeDuplicate(mapList []hazelcastv1alpha1.Map) []hazelcastv1alpha1.Map {
+	keySet := make(map[types.NamespacedName]struct{})
+	list := []hazelcastv1alpha1.Map{}
+	for _, item := range mapList {
+		nsname := types.NamespacedName{Name: item.Name, Namespace: item.Namespace}
+		if _, ok := keySet[nsname]; !ok {
+			keySet[nsname] = struct{}{}
+			list = append(list, item)
+		}
+	}
+	return list
 }
 
 func (r *WanReplicationReconciler) getAllMapsInHazelcast(ctx context.Context, hazelcastResourceName string, wanNamespace string) ([]hazelcastv1alpha1.Map, error) {

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -231,7 +231,7 @@ func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan 
 
 	mapWanStatus := make(map[string]wanOptionsBuilder)
 	for hzResourceName, maps := range HZClientMap {
-		cl, err := GetHazelcastClient(ctx, r.clientRegistry, &maps[0])
+		cl, err := GetHazelcastClient(ctx, r.clientRegistry, hzResourceName, wan.Namespace)
 		if err != nil {
 			return err
 		}
@@ -431,8 +431,7 @@ func (r *WanReplicationReconciler) stopWanReplication(ctx context.Context, wan *
 	log := getLogger(ctx)
 
 	for hzResourceName, maps := range HZClientMap {
-
-		cli, err := GetHazelcastClient(ctx, r.clientRegistry, &maps[0])
+		cli, err := GetHazelcastClient(ctx, r.clientRegistry, hzResourceName, wan.Namespace)
 		if err != nil {
 			return err
 		}
@@ -472,7 +471,7 @@ func stopWanRepForRemovedResources(ctx context.Context, wan *hazelcastv1alpha1.W
 		if ok {
 			continue
 		}
-		cli, err := GetHazelcastClient(ctx, cs, &m)
+		cli, err := GetHazelcastClient(ctx, cs, m.Spec.HazelcastResourceName, m.Namespace)
 		if err != nil {
 			return err
 		}

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -7,16 +7,21 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	"github.com/hazelcast/hazelcast-platform-operator/internal/config"
@@ -71,7 +76,6 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if !controllerutil.ContainsFinalizer(wan, n.Finalizer) && wan.GetDeletionTimestamp().IsZero() {
 		controllerutil.AddFinalizer(wan, n.Finalizer)
-		logger.Info("Adding finalizer")
 		if err := r.Update(ctx, wan); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -80,11 +84,9 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if !wan.GetDeletionTimestamp().IsZero() {
 		if controllerutil.ContainsFinalizer(wan, n.Finalizer) {
-			logger.Info("Deleting WAN configuration")
-			if err := r.stopWanReplication(ctx, wan); err != nil {
+			if err := r.stopWanReplicationAllMaps(ctx, wan); err != nil {
 				return updateWanStatus(ctx, r.Client, wan, wanTerminatingStatus().withMessage(err.Error()))
 			}
-			logger.Info("Deleting WAN configuration finalizer")
 			controllerutil.RemoveFinalizer(wan, n.Finalizer)
 			if err := r.Update(ctx, wan); err != nil {
 				return ctrl.Result{}, err
@@ -98,33 +100,12 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
-	if !util.IsApplied(wan) {
-		if err := r.Update(ctx, insertLastAppliedSpec(wan)); err != nil {
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
-		} else {
-			return updateWanStatus(ctx, r.Client, wan, wanPendingStatus())
-		}
-	}
-
-	HZClientMap, err := r.getMapsGroupByHazelcastName(ctx, wan)
+	hzClientMap, err := r.getMapsGroupByHazelcastName(ctx, wan)
 	if err != nil {
 		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
-	s, createdBefore := wan.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]
-	if createdBefore {
-		ms, err := json.Marshal(wan.Spec)
-
-		if err != nil {
-			err = fmt.Errorf("error marshaling WanReplication as JSON: %w", err)
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
-		}
-
-		if s == string(ms) {
-			logger.Info("WanReplication Config was already applied.", "name", wan.Name, "namespace", wan.Namespace)
-			return updateWanStatus(ctx, r.Client, wan, wanSuccessStatus())
-		}
-
+	if s, successfullyAppliedBefore := wan.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]; successfullyAppliedBefore {
 		lastSpec := &hazelcastv1alpha1.WanReplicationSpec{}
 		err = json.Unmarshal([]byte(s), lastSpec)
 		if err != nil {
@@ -136,31 +117,33 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err != nil {
 			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		}
-
-		err = stopWanRepForRemovedResources(ctx, wan, HZClientMap, r.clientRegistry)
-		if err != nil {
-			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
-		}
-
 	}
 
-	err = r.startWanReplication(ctx, wan, HZClientMap)
+	err = r.stopWanRepForRemovedResources(ctx, wan, hzClientMap, r.clientRegistry)
 	if err != nil {
+		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
+	}
+
+	err = r.cleanupTerminatingMaps(ctx, wan, hzClientMap)
+	if err != nil {
+		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
+	}
+
+	if err := r.startWanReplication(ctx, wan, hzClientMap); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	requeue, err := updateWanStatus(ctx, r.Client, wan, wanPersistingStatus(retryAfter).withMessage("Persisting the applied map config."))
-	if err != nil {
-		return requeue, err
+	if err := r.addWanRepFinalizerToReplicatedMaps(ctx, wan, hzClientMap); err != nil {
+		return ctrl.Result{}, err
 	}
 
-	persisted, err := r.validateWanConfigPersistence(ctx, wan, HZClientMap)
+	persisted, err := r.validateWanConfigPersistence(ctx, wan, hzClientMap)
 	if err != nil {
 		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
 	if !persisted {
-		return updateWanStatus(ctx, r.Client, wan, wanPersistingStatus(retryAfter).withMessage("Waiting for Wan Config to be persisted."))
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	if util.IsPhoneHomeEnabled() && !util.IsSuccessfullyApplied(wan) {
@@ -173,7 +156,51 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
-	return updateWanStatus(ctx, r.Client, wan, wanSuccessStatus())
+	return ctrl.Result{}, nil
+}
+
+func (r *WanReplicationReconciler) stopWanReplicationAllMaps(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) error {
+	hzMaps, err := r.getMapsFromStatus(ctx, wan)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range hzMaps {
+		cli, err := GetHazelcastClient(ctx, r.clientRegistry, m.Spec.HazelcastResourceName, m.Namespace)
+		if err != nil {
+			return err
+		}
+
+		// finalizer deletion and WanReplication map status deletion must be atomic, otherwise WanReplication can enter a faulty state.
+		err = r.stopWanReplicationMap(ctx, wan, &m, cli)
+		if err != nil {
+			return err
+		}
+		if err := deleteWanMapStatus(ctx, r.Client, wan, wanMapKey(m.Spec.HazelcastResourceName, m.MapName()), false); err != nil {
+			return err
+		}
+	}
+
+	if len := len(wan.Status.WanReplicationMapsStatus); len != 0 {
+		return fmt.Errorf("Not all maps are finalized, number of left maps is %d", len)
+	}
+	return nil
+}
+
+func (r *WanReplicationReconciler) getMapsFromStatus(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) ([]hazelcastv1alpha1.Map, error) {
+	hzMaps := make([]hazelcastv1alpha1.Map, 0)
+	for _, status := range wan.Status.WanReplicationMapsStatus {
+		if status.PublisherId == "" {
+			continue
+		}
+		m, err := r.getWanMap(ctx, types.NamespacedName{Name: status.ResourceName, Namespace: wan.Namespace})
+		if err != nil {
+			return nil, err
+		}
+		hzMaps = append(hzMaps, *m)
+	}
+
+	return hzMaps, nil
 }
 
 func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ctrl.Request, wan *hazelcastv1alpha1.WanReplication, logger logr.Logger) error {
@@ -226,11 +253,218 @@ func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ct
 	return nil
 }
 
-func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, HZClientMap map[string][]hazelcastv1alpha1.Map) error {
+func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) (map[string][]hazelcastv1alpha1.Map, error) {
+	hzClientMap := make(map[string][]hazelcastv1alpha1.Map)
+	for _, resource := range wan.Spec.Resources {
+		switch resource.Kind {
+		case hazelcastv1alpha1.ResourceKindMap:
+			m, err := r.getWanMap(ctx, types.NamespacedName{Name: resource.Name, Namespace: wan.Namespace})
+			if err != nil {
+				return nil, err
+			}
+			mapList, ok := hzClientMap[m.Spec.HazelcastResourceName]
+			if !ok {
+				hzClientMap[m.Spec.HazelcastResourceName] = []hazelcastv1alpha1.Map{*m}
+			}
+			hzClientMap[m.Spec.HazelcastResourceName] = append(mapList, *m)
+		case hazelcastv1alpha1.ResourceKindHZ:
+			maps, err := r.getAllMapsInHazelcast(ctx, resource.Name, wan.Namespace)
+			if err != nil {
+				return nil, err
+			}
+			// If no map is present for the Hazelcast resource
+			if len(maps) == 0 {
+				continue
+			}
+			mapList, ok := hzClientMap[resource.Name]
+			if !ok {
+				hzClientMap[resource.Name] = maps
+			}
+			hzClientMap[resource.Name] = append(mapList, maps...)
+		}
+	}
+	for k, v := range hzClientMap {
+		hzClientMap[k] = removeDuplicate(v)
+	}
+
+	return hzClientMap, nil
+}
+
+func (r *WanReplicationReconciler) getWanMap(ctx context.Context, lk types.NamespacedName) (*hazelcastv1alpha1.Map, error) {
+	m := &hazelcastv1alpha1.Map{}
+	if err := r.Client.Get(ctx, lk, m); err != nil {
+		return nil, fmt.Errorf("failed to get Map CR from WanReplication: %w", err)
+	}
+
+	return m, nil
+}
+
+func (r *WanReplicationReconciler) getAllMapsInHazelcast(ctx context.Context, hazelcastResourceName string, wanNamespace string) ([]hazelcastv1alpha1.Map, error) {
+	fieldMatcher := client.MatchingFields{"hazelcastResourceName": hazelcastResourceName}
+	nsMatcher := client.InNamespace(wanNamespace)
+
+	wrl := &hazelcastv1alpha1.MapList{}
+
+	if err := r.Client.List(ctx, wrl, fieldMatcher, nsMatcher); err != nil {
+		return nil, fmt.Errorf("could not get Map resources dependent under given Hazelcast %w", err)
+	}
+	return wrl.Items, nil
+}
+
+func removeDuplicate(mapList []hazelcastv1alpha1.Map) []hazelcastv1alpha1.Map {
+	keySet := make(map[types.NamespacedName]struct{})
+	list := []hazelcastv1alpha1.Map{}
+	for _, item := range mapList {
+		nsname := types.NamespacedName{Name: item.Name, Namespace: item.Namespace}
+		if _, ok := keySet[nsname]; !ok {
+			keySet[nsname] = struct{}{}
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
+func (r *WanReplicationReconciler) stopWanReplicationMap(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, m *hazelcastv1alpha1.Map, cli hzclient.Client) error {
+	log := getLogger(ctx)
+
+	mapWanKey := wanMapKey(m.Spec.HazelcastResourceName, m.MapName())
+	// Check publisherId is registered to the status, otherwise issue WanReplication to Hazelcast
+	publisherId := wan.Status.WanReplicationMapsStatus[mapWanKey].PublisherId
+	if publisherId == "" {
+		log.V(util.DebugLevel).Info("publisherId is empty, will skip stopping WAN replication", "mapKey", mapWanKey)
+		return nil
+	}
+	ws := hzclient.NewWanService(cli, wanName(m.MapName()), publisherId)
+
+	if err := ws.ChangeWanState(ctx, codecTypes.WanReplicationStateStopped); err != nil {
+		return err
+	}
+	if err := ws.ClearWanQueue(ctx); err != nil {
+		return err
+	}
+	if err := r.removeOwnerReference(ctx, wan, m, cli); err != nil {
+		return err
+	}
+	if err := r.removeWanRepFinalizerFromMap(ctx, wan, m, cli); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *WanReplicationReconciler) removeWanRepFinalizerFromMap(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, m *hazelcastv1alpha1.Map, cli hzclient.Client) error {
+	if !controllerutil.ContainsFinalizer(m, n.WanRepMapFinalizer) {
+		return nil
+	}
+
+	controllerutil.RemoveFinalizer(m, n.WanRepMapFinalizer)
+	if err := r.Update(ctx, m); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *WanReplicationReconciler) removeOwnerReference(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, m *hazelcastv1alpha1.Map, cli hzclient.Client) error {
+	newOwnerRef := []metav1.OwnerReference{}
+	for _, owner := range m.OwnerReferences {
+		if owner.Kind == wan.Kind && owner.Name == wan.Name && owner.UID == wan.UID {
+			continue
+		}
+		newOwnerRef = append(newOwnerRef, owner)
+	}
+
+	if len(newOwnerRef) == len(m.OwnerReferences) {
+		return nil
+	}
+
+	m.OwnerReferences = newOwnerRef
+	if err := r.Update(ctx, m); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateNotUpdatableFields(current *hazelcastv1alpha1.WanReplicationSpec, last *hazelcastv1alpha1.WanReplicationSpec) error {
+	if current.TargetClusterName != last.TargetClusterName {
+		return fmt.Errorf("targetClusterName cannot be updated")
+	}
+	if current.Endpoints != last.Endpoints {
+		return fmt.Errorf("endpoints cannot be updated")
+	}
+	if current.Queue != last.Queue {
+		return fmt.Errorf("queue cannot be updated")
+	}
+	if current.Batch != last.Batch {
+		return fmt.Errorf("batch cannot be updated")
+	}
+	if current.Acknowledgement != last.Acknowledgement {
+		return fmt.Errorf("acknowledgement cannot be updated")
+	}
+	return nil
+}
+
+func (r *WanReplicationReconciler) stopWanRepForRemovedResources(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, hzClientMap map[string][]hazelcastv1alpha1.Map, cs hzclient.ClientRegistry) error {
+	mapsInSpec := make(map[string]hazelcastv1alpha1.Map)
+	for hzName, maps := range hzClientMap {
+		for _, m := range maps {
+			mapsInSpec[wanMapKey(hzName, m.MapName())] = m
+		}
+	}
+
+	for mapWanKey, status := range wan.Status.WanReplicationMapsStatus {
+		_, ok := mapsInSpec[mapWanKey]
+		if ok {
+			continue
+		}
+		// Map is deleted from spec, stop replication.
+		m, err := r.getWanMap(ctx, types.NamespacedName{Name: status.ResourceName, Namespace: wan.Namespace})
+		if err != nil {
+			return err
+		}
+		cli, err := GetHazelcastClient(ctx, cs, m.Spec.HazelcastResourceName, m.Namespace)
+		if err != nil {
+			return err
+		}
+		// finalizer deletion and WanReplication map status deletion must be atomic, otherwise WanReplication can enter a faulty state.
+		if err = r.stopWanReplicationMap(ctx, wan, m, cli); err != nil {
+			return err
+		}
+		if err := deleteWanMapStatus(ctx, r.Client, wan, mapWanKey, false); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *WanReplicationReconciler) cleanupTerminatingMaps(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, hzClientMap map[string][]hazelcastv1alpha1.Map) error {
+	for hzResourceName, maps := range hzClientMap {
+		cli, err := GetHazelcastClient(ctx, r.clientRegistry, hzResourceName, wan.Namespace)
+		if err != nil {
+			return err
+		}
+
+		for _, m := range maps {
+			if m.Status.State != hazelcastv1alpha1.MapTerminating {
+				continue
+			}
+			// finalizer deletion and WanReplication map status deletion must be atomic, otherwise WanReplication can enter a faulty state.
+			err = r.stopWanReplicationMap(ctx, wan, &m, cli)
+			if err != nil {
+				return err
+			}
+			if err := deleteWanMapStatus(ctx, r.Client, wan, wanMapKey(hzResourceName, m.MapName()), false); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, hzClientMap map[string][]hazelcastv1alpha1.Map) error {
 	log := getLogger(ctx)
 
 	mapWanStatus := make(map[string]wanOptionsBuilder)
-	for hzResourceName, maps := range HZClientMap {
+	for hzResourceName, maps := range hzClientMap {
 		cl, err := GetHazelcastClient(ctx, r.clientRegistry, hzResourceName, wan.Namespace)
 		if err != nil {
 			return err
@@ -239,15 +473,27 @@ func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan 
 		for _, m := range maps {
 			mapWanKey := wanMapKey(hzResourceName, m.MapName())
 			// Check publisherId is registered to the status, otherwise issue WanReplication to Hazelcast
-			if wan.Status.WanReplicationMapsStatus[mapWanKey].PublisherId == "" {
-				log.Info("Applying WAN configuration for ", "mapKey", mapWanKey)
-				if publisherId, err := r.applyWanReplication(ctx, cl, wan, m.MapName(), mapWanKey); err != nil {
-					mapWanStatus[mapWanKey] = wanFailedStatus(err).withMessage(err.Error())
-				} else {
-					mapWanStatus[mapWanKey] = wanPersistingStatus(0).withPublisherId(publisherId)
-				}
-
+			if wan.Status.WanReplicationMapsStatus[mapWanKey].PublisherId != "" {
+				continue
 			}
+
+			if m.Status.State == hazelcastv1alpha1.MapTerminating {
+				log.Info("Not applying WAN configuration to terminating map for ", "mapKey", mapWanKey)
+				continue
+			}
+
+			if m.Status.State != hazelcastv1alpha1.MapSuccess {
+				log.Info("Not applying WAN configuration for ", "mapKey", mapWanKey, "because the map state is ", m.Status.State)
+				continue
+			}
+
+			log.Info("Applying WAN configuration for ", "mapKey", mapWanKey)
+			publisherId, err := r.applyWanReplication(ctx, cl, wan, m.MapName(), mapWanKey)
+			if err != nil {
+				mapWanStatus[mapWanKey] = wanFailedStatus(err).withMessage(err.Error())
+				continue
+			}
+			mapWanStatus[mapWanKey] = wanPersistingStatus(0).withPublisherId(publisherId).withResourceName(m.Name)
 		}
 	}
 
@@ -257,11 +503,93 @@ func (r *WanReplicationReconciler) startWanReplication(ctx context.Context, wan 
 	return nil
 }
 
-func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, HZClientMap map[string][]hazelcastv1alpha1.Map) (bool, error) {
+func wanMapKey(hzName, mapName string) string {
+	return hzName + "__" + mapName
+}
+
+func (r *WanReplicationReconciler) applyWanReplication(ctx context.Context, cli hzclient.Client, wan *hazelcastv1alpha1.WanReplication, mapName, mapWanKey string) (string, error) {
+	publisherId := wan.Name + "-" + mapWanKey
+
+	req := &hzclient.AddBatchPublisherRequest{
+		TargetCluster:         wan.Spec.TargetClusterName,
+		Endpoints:             wan.Spec.Endpoints,
+		QueueCapacity:         wan.Spec.Queue.Capacity,
+		BatchSize:             wan.Spec.Batch.Size,
+		BatchMaxDelayMillis:   wan.Spec.Batch.MaximumDelay,
+		ResponseTimeoutMillis: wan.Spec.Acknowledgement.Timeout,
+		AckType:               wan.Spec.Acknowledgement.Type,
+		QueueFullBehavior:     wan.Spec.Queue.FullBehavior,
+	}
+
+	ws := hzclient.NewWanService(cli, wanName(mapName), publisherId)
+	err := ws.AddBatchPublisherConfig(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to apply WAN configuration: %w", err)
+	}
+	return publisherId, nil
+}
+
+func wanName(mapName string) string {
+	return mapName + "-default"
+}
+
+func (r *WanReplicationReconciler) addWanRepFinalizerToReplicatedMaps(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, hzClientMap map[string][]hazelcastv1alpha1.Map) error {
+	for mapWanKey, status := range wan.Status.WanReplicationMapsStatus {
+		if status.PublisherId == "" {
+			continue
+		}
+		hzName, mapName := splitWanMapKey(mapWanKey)
+		m, found := findMapInSlice(hzClientMap[hzName], mapName)
+		if !found {
+			return fmt.Errorf("Map %s is not present in the Hazelcast Client Map", mapName)
+		}
+
+		// Set owner reference for reconciler to get triggered when map is marked to be deleted
+		// Wan Reconciler watches maps and filters map with owner references.
+		if err := controllerutil.SetOwnerReference(wan, m, r.Scheme); err != nil {
+			return err
+		}
+
+		if err := r.addWanRepFinalizerToMap(ctx, m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func splitWanMapKey(key string) (hzName string, mapName string) {
+	list := strings.Split(key, "__")
+	return list[0], list[1]
+}
+
+func findMapInSlice(slice []hazelcastv1alpha1.Map, mapName string) (*hazelcastv1alpha1.Map, bool) {
+	for i, mp := range slice {
+		if mp.Name == mapName {
+			return &slice[i], true
+		}
+	}
+	return nil, false
+}
+
+func (r *WanReplicationReconciler) addWanRepFinalizerToMap(ctx context.Context, m *hazelcastv1alpha1.Map) error {
+	if controllerutil.ContainsFinalizer(m, n.WanRepMapFinalizer) {
+		return nil
+	}
+
+	controllerutil.AddFinalizer(m, n.WanRepMapFinalizer)
+	if err := r.Update(ctx, m); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, hzClientMap map[string][]hazelcastv1alpha1.Map) (bool, error) {
 	cmMap := map[string]config.WanReplicationConfig{}
 
 	// Fill map with Wan configs for each map wan key
-	for hz := range HZClientMap {
+	for hz := range hzClientMap {
 		cm := &corev1.ConfigMap{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: hz, Namespace: wan.Namespace}, cm)
 		if err != nil {
@@ -300,7 +628,7 @@ func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Cont
 			continue
 		}
 
-		mapWanStatus[mapWanKey] = wanSuccessStatus().withPublisherId(v.PublisherId)
+		mapWanStatus[mapWanKey] = wanSuccessStatus().withPublisherId(v.PublisherId).withResourceName(v.ResourceName)
 	}
 
 	if err := putWanMapStatus(ctx, r.Client, wan, mapWanStatus); err != nil {
@@ -319,215 +647,8 @@ func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Cont
 
 }
 
-func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) (map[string][]hazelcastv1alpha1.Map, error) {
-	HZClientMap := make(map[string][]hazelcastv1alpha1.Map)
-	for _, resource := range wan.Spec.Resources {
-		switch resource.Kind {
-		case hazelcastv1alpha1.ResourceKindMap:
-			m, err := r.getWanMap(ctx, types.NamespacedName{Name: resource.Name, Namespace: wan.Namespace}, true)
-			if err != nil {
-				return nil, err
-			}
-			mapList, ok := HZClientMap[m.Spec.HazelcastResourceName]
-			if !ok {
-				HZClientMap[m.Spec.HazelcastResourceName] = []hazelcastv1alpha1.Map{*m}
-			}
-			HZClientMap[m.Spec.HazelcastResourceName] = append(mapList, *m)
-		case hazelcastv1alpha1.ResourceKindHZ:
-			maps, err := r.getAllMapsInHazelcast(ctx, resource.Name, wan.Namespace)
-			if err != nil {
-				return nil, err
-			}
-			// If no map is present for the Hazelcast resource
-			if len(maps) == 0 {
-				continue
-			}
-			mapList, ok := HZClientMap[resource.Name]
-			if !ok {
-				HZClientMap[resource.Name] = maps
-			}
-			HZClientMap[resource.Name] = append(mapList, maps...)
-		}
-	}
-	for k, v := range HZClientMap {
-		HZClientMap[k] = removeDuplicate(v)
-	}
-
-	return HZClientMap, nil
-}
-
-func removeDuplicate(mapList []hazelcastv1alpha1.Map) []hazelcastv1alpha1.Map {
-	keySet := make(map[types.NamespacedName]struct{})
-	list := []hazelcastv1alpha1.Map{}
-	for _, item := range mapList {
-		nsname := types.NamespacedName{Name: item.Name, Namespace: item.Namespace}
-		if _, ok := keySet[nsname]; !ok {
-			keySet[nsname] = struct{}{}
-			list = append(list, item)
-		}
-	}
-	return list
-}
-
-func (r *WanReplicationReconciler) getAllMapsInHazelcast(ctx context.Context, hazelcastResourceName string, wanNamespace string) ([]hazelcastv1alpha1.Map, error) {
-	fieldMatcher := client.MatchingFields{"hazelcastResourceName": hazelcastResourceName}
-	nsMatcher := client.InNamespace(wanNamespace)
-
-	wrl := &hazelcastv1alpha1.MapList{}
-
-	if err := r.Client.List(ctx, wrl, fieldMatcher, nsMatcher); err != nil {
-		return nil, fmt.Errorf("could not get Map resources dependent under given Hazelcast %w", err)
-	}
-	return wrl.Items, nil
-}
-
-func validateNotUpdatableFields(current *hazelcastv1alpha1.WanReplicationSpec, last *hazelcastv1alpha1.WanReplicationSpec) error {
-	if current.TargetClusterName != last.TargetClusterName {
-		return fmt.Errorf("targetClusterName cannot be updated")
-	}
-	if current.Endpoints != last.Endpoints {
-		return fmt.Errorf("endpoints cannot be updated")
-	}
-	if current.Queue != last.Queue {
-		return fmt.Errorf("queue cannot be updated")
-	}
-	if current.Batch != last.Batch {
-		return fmt.Errorf("batch cannot be updated")
-	}
-	if current.Acknowledgement != last.Acknowledgement {
-		return fmt.Errorf("acknowledgement cannot be updated")
-	}
-	return nil
-}
-
-func (r *WanReplicationReconciler) getWanMap(ctx context.Context, lk types.NamespacedName, checkSuccess bool) (*hazelcastv1alpha1.Map, error) {
-	m := &hazelcastv1alpha1.Map{}
-	if err := r.Client.Get(ctx, lk, m); err != nil {
-		if kerrors.IsNotFound(err) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("failed to get Map CR from WanReplication: %w", err)
-	}
-
-	if checkSuccess && m.Status.State != hazelcastv1alpha1.MapSuccess {
-		return nil, fmt.Errorf("status of map %s is not success", m.Name)
-	}
-
-	return m, nil
-
-}
-
-func (r *WanReplicationReconciler) applyWanReplication(ctx context.Context, cli hzclient.Client, wan *hazelcastv1alpha1.WanReplication, mapName, mapWanKey string) (string, error) {
-	publisherId := wan.Name + "-" + mapWanKey
-
-	req := &hzclient.AddBatchPublisherRequest{
-		TargetCluster:         wan.Spec.TargetClusterName,
-		Endpoints:             wan.Spec.Endpoints,
-		QueueCapacity:         wan.Spec.Queue.Capacity,
-		BatchSize:             wan.Spec.Batch.Size,
-		BatchMaxDelayMillis:   wan.Spec.Batch.MaximumDelay,
-		ResponseTimeoutMillis: wan.Spec.Acknowledgement.Timeout,
-		AckType:               wan.Spec.Acknowledgement.Type,
-		QueueFullBehavior:     wan.Spec.Queue.FullBehavior,
-	}
-
-	ws := hzclient.NewWanService(cli, wanName(mapName), publisherId)
-	err := ws.AddBatchPublisherConfig(ctx, req)
-	if err != nil {
-		return "", fmt.Errorf("failed to apply WAN configuration: %w", err)
-	}
-	return publisherId, nil
-}
-
-func (r *WanReplicationReconciler) stopWanReplication(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) error {
-	HZClientMap, err := r.getMapsGroupByHazelcastName(ctx, wan)
-	if err != nil {
-		return err
-	}
-
-	log := getLogger(ctx)
-
-	for hzResourceName, maps := range HZClientMap {
-		cli, err := GetHazelcastClient(ctx, r.clientRegistry, hzResourceName, wan.Namespace)
-		if err != nil {
-			return err
-		}
-
-		for _, m := range maps {
-			mapWanKey := wanMapKey(hzResourceName, m.MapName())
-			// Check publisherId is registered to the status, otherwise issue WanReplication to Hazelcast
-			publisherId := wan.Status.WanReplicationMapsStatus[mapWanKey].PublisherId
-			if publisherId == "" {
-				log.V(util.DebugLevel).Info("publisherId is empty, will skip stopping WAN replication", "mapKey", mapWanKey)
-				continue
-			}
-			ws := hzclient.NewWanService(cli, wanName(m.MapName()), publisherId)
-
-			if err := ws.ChangeWanState(ctx, codecTypes.WanReplicationStateStopped); err != nil {
-				return err
-			}
-			if err := ws.ClearWanQueue(ctx); err != nil {
-				return err
-			}
-			delete(wan.Status.WanReplicationMapsStatus, mapWanKey)
-		}
-	}
-	return nil
-}
-
-func stopWanRepForRemovedResources(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, HZClientMap map[string][]hazelcastv1alpha1.Map, cs hzclient.ClientRegistry) error {
-	tempMapSet := make(map[string]hazelcastv1alpha1.Map)
-	for hzName, maps := range HZClientMap {
-		for _, m := range maps {
-			tempMapSet[wanMapKey(hzName, m.MapName())] = m
-		}
-	}
-
-	for mapWanKey, status := range wan.Status.WanReplicationMapsStatus {
-		m, ok := tempMapSet[mapWanKey]
-		if ok {
-			continue
-		}
-		cli, err := GetHazelcastClient(ctx, cs, m.Spec.HazelcastResourceName, m.Namespace)
-		if err != nil {
-			return err
-		}
-		ws := hzclient.NewWanService(cli, wanName(m.MapName()), status.PublisherId)
-		if err := ws.ChangeWanState(ctx, codecTypes.WanReplicationStateStopped); err != nil {
-			return err
-		}
-		if err := ws.ClearWanQueue(ctx); err != nil {
-			return err
-		}
-		delete(wan.Status.WanReplicationMapsStatus, mapWanKey)
-	}
-	return nil
-}
-
-func wanMapKey(hzName, mapName string) string {
-	return hzName + "__" + mapName
-}
-
-func splitWanMapKey(key string) (hzName string, mapName string) {
-	list := strings.Split(key, "__")
-	return list[0], list[1]
-}
-
-func wanName(mapName string) string {
-	return mapName + "-default"
-}
-
 func splitWanName(name string) string {
 	return strings.TrimSuffix(name, "-default")
-}
-
-func insertLastAppliedSpec(wan *hazelcastv1alpha1.WanReplication) *hazelcastv1alpha1.WanReplication {
-	b, _ := json.Marshal(wan.Spec)
-	if wan.Annotations == nil {
-		wan.Annotations = make(map[string]string)
-	}
-	wan.Annotations[n.LastAppliedSpecAnnotation] = string(b)
-	return wan
 }
 
 func (r *WanReplicationReconciler) updateLastSuccessfulConfiguration(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) error {
@@ -562,5 +683,38 @@ func getLogger(ctx context.Context) logr.Logger {
 func (r *WanReplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hazelcastv1alpha1.WanReplication{}).
+		Watches(&source.Kind{Type: &hazelcastv1alpha1.Map{}}, handler.EnqueueRequestsFromMapFunc(r.terminatingMapUpdates)).
 		Complete(r)
+}
+
+func (r *WanReplicationReconciler) terminatingMapUpdates(m client.Object) []reconcile.Request {
+	mp, ok := m.(*hazelcastv1alpha1.Map)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	if mp.Status.State != hazelcastv1alpha1.MapTerminating {
+		return []reconcile.Request{}
+	}
+
+	// If map reconciler did not delete its finalizer yet
+	for _, finalizer := range mp.Finalizers {
+		if finalizer == n.Finalizer {
+			return []reconcile.Request{}
+		}
+	}
+
+	reqs := []reconcile.Request{}
+	for _, owner := range mp.OwnerReferences {
+		if owner.Kind == "WanReplication" {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      owner.Name,
+					Namespace: mp.GetNamespace(),
+				},
+			})
+		}
+	}
+
+	return reqs
 }

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -213,7 +213,7 @@ func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ct
 			}
 			if err := r.Get(ctx, nn, m); err != nil {
 				if kerrors.IsNotFound(err) {
-					logger.V(util.DebugLevel).Info("Could not find Map ", nn.Name)
+					logger.V(util.DebugLevel).Info("Could not find", "Map", nn.Name)
 				}
 				return err
 			}

--- a/controllers/hazelcast/wanreplication_status.go
+++ b/controllers/hazelcast/wanreplication_status.go
@@ -12,23 +12,18 @@ import (
 )
 
 type wanOptionsBuilder struct {
-	publisherId string
-	err         error
-	status      hazelcastv1alpha1.WanStatus
-	message     string
-	retryAfter  time.Duration
+	publisherId  string
+	err          error
+	status       hazelcastv1alpha1.WanStatus
+	message      string
+	resourceName string
+	retryAfter   time.Duration
 }
 
 func wanFailedStatus(err error) wanOptionsBuilder {
 	return wanOptionsBuilder{
 		status: hazelcastv1alpha1.WanStatusFailed,
 		err:    err,
-	}
-}
-
-func wanPendingStatus() wanOptionsBuilder {
-	return wanOptionsBuilder{
-		status: hazelcastv1alpha1.WanStatusPending,
 	}
 }
 
@@ -88,6 +83,11 @@ func (o wanOptionsBuilder) withPublisherId(hz string) wanOptionsBuilder {
 	return o
 }
 
+func (o wanOptionsBuilder) withResourceName(rn string) wanOptionsBuilder {
+	o.resourceName = rn
+	return o
+}
+
 func (o wanOptionsBuilder) withMessage(msg string) wanOptionsBuilder {
 	o.message = msg
 	return o
@@ -120,16 +120,37 @@ func putWanMapStatus(ctx context.Context, c client.Client, wan *hazelcastv1alpha
 
 	for mapWanKey, builder := range options {
 		wan.Status.WanReplicationMapsStatus[mapWanKey] = hazelcastv1alpha1.WanReplicationMapStatus{
-			PublisherId: builder.publisherId,
-			Message:     builder.message,
-			Status:      builder.status,
+			PublisherId:  builder.publisherId,
+			Message:      builder.message,
+			Status:       builder.status,
+			ResourceName: builder.resourceName,
 		}
 	}
 
 	wan.Status.Status = wanStatus(wan.Status.WanReplicationMapsStatus)
+	if wan.Status.Status == hazelcastv1alpha1.WanStatusSuccess {
+		wan.Status.Message = ""
+	}
 
 	if err := c.Status().Update(ctx, wan); err != nil {
 		if errors.IsConflict(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func deleteWanMapStatus(ctx context.Context, c client.Client, wan *hazelcastv1alpha1.WanReplication, mapWanKey string, conflictOk bool) error {
+	if wan.Status.WanReplicationMapsStatus == nil {
+		return nil
+	}
+
+	delete(wan.Status.WanReplicationMapsStatus, mapWanKey)
+
+	if err := c.Status().Update(ctx, wan); err != nil {
+		if conflictOk && errors.IsConflict(err) {
 			return nil
 		}
 		return err

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -4127,6 +4127,9 @@ spec:
                     publisherId:
                       description: PublisherId is the ID used for WAN publisher ID
                       type: string
+                    resourceName:
+                      description: ResourceName is the name of the Map CR
+                      type: string
                     status:
                       description: Status is the status of WAN replication
                       type: string

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -8,6 +8,8 @@ import (
 const (
 	// Finalizer name used by operator
 	Finalizer = "hazelcast.com/finalizer"
+	// Finalizer name used by operator to stop wan replication of a map
+	WanRepMapFinalizer = "hazelcast.com/wan-replicated-map"
 	// LicenseDataKey is a key used in k8s secret that holds the Hazelcast license
 	LicenseDataKey = "license-key"
 	// LicenseKeySecret default license key secret

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -441,6 +441,21 @@ var (
 		}
 	}
 
+	WanReplication = func(wan types.NamespacedName, targetClusterName, endpoints string, resources []hazelcastv1alpha1.ResourceSpec, lbls map[string]string) *hazelcastv1alpha1.WanReplication {
+		return &hazelcastv1alpha1.WanReplication{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      wan.Name,
+				Namespace: wan.Namespace,
+				Labels:    lbls,
+			},
+			Spec: hazelcastv1alpha1.WanReplicationSpec{
+				TargetClusterName: targetClusterName,
+				Endpoints:         endpoints,
+				Resources:         resources,
+			},
+		}
+	}
+
 	DefaultMultiMap = func(lk types.NamespacedName, hzName string, lbls map[string]string) *hazelcastv1alpha1.MultiMap {
 		return &hazelcastv1alpha1.MultiMap{
 			ObjectMeta: v1.ObjectMeta{

--- a/test/e2e/custom_resource_test.go
+++ b/test/e2e/custom_resource_test.go
@@ -50,7 +50,7 @@ func setCRNamespace(ns string) {
 	targetLookupKey2.Namespace = targetNamespace
 }
 
-func setLabelAndCRName(n string) {
+func setLabelAndCRName(n string) string {
 	n = n + "-" + randString(6)
 	By(fmt.Sprintf("setting the label and CR with name '%s'", n))
 	labels["test_suite"] = n
@@ -71,6 +71,7 @@ func setLabelAndCRName(n string) {
 	targetLookupKey.Name = "trg-" + n
 	targetLookupKey2.Name = "trg-2-" + n
 	AddReportEntry("CR_ID:" + n)
+	return n
 }
 
 const charset = "abcdefghijklmnopqrstuvwxyz" +

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -65,294 +65,294 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		waitForMapSizePortForward(context.Background(), hzCrs[hzTrgLookupKey.Name], localPort, mapLookupKey.Name, mapSize, 1*Minute)
 	})
 
-	When("All pods are deleted",
-		It("should send data to another cluster using ConfigMap configuration", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			setLabelAndCRName("hw-2")
+	//When("All pods are deleted",
+	It("should send data to another cluster using ConfigMap configuration", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		setLabelAndCRName("hw-2")
 
-			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
-				hzSrcLookupKey.Name: {mapLookupKey.Name},
-				hzTrgLookupKey.Name: nil,
-			}, hzSrcLookupKey.Namespace, labels)
+		hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+			hzSrcLookupKey.Name: {mapLookupKey.Name},
+			hzTrgLookupKey.Name: nil,
+		}, hzSrcLookupKey.Namespace, labels)
 
-			By("creating WAN configuration")
-			createWanConfig(context.Background(), wanLookupKey, hzCrs[hzTrgLookupKey.Name],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: mapLookupKey.Name},
-				}, 1, labels)
+		By("creating WAN configuration")
+		createWanConfig(context.Background(), wanLookupKey, hzCrs[hzTrgLookupKey.Name],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: mapLookupKey.Name},
+			}, 1, labels)
 
-			deletePods(hzSrcLookupKey)
-			// Wait for pod to be deleted
-			Sleep(5 * Second)
-			evaluateReadyMembers(hzSrcLookupKey)
+		deletePods(hzSrcLookupKey)
+		// Wait for pod to be deleted
+		Sleep(5 * Second)
+		evaluateReadyMembers(hzSrcLookupKey)
 
-			By("checking the size of the maps in the target cluster")
-			mapSize := 1024
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSrcLookupKey.Name], localPort, mapLookupKey.Name, mapSize)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTrgLookupKey.Name], localPort, mapLookupKey.Name, mapSize, 1*Minute)
-		}))
+		By("checking the size of the maps in the target cluster")
+		mapSize := 1024
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSrcLookupKey.Name], localPort, mapLookupKey.Name, mapSize)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTrgLookupKey.Name], localPort, mapLookupKey.Name, mapSize, 1*Minute)
+	})
 
-	When("Multiple WanReplication resources with multiple maps exist",
-		It("should replicate maps to target cluster ", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			suffix := setLabelAndCRName("hw-3")
+	//When("Multiple WanReplication resources with multiple maps exist",
+	It("should replicate maps to target cluster ", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		suffix := setLabelAndCRName("hw-3")
 
-			// Hazelcast and Map CRs
-			hzSource1 := "hz1-source" + suffix
-			map11 := "map11" + suffix
-			map12 := "map12" + suffix
+		// Hazelcast and Map CRs
+		hzSource1 := "hz1-source" + suffix
+		map11 := "map11" + suffix
+		map12 := "map12" + suffix
 
-			hzSource2 := "hz2-source" + suffix
-			map21 := "map21" + suffix
+		hzSource2 := "hz2-source" + suffix
+		map21 := "map21" + suffix
 
-			hzTarget1 := "hz1-target" + suffix
+		hzTarget1 := "hz1-target" + suffix
 
-			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
-				hzSource1: {map11, map12},
-				hzSource2: {map21},
-				hzTarget1: nil,
-			}, hzSrcLookupKey.Namespace, labels)
+		hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+			hzSource1: {map11, map12},
+			hzSource2: {map21},
+			hzTarget1: nil,
+		}, hzSrcLookupKey.Namespace, labels)
 
-			By("creating first WAN configuration")
-			createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
-					{Name: hzSource2, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-				}, 2, labels)
+		By("creating first WAN configuration")
+		createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+				{Name: hzSource2, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+			}, 2, labels)
 
-			By("creating second WAN configuration")
-			createWanConfig(context.Background(), types.NamespacedName{Name: "wan2" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: map12},
-				}, 1, labels)
+		By("creating second WAN configuration")
+		createWanConfig(context.Background(), types.NamespacedName{Name: "wan2" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: map12},
+			}, 1, labels)
 
-			By("filling the maps in the source clusters")
-			mapSize := 10
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, mapSize)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, mapSize)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, mapSize)
+		By("filling the maps in the source clusters")
+		mapSize := 10
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, mapSize)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, mapSize)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, mapSize)
 
-			By("checking the size of the maps in the target cluster")
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, mapSize, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, mapSize, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, mapSize, 1*Minute)
-		}))
+		By("checking the size of the maps in the target cluster")
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, mapSize, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, mapSize, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, mapSize, 1*Minute)
+	})
 
-	When("Wan replicated Map CR is deleted which was given as a Map resource in Wan spec",
-		It("should delete the map from status and Wan status should be failed", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			suffix := setLabelAndCRName("hw-4")
+	//When("Wan replicated Map CR is deleted which was given as a Map resource in Wan spec",
+	It("should delete the map from status and Wan status should be failed", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		suffix := setLabelAndCRName("hw-4")
 
-			// Hazelcast and Map CRs
-			hzSource1 := "hz1-source" + suffix
-			map11 := "map11" + suffix
+		// Hazelcast and Map CRs
+		hzSource1 := "hz1-source" + suffix
+		map11 := "map11" + suffix
 
-			hzTarget1 := "hz1-target" + suffix
+		hzTarget1 := "hz1-target" + suffix
 
-			hzCrs, mapCrs := createWanResources(context.Background(), map[string][]string{
-				hzSource1: {map11},
-				hzTarget1: nil,
-			}, hzSrcLookupKey.Namespace, labels)
+		hzCrs, mapCrs := createWanResources(context.Background(), map[string][]string{
+			hzSource1: {map11},
+			hzTarget1: nil,
+		}, hzSrcLookupKey.Namespace, labels)
 
-			By("creating first WAN configuration")
-			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
-				}, 1, labels)
+		By("creating first WAN configuration")
+		wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+			}, 1, labels)
 
-			Expect(k8sClient.Delete(context.Background(), mapCrs[map11])).Should(BeNil())
-			assertObjectDoesNotExist(mapCrs[map11])
-			wan = assertWanStatusMapCount(wan, 0)
-			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusFailed)
+		Expect(k8sClient.Delete(context.Background(), mapCrs[map11])).Should(BeNil())
+		assertObjectDoesNotExist(mapCrs[map11])
+		wan = assertWanStatusMapCount(wan, 0)
+		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusFailed)
 
-			Expect(k8sClient.Delete(context.Background(), wan)).Should(BeNil())
-			assertObjectDoesNotExist(wan)
-		}))
+		Expect(k8sClient.Delete(context.Background(), wan)).Should(BeNil())
+		assertObjectDoesNotExist(wan)
+	})
 
-	When("Wan replicated Map CR is deleted which was given as a Hazelcast resource in Wan spec",
-		It("should delete the map from status and Wan status should be Pending", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			suffix := setLabelAndCRName("hw-5")
+	//When("Wan replicated Map CR is deleted which was given as a Hazelcast resource in Wan spec",
+	It("should delete the map from status and Wan status should be Pending", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		suffix := setLabelAndCRName("hw-5")
 
-			// Hazelcast and Map CRs
-			hzSource1 := "hz1-source" + suffix
-			map11 := "map11" + suffix
+		// Hazelcast and Map CRs
+		hzSource1 := "hz1-source" + suffix
+		map11 := "map11" + suffix
 
-			hzTarget1 := "hz1-target" + suffix
+		hzTarget1 := "hz1-target" + suffix
 
-			hzCrs, mapCrs := createWanResources(context.Background(), map[string][]string{
-				hzSource1: {map11},
-				hzTarget1: nil,
-			}, hzSrcLookupKey.Namespace, labels)
+		hzCrs, mapCrs := createWanResources(context.Background(), map[string][]string{
+			hzSource1: {map11},
+			hzTarget1: nil,
+		}, hzSrcLookupKey.Namespace, labels)
 
-			By("creating first WAN configuration")
-			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-				}, 1, labels)
-
-			Expect(k8sClient.Delete(context.Background(), mapCrs[map11])).Should(BeNil())
-			assertObjectDoesNotExist(mapCrs[map11])
-			wan = assertWanStatusMapCount(wan, 0)
-			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusPending)
-
-			Expect(k8sClient.Delete(context.Background(), wan)).Should(BeNil())
-			assertObjectDoesNotExist(wan)
-		}))
-
-	When("Wan replicated Hazelcast CR is deleted which was given as a Hazelcast resource in Wan spec",
-		It("should delete the maps from status and Wan status should be Pending ", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			suffix := setLabelAndCRName("hw-6")
-
-			// Hazelcast and Map CRs
-			hzSource1 := "hz1-source" + suffix
-			map11 := "map11" + suffix
-			map12 := "map12" + suffix
-			map13 := "map13" + suffix
-
-			hzSource2 := "hz2-source" + suffix
-			map21 := "map21" + suffix
-			map22 := "map22" + suffix
-
-			hzTarget1 := "hz1-target" + suffix
-
-			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
-				hzSource1: {map11, map12, map13},
-				hzSource2: {map21, map22},
-				hzTarget1: nil,
-			}, hzSrcLookupKey.Namespace, labels)
-
-			By("creating first WAN configuration")
-			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-					{Name: hzSource2, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-				}, 5, labels)
-
-			Expect(k8sClient.Delete(context.Background(), hzCrs[hzSource2])).Should(BeNil())
-			assertObjectDoesNotExist(hzCrs[hzSource2])
-			wan = assertWanStatusMapCount(wan, 3)
-			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-
-			Expect(k8sClient.Delete(context.Background(), hzCrs[hzSource1])).Should(BeNil())
-			assertObjectDoesNotExist(hzCrs[hzSource1])
-			wan = assertWanStatusMapCount(wan, 0)
-			_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusPending)
-		}))
-
-	When("Wan replicated maps are removed from Wan spec",
-		It("should stop replicating to target cluster", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			suffix := setLabelAndCRName("hw-7")
-
-			// Hazelcast and Map CRs
-			hzSource1 := "hz1-source" + suffix
-			map11 := "map11" + suffix
-			map12 := "map12" + suffix
-
-			hzSource2 := "hz2-source" + suffix
-			map21 := "map21" + suffix
-			map22 := "map22" + suffix
-
-			hzTarget1 := "hz1-target" + suffix
-
-			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
-				hzSource1: {map11, map12},
-				hzSource2: {map21, map22},
-				hzTarget1: nil,
-			}, hzSrcLookupKey.Namespace, labels)
-
-			By("creating first WAN configuration")
-			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-					{Name: map21, Kind: hazelcastcomv1alpha1.ResourceKindMap},
-					{Name: map22, Kind: hazelcastcomv1alpha1.ResourceKindMap},
-				}, 4, labels)
-
-			By("filling the maps in the source clusters")
-			entryCount := 10
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, entryCount)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, entryCount)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, entryCount)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map22, entryCount)
-
-			By("checking the size of the maps in the target cluster")
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, entryCount, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, entryCount, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, entryCount, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map22, entryCount, 1*Minute)
-
-			By("stopping replicating all maps but map22")
-
-			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-			wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
-				{Name: map22, Kind: hazelcastcomv1alpha1.ResourceKindMap},
-			}
-			Expect(k8sClient.Update(context.Background(), wan)).Should(BeNil())
-			wan = assertWanStatusMapCount(wan, 1)
-			_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-
-			currentSize := entryCount
-			newEntryCount := 50
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map22, newEntryCount)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, newEntryCount)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, newEntryCount)
-			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, newEntryCount)
-
-			By("checking the size of the maps in the target cluster")
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map22, currentSize+newEntryCount, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, currentSize, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, currentSize, 1*Minute)
-			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, currentSize, 1*Minute)
-		}))
-
-	When("Map is given twice in the Wan spec",
-		It("should continue replication if one reference is deleted ", Label("slow"), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			suffix := setLabelAndCRName("hw-8")
-
-			// Hazelcast and Map CRs
-			hzSource1 := "hz1-source" + suffix
-			map11 := "map11" + suffix
-			map12 := "map12" + suffix
-
-			hzTarget1 := "hz1-target" + suffix
-
-			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
-				hzSource1: {map11, map12},
-				hzTarget1: nil,
-			}, hzSrcLookupKey.Namespace, labels)
-
-			By("creating first WAN configuration")
-			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
-				[]hazelcastcomv1alpha1.ResourceSpec{
-					{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
-					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-				}, 2, labels)
-
-			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-			wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+		By("creating first WAN configuration")
+		wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
 				{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-			}
-			Expect(k8sClient.Update(context.Background(), wan)).Should(BeNil())
-			Sleep(5 * Second)
-			wan = assertWanStatusMapCount(wan, 2)
-			_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-		}))
+			}, 1, labels)
+
+		Expect(k8sClient.Delete(context.Background(), mapCrs[map11])).Should(BeNil())
+		assertObjectDoesNotExist(mapCrs[map11])
+		wan = assertWanStatusMapCount(wan, 0)
+		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusPending)
+
+		Expect(k8sClient.Delete(context.Background(), wan)).Should(BeNil())
+		assertObjectDoesNotExist(wan)
+	})
+
+	//When("Wan replicated Hazelcast CR is deleted which was given as a Hazelcast resource in Wan spec",
+	It("should delete the maps from status and Wan status should be Pending ", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		suffix := setLabelAndCRName("hw-6")
+
+		// Hazelcast and Map CRs
+		hzSource1 := "hz1-source" + suffix
+		map11 := "map11" + suffix
+		map12 := "map12" + suffix
+		map13 := "map13" + suffix
+
+		hzSource2 := "hz2-source" + suffix
+		map21 := "map21" + suffix
+		map22 := "map22" + suffix
+
+		hzTarget1 := "hz1-target" + suffix
+
+		hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+			hzSource1: {map11, map12, map13},
+			hzSource2: {map21, map22},
+			hzTarget1: nil,
+		}, hzSrcLookupKey.Namespace, labels)
+
+		By("creating first WAN configuration")
+		wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+				{Name: hzSource2, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+			}, 5, labels)
+
+		Expect(k8sClient.Delete(context.Background(), hzCrs[hzSource2])).Should(BeNil())
+		assertObjectDoesNotExist(hzCrs[hzSource2])
+		wan = assertWanStatusMapCount(wan, 3)
+		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+
+		Expect(k8sClient.Delete(context.Background(), hzCrs[hzSource1])).Should(BeNil())
+		assertObjectDoesNotExist(hzCrs[hzSource1])
+		wan = assertWanStatusMapCount(wan, 0)
+		_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusPending)
+	})
+
+	//When("Wan replicated maps are removed from Wan spec",
+	It("should stop replicating to target cluster", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		suffix := setLabelAndCRName("hw-7")
+
+		// Hazelcast and Map CRs
+		hzSource1 := "hz1-source" + suffix
+		map11 := "map11" + suffix
+		map12 := "map12" + suffix
+
+		hzSource2 := "hz2-source" + suffix
+		map21 := "map21" + suffix
+		map22 := "map22" + suffix
+
+		hzTarget1 := "hz1-target" + suffix
+
+		hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+			hzSource1: {map11, map12},
+			hzSource2: {map21, map22},
+			hzTarget1: nil,
+		}, hzSrcLookupKey.Namespace, labels)
+
+		By("creating first WAN configuration")
+		wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+				{Name: map21, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+				{Name: map22, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+			}, 4, labels)
+
+		By("filling the maps in the source clusters")
+		entryCount := 10
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, entryCount)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, entryCount)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, entryCount)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map22, entryCount)
+
+		By("checking the size of the maps in the target cluster")
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, entryCount, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, entryCount, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, entryCount, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map22, entryCount, 1*Minute)
+
+		By("stopping replicating all maps but map22")
+
+		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+		wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+			{Name: map22, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+		}
+		Expect(k8sClient.Update(context.Background(), wan)).Should(BeNil())
+		wan = assertWanStatusMapCount(wan, 1)
+		_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+
+		currentSize := entryCount
+		newEntryCount := 50
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map22, newEntryCount)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, newEntryCount)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, newEntryCount)
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, newEntryCount)
+
+		By("checking the size of the maps in the target cluster")
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map22, currentSize+newEntryCount, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, currentSize, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, currentSize, 1*Minute)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, currentSize, 1*Minute)
+	})
+
+	//When("Map is given twice in the Wan spec",
+	It("should continue replication if one reference is deleted ", Label("slow"), func() {
+		if !ee {
+			Skip("This test will only run in EE configuration")
+		}
+		suffix := setLabelAndCRName("hw-8")
+
+		// Hazelcast and Map CRs
+		hzSource1 := "hz1-source" + suffix
+		map11 := "map11" + suffix
+		map12 := "map12" + suffix
+
+		hzTarget1 := "hz1-target" + suffix
+
+		hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+			hzSource1: {map11, map12},
+			hzTarget1: nil,
+		}, hzSrcLookupKey.Namespace, labels)
+
+		By("creating first WAN configuration")
+		wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+				{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+			}, 2, labels)
+
+		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+		wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+			{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+		}
+		Expect(k8sClient.Update(context.Background(), wan)).Should(BeNil())
+		Sleep(5 * Second)
+		wan = assertWanStatusMapCount(wan, 2)
+		_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+	})
 })

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -9,28 +9,12 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
-	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
-	hazelcastconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/hazelcast"
 )
 
 var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 	localPort := strconv.Itoa(8900 + GinkgoParallelProcess())
-
-	waitForLBAddress := func(name types.NamespacedName) string {
-		By("waiting for load balancer address")
-		hz := &hazelcastcomv1alpha1.Hazelcast{}
-		Eventually(func() string {
-			hz := &hazelcastcomv1alpha1.Hazelcast{}
-			err := k8sClient.Get(context.Background(), name, hz)
-			Expect(err).ToNot(HaveOccurred())
-			return hz.Status.ExternalAddresses
-		}, 3*Minute, interval).Should(Not(BeEmpty()))
-		Expect(k8sClient.Get(context.Background(), name, hz)).To(Succeed())
-		return hz.Status.ExternalAddresses
-	}
 
 	BeforeEach(func() {
 		if !useExistingCluster() {
@@ -64,143 +48,311 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		}
 		setLabelAndCRName("hw-1")
 
-		By("creating source Hazelcast cluster")
-		hazelcastSource := hazelcastconfig.ExposeExternallyUnisocket(hzSrcLookupKey, ee, labels)
-		hazelcastSource.Spec.ClusterName = "source"
-		CreateHazelcastCR(hazelcastSource)
-
-		By("creating target Hazelcast cluster")
-		hazelcastTarget := hazelcastconfig.ExposeExternallyUnisocket(hzTrgLookupKey, ee, labels)
-		hazelcastTarget.Spec.ClusterName = "target"
-		CreateHazelcastCR(hazelcastTarget)
-		evaluateReadyMembers(hzSrcLookupKey)
-		evaluateReadyMembers(hzTrgLookupKey)
-
-		_ = waitForLBAddress(hzSrcLookupKey)
-		targetAddress := waitForLBAddress(hzTrgLookupKey)
-
-		By("creating map for source Hazelcast cluster")
-		m := hazelcastconfig.DefaultMap(mapLookupKey, hazelcastSource.Name, labels)
-		Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
-		m = assertMapStatus(m, hazelcastcomv1alpha1.MapSuccess)
+		hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+			hzSrcLookupKey.Name: {mapLookupKey.Name},
+			hzTrgLookupKey.Name: nil,
+		}, hzSrcLookupKey.Namespace, labels)
 
 		By("creating WAN configuration")
-		wan := hazelcastconfig.DefaultWanReplication(
-			wanLookupKey,
-			m.Name,
-			hazelcastTarget.Spec.ClusterName,
-			targetAddress,
-			labels,
-		)
-		Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
-
-		Eventually(func() (hazelcastcomv1alpha1.WanStatus, error) {
-			wan := &hazelcastcomv1alpha1.WanReplication{}
-			err := k8sClient.Get(context.Background(), wanLookupKey, wan)
-			if err != nil {
-				return hazelcastcomv1alpha1.WanStatusFailed, err
-			}
-			return wan.Status.Status, nil
-		}, 30*Second, interval).Should(Equal(hazelcastcomv1alpha1.WanStatusSuccess))
-
-		mapSize := 1024
-		FillTheMapData(context.Background(), hzSrcLookupKey, true, m.Name, mapSize)
-
-		By("checking the size of the map in the target cluster")
-		WaitForMapSize(context.Background(), hzTrgLookupKey, m.Name, mapSize, 1*Minute)
-	})
-
-	It("should replicate multiple maps to target cluster ", Label("slow"), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
-		setLabelAndCRName("hw-2")
-		source1LookupKey := types.NamespacedName{Name: hzSrcLookupKey.Name + "1", Namespace: hzSrcLookupKey.Namespace}
-		source2LookupKey := types.NamespacedName{Name: hzSrcLookupKey.Name + "2", Namespace: hzSrcLookupKey.Namespace}
-
-		By("creating first source Hazelcast cluster")
-		source1 := hazelcastconfig.Default(source1LookupKey, ee, labels)
-		source1.Spec.ClusterName = "source1"
-		source1.Spec.ClusterSize = pointer.Int32(1)
-		CreateHazelcastCR(source1)
-
-		By("creating second source Hazelcast cluster")
-		source2 := hazelcastconfig.Default(source2LookupKey, ee, labels)
-		source2.Spec.ClusterName = "source2"
-		source2.Spec.ClusterSize = pointer.Int32(1)
-		CreateHazelcastCR(source2)
-
-		By("creating target Hazelcast cluster")
-		target1 := hazelcastconfig.Default(hzTrgLookupKey, ee, labels)
-		target1.Spec.ClusterName = "target"
-		target1.Spec.ClusterSize = pointer.Int32(1)
-		CreateHazelcastCR(target1)
-
-		evaluateReadyMembers(source1LookupKey)
-		evaluateReadyMembers(source2LookupKey)
-		evaluateReadyMembers(hzTrgLookupKey)
-
-		By("creating first map for first source Hazelcast cluster")
-		source1_map1 := hazelcastconfig.DefaultMap(mapLookupKey, source1.Name, labels)
-		source1_map1.Name = "source1-map1"
-		Expect(k8sClient.Create(context.Background(), source1_map1)).Should(Succeed())
-		_ = assertMapStatus(source1_map1, hazelcastcomv1alpha1.MapSuccess)
-
-		By("creating second map for first source Hazelcast cluster")
-		source1_map2 := hazelcastconfig.DefaultMap(mapLookupKey, source1.Name, labels)
-		source1_map2.Name = "source1-map2"
-		Expect(k8sClient.Create(context.Background(), source1_map2)).Should(Succeed())
-		_ = assertMapStatus(source1_map2, hazelcastcomv1alpha1.MapSuccess)
-
-		By("creating first map for second source Hazelcast cluster")
-		source2_map1 := hazelcastconfig.DefaultMap(mapLookupKey, source2.Name, labels)
-		source2_map1.Name = "source2-map1"
-		Expect(k8sClient.Create(context.Background(), source2_map1)).Should(Succeed())
-		_ = assertMapStatus(source2_map1, hazelcastcomv1alpha1.MapSuccess)
-
-		By("creating first WAN configuration")
-		wan := hazelcastconfig.DefaultWanReplication(
-			wanLookupKey,
-			source1_map1.Name,
-			target1.Spec.ClusterName,
-			hzclient.HazelcastUrl(target1),
-			labels,
-		)
-
-		wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
-			{Name: source1_map1.Name},
-			{Name: source2.Name, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
-		}
-
-		Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
-		assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-
-		By("creating second WAN configuration")
-		wlk := types.NamespacedName{Namespace: wan.Namespace, Name: "second-wan"}
-		wan2 := hazelcastconfig.DefaultWanReplication(
-			wlk,
-			source1_map1.Name,
-			target1.Spec.ClusterName,
-			hzclient.HazelcastUrl(target1),
-			labels,
-		)
-
-		wan2.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
-			{Name: source1_map2.Name},
-		}
-
-		Expect(k8sClient.Create(context.Background(), wan2)).Should(Succeed())
-		assertWanStatus(wan2, hazelcastcomv1alpha1.WanStatusSuccess)
-
-		By("filling the maps in the source clusters")
-		mapSize := 10
-		fillTheMapDataPortForward(context.Background(), source1, localPort, source1_map1.Name, mapSize)
-		fillTheMapDataPortForward(context.Background(), source1, localPort, source1_map2.Name, mapSize)
-		fillTheMapDataPortForward(context.Background(), source2, localPort, source2_map1.Name, mapSize)
+		createWanConfig(context.Background(), wanLookupKey, hzCrs[hzTrgLookupKey.Name],
+			[]hazelcastcomv1alpha1.ResourceSpec{
+				{Name: mapLookupKey.Name},
+			}, 1, labels)
 
 		By("checking the size of the maps in the target cluster")
-		waitForMapSizePortForward(context.Background(), target1, localPort, source1_map1.Name, mapSize, 1*Minute)
-		waitForMapSizePortForward(context.Background(), target1, localPort, source1_map2.Name, mapSize, 1*Minute)
-		waitForMapSizePortForward(context.Background(), target1, localPort, source2_map1.Name, mapSize, 1*Minute)
+		mapSize := 1024
+		fillTheMapDataPortForward(context.Background(), hzCrs[hzSrcLookupKey.Name], localPort, mapLookupKey.Name, mapSize)
+		waitForMapSizePortForward(context.Background(), hzCrs[hzTrgLookupKey.Name], localPort, mapLookupKey.Name, mapSize, 1*Minute)
 	})
+
+	When("All pods are deleted",
+		It("should send data to another cluster using ConfigMap configuration", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			setLabelAndCRName("hw-2")
+
+			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+				hzSrcLookupKey.Name: {mapLookupKey.Name},
+				hzTrgLookupKey.Name: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating WAN configuration")
+			createWanConfig(context.Background(), wanLookupKey, hzCrs[hzTrgLookupKey.Name],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: mapLookupKey.Name},
+				}, 1, labels)
+
+			deletePods(hzSrcLookupKey)
+			// Wait for pod to be deleted
+			Sleep(5 * Second)
+			evaluateReadyMembers(hzSrcLookupKey)
+
+			By("checking the size of the maps in the target cluster")
+			mapSize := 1024
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSrcLookupKey.Name], localPort, mapLookupKey.Name, mapSize)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTrgLookupKey.Name], localPort, mapLookupKey.Name, mapSize, 1*Minute)
+		}))
+
+	When("Multiple WanReplication resources with multiple maps exist",
+		It("should replicate maps to target cluster ", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			suffix := setLabelAndCRName("hw-3")
+
+			// Hazelcast and Map CRs
+			hzSource1 := "hz1-source" + suffix
+			map11 := "map11" + suffix
+			map12 := "map12" + suffix
+
+			hzSource2 := "hz2-source" + suffix
+			map21 := "map21" + suffix
+
+			hzTarget1 := "hz1-target" + suffix
+
+			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+				hzSource1: {map11, map12},
+				hzSource2: {map21},
+				hzTarget1: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating first WAN configuration")
+			createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+					{Name: hzSource2, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+				}, 2, labels)
+
+			By("creating second WAN configuration")
+			createWanConfig(context.Background(), types.NamespacedName{Name: "wan2" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: map12},
+				}, 1, labels)
+
+			By("filling the maps in the source clusters")
+			mapSize := 10
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, mapSize)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, mapSize)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, mapSize)
+
+			By("checking the size of the maps in the target cluster")
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, mapSize, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, mapSize, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, mapSize, 1*Minute)
+		}))
+
+	When("Wan replicated Map CR is deleted which was given as a Map resource in Wan spec",
+		It("should delete the map from status and Wan status should be failed", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			suffix := setLabelAndCRName("hw-4")
+
+			// Hazelcast and Map CRs
+			hzSource1 := "hz1-source" + suffix
+			map11 := "map11" + suffix
+
+			hzTarget1 := "hz1-target" + suffix
+
+			hzCrs, mapCrs := createWanResources(context.Background(), map[string][]string{
+				hzSource1: {map11},
+				hzTarget1: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating first WAN configuration")
+			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+				}, 1, labels)
+
+			Expect(k8sClient.Delete(context.Background(), mapCrs[map11])).Should(BeNil())
+			assertObjectDoesNotExist(mapCrs[map11])
+			wan = assertWanStatusMapCount(wan, 0)
+			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusFailed)
+
+			Expect(k8sClient.Delete(context.Background(), wan)).Should(BeNil())
+			assertObjectDoesNotExist(wan)
+		}))
+
+	When("Wan replicated Map CR is deleted which was given as a Hazelcast resource in Wan spec",
+		It("should delete the map from status and Wan status should be Pending", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			suffix := setLabelAndCRName("hw-5")
+
+			// Hazelcast and Map CRs
+			hzSource1 := "hz1-source" + suffix
+			map11 := "map11" + suffix
+
+			hzTarget1 := "hz1-target" + suffix
+
+			hzCrs, mapCrs := createWanResources(context.Background(), map[string][]string{
+				hzSource1: {map11},
+				hzTarget1: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating first WAN configuration")
+			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+				}, 1, labels)
+
+			Expect(k8sClient.Delete(context.Background(), mapCrs[map11])).Should(BeNil())
+			assertObjectDoesNotExist(mapCrs[map11])
+			wan = assertWanStatusMapCount(wan, 0)
+			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusPending)
+
+			Expect(k8sClient.Delete(context.Background(), wan)).Should(BeNil())
+			assertObjectDoesNotExist(wan)
+		}))
+
+	When("Wan replicated Hazelcast CR is deleted which was given as a Hazelcast resource in Wan spec",
+		It("should delete the maps from status and Wan status should be Pending ", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			suffix := setLabelAndCRName("hw-6")
+
+			// Hazelcast and Map CRs
+			hzSource1 := "hz1-source" + suffix
+			map11 := "map11" + suffix
+			map12 := "map12" + suffix
+			map13 := "map13" + suffix
+
+			hzSource2 := "hz2-source" + suffix
+			map21 := "map21" + suffix
+			map22 := "map22" + suffix
+
+			hzTarget1 := "hz1-target" + suffix
+
+			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+				hzSource1: {map11, map12, map13},
+				hzSource2: {map21, map22},
+				hzTarget1: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating first WAN configuration")
+			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+					{Name: hzSource2, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+				}, 5, labels)
+
+			Expect(k8sClient.Delete(context.Background(), hzCrs[hzSource2])).Should(BeNil())
+			assertObjectDoesNotExist(hzCrs[hzSource2])
+			wan = assertWanStatusMapCount(wan, 3)
+			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+
+			Expect(k8sClient.Delete(context.Background(), hzCrs[hzSource1])).Should(BeNil())
+			assertObjectDoesNotExist(hzCrs[hzSource1])
+			wan = assertWanStatusMapCount(wan, 0)
+			_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusPending)
+		}))
+
+	When("Wan replicated maps are removed from Wan spec",
+		It("should stop replicating to target cluster", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			suffix := setLabelAndCRName("hw-7")
+
+			// Hazelcast and Map CRs
+			hzSource1 := "hz1-source" + suffix
+			map11 := "map11" + suffix
+			map12 := "map12" + suffix
+
+			hzSource2 := "hz2-source" + suffix
+			map21 := "map21" + suffix
+			map22 := "map22" + suffix
+
+			hzTarget1 := "hz1-target" + suffix
+
+			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+				hzSource1: {map11, map12},
+				hzSource2: {map21, map22},
+				hzTarget1: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating first WAN configuration")
+			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+					{Name: map21, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+					{Name: map22, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+				}, 4, labels)
+
+			By("filling the maps in the source clusters")
+			entryCount := 10
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, entryCount)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, entryCount)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, entryCount)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map22, entryCount)
+
+			By("checking the size of the maps in the target cluster")
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, entryCount, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, entryCount, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, entryCount, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map22, entryCount, 1*Minute)
+
+			By("stopping replicating all maps but map22")
+
+			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+			wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+				{Name: map22, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+			}
+			Expect(k8sClient.Update(context.Background(), wan)).Should(BeNil())
+			wan = assertWanStatusMapCount(wan, 1)
+			_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+
+			currentSize := entryCount
+			newEntryCount := 50
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map22, newEntryCount)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map11, newEntryCount)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource1], localPort, map12, newEntryCount)
+			fillTheMapDataPortForward(context.Background(), hzCrs[hzSource2], localPort, map21, newEntryCount)
+
+			By("checking the size of the maps in the target cluster")
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map22, currentSize+newEntryCount, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map11, currentSize, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map12, currentSize, 1*Minute)
+			waitForMapSizePortForward(context.Background(), hzCrs[hzTarget1], localPort, map21, currentSize, 1*Minute)
+		}))
+
+	When("Map is given twice in the Wan spec",
+		It("should continue replication if one reference is deleted ", Label("slow"), func() {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			suffix := setLabelAndCRName("hw-8")
+
+			// Hazelcast and Map CRs
+			hzSource1 := "hz1-source" + suffix
+			map11 := "map11" + suffix
+			map12 := "map12" + suffix
+
+			hzTarget1 := "hz1-target" + suffix
+
+			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
+				hzSource1: {map11, map12},
+				hzTarget1: nil,
+			}, hzSrcLookupKey.Namespace, labels)
+
+			By("creating first WAN configuration")
+			wan := createWanConfig(context.Background(), types.NamespacedName{Name: "wan1" + suffix, Namespace: hzNamespace}, hzCrs[hzTarget1],
+				[]hazelcastcomv1alpha1.ResourceSpec{
+					{Name: map11, Kind: hazelcastcomv1alpha1.ResourceKindMap},
+					{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+				}, 2, labels)
+
+			wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+			wan.Spec.Resources = []hazelcastcomv1alpha1.ResourceSpec{
+				{Name: hzSource1, Kind: hazelcastcomv1alpha1.ResourceKindHZ},
+			}
+			Expect(k8sClient.Update(context.Background(), wan)).Should(BeNil())
+			Sleep(5 * Second)
+			wan = assertWanStatusMapCount(wan, 2)
+			_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+		}))
 })

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -29,7 +29,7 @@ func useExistingCluster() bool {
 }
 
 func runningLocally() bool {
-	return strings.ToLower(os.Getenv("RUN_MANAGER_LOCALLY")) == "true"
+	return true //TODO: revert
 }
 
 func GetControllerManagerName() string {

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -29,7 +29,7 @@ func useExistingCluster() bool {
 }
 
 func runningLocally() bool {
-	return true //TODO: revert
+	return strings.ToLower(os.Getenv("RUN_MANAGER_LOCALLY")) == "true"
 }
 
 func GetControllerManagerName() string {


### PR DESCRIPTION
## Description

 Added support for deletion of wan replicated maps
  
Added finalizer to maps for which we start Wan replication. So, whenthe map is deleted Wan reconciler has the time to do the clean up. I also added owner reference to the maps along with a map watcher to Wan reconciler manager. This is done to be able to trigger the Wan reconciler when a replicated map is marked to be deleted.

Along with the support, did the following:
- Refactored  GetHazelcastClient input parameters
- Fixed bug causing Hazelcast reconciler  to trigger continuously
- Added resourceName to WanMapStatus, this is done to be able to get the map CR from the Wan status
- Fixed incorrect field assignment in Wan ConfigMap creation
- Reordered functions top down approach
- Fixed hidden errors in Hazelcast reconciler update func
- Fixed a bug where the error was hidden in stopWanReplicationAllMaps function
- Removed duplicate entries in Hazelcast Map list
- Moved stopWanRepForRemovedResources from inside appliedBefore because partial applications can exist
- Fixed stopWanRepForRemovedResources function where we were operating on an empty map
- Changed map deletion mode in stopWanReplicationForAllMaps and stopWanRepForRemovedResources, this is done to make finalizer and map status deletion as close as possible.
- Made install-crds directive be able to update crds
-  Fix errors happening between finalizer and status deletion. 

Added test cases for Wan Replication. New test cases cover:
- Map CR deletion, where map could be given in Wan spec as a map or hazelcast resource
- Hazelcast CR deletion with multiple replicated maps
- Wan replicated map removal from Wan spec
- Duplicate map entry in the Wan spec

I also want to note that to fix the bug causing Hazelcast reconciler  to trigger continuously, I deleted the code part  `r.update(ctx, h, terminatingPhase(nil)) //nolint:errcheck` in hazelcast reconciler. This will be readded when, we update CR status update process. With the way we implemented, some updates cause continuous reconciler triggers with no end.

## User Impact

Deletion of Map CRs of removal of map resources from WanRepllication spec will not cause unexpected behavior.
