### PR TITLE
Add separate config to update only PR labels in PR builder

### DIFF
--- a/.github/pr-autolabeler-config.yml
+++ b/.github/pr-autolabeler-config.yml
@@ -1,0 +1,30 @@
+commitish: 'main'
+autolabeler:
+  - label: 'feature'
+    branch:
+      - '/feat\/.+/'
+    title:
+      - '/feature/i'
+      - '/feat/i'
+  - label: 'enhancement'
+    branch:
+      - '/enhancement\/.+/'
+    title:
+      - '/enhancement/i'
+      - '/improve/i'
+      - '/upgrade/i'
+      - '/update/i'
+  - label: 'fix'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+      - '/bug/i'
+      - '/issue/i'
+      - '/error/i'
+  - label: 'ci'
+    files:
+      - '.github/workflows/*'
+  - label: 'documentation'
+    files:
+      - '*.md'

--- a/.github/workflows/pull-request-label-update.yaml
+++ b/.github/workflows/pull-request-label-update.yaml
@@ -32,6 +32,6 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         with:
-          config-name: release-drafter-config.yml
+          config-name: pr-autolabeler-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Add separate config to update only PR labels in PR builder. Before each merge to the main it updates RN.
