### PR TITLE
[CN-671] Support -XX:{Initial,Max,Min}RAMPercentage Java options

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -132,6 +132,11 @@ type HazelcastSpec struct {
 	// +optional
 	// +kubebuilder:default:={}
 	HighAvailabilityMode HighAvailabilityMode `json:"highAvailabilityMode,omitempty"`
+
+	// Hazelcast JVM configuration
+	// +optional
+	// +kubebuilder:default:={}
+	JVM *JVMConfiguration `json:"jvm,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=NODE;ZONE
@@ -558,6 +563,56 @@ func (c *ExposeExternallyConfiguration) MemberAccessServiceType() corev1.Service
 	default:
 		return corev1.ServiceTypeNodePort
 	}
+}
+
+// JVMConfiguration is a Hazelcast JVM configuration
+type JVMConfiguration struct {
+	// Memory is a JVM memory configuration
+	// +optional
+	Memory *JVMMemoryConfiguration `json:"memory,omitempty"`
+}
+
+func (c *JVMConfiguration) GetMemory() *JVMMemoryConfiguration {
+	if c != nil {
+		return c.Memory
+	}
+	return nil
+}
+
+// JVMMemoryConfiguration is a JVM memory configuration
+type JVMMemoryConfiguration struct {
+	// InitialRAMPercentage configures JVM initial heap size
+	// +optional
+	InitialRAMPercentage *string `json:"initialRAMPercentage,omitempty"`
+
+	// MinRAMPercentage sets the minimum heap size for a JVM
+	// +optional
+	MinRAMPercentage *string `json:"minRAMPercentage,omitempty"`
+
+	// MaxRAMPercentage sets the maximum heap size for a JVM
+	// +optional
+	MaxRAMPercentage *string `json:"maxRAMPercentage,omitempty"`
+}
+
+func (c *JVMMemoryConfiguration) GetInitialRAMPercentage() string {
+	if c != nil && c.InitialRAMPercentage != nil {
+		return *c.InitialRAMPercentage
+	}
+	return ""
+}
+
+func (c *JVMMemoryConfiguration) GetMinRAMPercentage() string {
+	if c != nil && c.MinRAMPercentage != nil {
+		return *c.MinRAMPercentage
+	}
+	return ""
+}
+
+func (c *JVMMemoryConfiguration) GetMaxRAMPercentage() string {
+	if c != nil && c.MaxRAMPercentage != nil {
+		return *c.MaxRAMPercentage
+	}
+	return ""
 }
 
 // HazelcastStatus defines the observed state of Hazelcast

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -199,6 +199,26 @@ spec:
                     description: When true, enables resource uploading for Jet jobs.
                     type: boolean
                 type: object
+              jvm:
+                description: Hazelcast JVM configuration
+                properties:
+                  memory:
+                    description: Memory is a JVM memory configuration
+                    properties:
+                      initialRAMPercentage:
+                        description: InitialRAMPercentage configures JVM initial heap
+                          size
+                        type: string
+                      maxRAMPercentage:
+                        description: MaxRAMPercentage sets the maximum heap size for
+                          a JVM
+                        type: string
+                      minRAMPercentage:
+                        description: MinRAMPercentage sets the minimum heap size for
+                          a JVM
+                        type: string
+                    type: object
+                type: object
               licenseKeySecret:
                 description: Name of the secret with Hazelcast Enterprise License
                   Key.

--- a/config/samples/_v1alpha1_hazelcast_jvm_memory.yaml
+++ b/config/samples/_v1alpha1_hazelcast_jvm_memory.yaml
@@ -1,0 +1,10 @@
+apiVersion: hazelcast.com/v1alpha1
+kind: Hazelcast
+metadata:
+  name: hazelcast
+spec:
+  jvm:
+    memory:
+      initialRAMPercentage: "10"
+      maxRAMPercentage: "20"
+      minRAMPercentage: "10"

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1681,7 +1681,7 @@ func env(h *hazelcastv1alpha1.Hazelcast) []v1.EnvVar {
 	envs := []v1.EnvVar{
 		{
 			Name:  "JAVA_OPTS",
-			Value: fmt.Sprintf("-Dhazelcast.config=%s/hazelcast.yaml", n.HazelcastMountPath),
+			Value: javaOPTS(h),
 		},
 		{
 			Name:  "HZ_PARDOT_ID",
@@ -1720,6 +1720,31 @@ func env(h *hazelcastv1alpha1.Hazelcast) []v1.EnvVar {
 	}
 
 	return envs
+}
+
+func javaOPTS(h *hazelcastv1alpha1.Hazelcast) string {
+	b := strings.Builder{}
+	b.WriteString("-Dhazelcast.config=" + path.Join(n.HazelcastMountPath, "hazelcast.yaml"))
+
+	// we should configure JVM to respect container’s resource limits
+	b.WriteString(" -XX:+UseContainerSupport")
+
+	jvmMemory := h.Spec.JVM.GetMemory()
+
+	// in addition we allow user to set explicit memory limits
+	if value := jvmMemory.GetInitialRAMPercentage(); value != "" {
+		b.WriteString(" -XX:InitialRAMPercentage=" + value)
+	}
+
+	if value := jvmMemory.GetMinRAMPercentage(); value != "" {
+		b.WriteString(" -XX:MinRAMPercentage=" + value)
+	}
+
+	if value := jvmMemory.GetMaxRAMPercentage(); value != "" {
+		b.WriteString(" -XX:MaxRAMPercentage=" + value)
+	}
+
+	return b.String()
 }
 
 func javaClassPath(h *hazelcastv1alpha1.Hazelcast) string {

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -349,7 +349,7 @@ func env(mc *hazelcastv1alpha1.ManagementCenter) []v1.EnvVar {
 			},
 			v1.EnvVar{
 				Name: javaOpts,
-				Value: fmt.Sprintf("-Dhazelcast.mc.license=$(MC_LICENSE_KEY) -Dhazelcast.mc.healthCheck.enable=true"+
+				Value: fmt.Sprintf("-XX:+UseContainerSupport -Dhazelcast.mc.license=$(MC_LICENSE_KEY) -Dhazelcast.mc.healthCheck.enable=true"+
 					" -Dhazelcast.mc.lock.skip=true -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false -Dhazelcast.mc.phone.home.enabled=%t", util.IsPhoneHomeEnabled()),
 			},
 		)
@@ -357,7 +357,7 @@ func env(mc *hazelcastv1alpha1.ManagementCenter) []v1.EnvVar {
 		envs = append(envs,
 			v1.EnvVar{
 				Name: javaOpts,
-				Value: fmt.Sprintf("-Dhazelcast.mc.healthCheck.enable=true -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false"+
+				Value: fmt.Sprintf("-XX:+UseContainerSupport -Dhazelcast.mc.healthCheck.enable=true -Dhazelcast.mc.tls.enabled=false -Dmancenter.ssl=false"+
 					" -Dhazelcast.mc.lock.skip=true -Dhazelcast.mc.phone.home.enabled=%t", util.IsPhoneHomeEnabled()),
 			},
 		)

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -436,6 +436,26 @@ spec:
                     description: When true, enables resource uploading for Jet jobs.
                     type: boolean
                 type: object
+              jvm:
+                description: Hazelcast JVM configuration
+                properties:
+                  memory:
+                    description: Memory is a JVM memory configuration
+                    properties:
+                      initialRAMPercentage:
+                        description: InitialRAMPercentage configures JVM initial heap
+                          size
+                        type: string
+                      maxRAMPercentage:
+                        description: MaxRAMPercentage sets the maximum heap size for
+                          a JVM
+                        type: string
+                      minRAMPercentage:
+                        description: MinRAMPercentage sets the minimum heap size for
+                          a JVM
+                        type: string
+                    type: object
+                type: object
               licenseKeySecret:
                 description: Name of the secret with Hazelcast Enterprise License
                   Key.


### PR DESCRIPTION
## Description

Following configuration parameters were added to Hazelcast CR:
1. spec.jvm.memory.initialRAMPercentage (`-XX:InitialRAMPercentage`)
2. spec.jvm.memory.minRAMPercentage (`-XX:MinRAMPercentage`)
3. spec.jvm.memory.maxRAMPercentage (`-XX:MaxRAMPercentage`)

In addition by default we add `-XX:+UseContainerSupport` to `JAVA_OPTS`.

## User Impact

User can now configure  `-XX:{Initial,Max,Min}RAMPercentage` JVM options using Hazelcast CR.
