### PR TITLE
Remove duplicate expose externally ee test

### DIFF
--- a/test/e2e/hazelcast_expose_externally_test.go
+++ b/test/e2e/hazelcast_expose_externally_test.go
@@ -161,18 +161,6 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 
 		assertExternalAddressesNotEmpty()
 	})
-
-	It("should not try to assume external IP of the discovery service load balancer", Label("slow"), func() {
-		setLabelAndCRName("hee-4")
-		hazelcast := hazelcastconfig.ExposeExternallyUnisocket(hzLookupKey, ee, labels)
-		CreateHazelcastCR(hazelcast)
-		evaluateReadyMembers(hzLookupKey)
-
-		FillTheMapData(ctx, hzLookupKey, true, "map", 100)
-		WaitForMapSize(ctx, hzLookupKey, "map", 100, 1*Minute)
-
-		assertExternalAddressesNotEmpty()
-	})
 })
 
 func getHazelcastMembers(ctx context.Context, hazelcast *hazelcastcomv1alpha1.Hazelcast) []hazelcastcomv1alpha1.HazelcastMemberStatus {


### PR DESCRIPTION
## Description

`hee-1` and `hee-4` are the same test. Removed `hee-4`.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
