### PR TITLE
[CN-660] Separate Watched and Operator Namespace roles 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,9 @@ sync-manifests: manifests yq
 # Move CRDs into helm template
 	@cat config/crd/bases/* >> all-crds.yaml && mv all-crds.yaml $(CRD_CHART)/templates/
 # Move role rules into helm template
-	@role=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/role.yaml \
-		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role") | .rules') ;\
+	role=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/role.yaml \
+		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "operator-namespace") | .rules' \
+		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "watched") | .rules') ;\
 		echo "$$role" > $(OPERATOR_CHART)/templates/role.yaml
 # Move clusterrole rules into helm template
 	@clusterrole=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/clusterrole.yaml \

--- a/api/v1alpha1/hazelcast_webhook.go
+++ b/api/v1alpha1/hazelcast_webhook.go
@@ -8,6 +8,7 @@ import (
 
 	"encoding/json"
 	"fmt"
+
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 )
 
@@ -22,7 +23,6 @@ func (r *Hazelcast) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/validate-hazelcast-com-v1alpha1-hazelcast,mutating=false,failurePolicy=ignore,sideEffects=None,groups=hazelcast.com,resources=hazelcasts,verbs=create;update,versions=v1alpha1,name=vhazelcast.kb.io,admissionReviewVersions=v1
 // Role related to webhooks
-//+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=update;get;watch;list
 
 var _ webhook.Validator = &Hazelcast{}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -49,7 +49,33 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
-  namespace: system
+  namespace: operator-namespace
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+  namespace: watched
 rules:
 - apiGroups:
   - ""
@@ -79,25 +105,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
   verbs:
   - create
   - delete

--- a/config/samples/_v1alpha1_hazelcast_persistence.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence.yaml
@@ -13,4 +13,3 @@ spec:
     pvc:
       accessModes: ["ReadWriteOnce"]
       requestStorage: 8Gi
-      storageClassName: "standard"

--- a/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
@@ -15,4 +15,3 @@ spec:
     pvc:
       accessModes: ["ReadWriteOnce"]
       requestStorage: 8Gi
-      storageClassName: "standard"

--- a/config/samples/_v1alpha1_hazelcast_persistence_force_start.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_force_start.yaml
@@ -13,5 +13,4 @@ spec:
     pvc:
       accessModes: ["ReadWriteOnce"]
       requestStorage: 8Gi
-      storageClassName: "standard"
     startupAction: ForceStart

--- a/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
@@ -15,7 +15,6 @@ spec:
     pvc:
       accessModes: ["ReadWriteOnce"]
       requestStorage: 8Gi
-      storageClassName: "standard"
     restore:
       bucketConfig:
         secret: br-secret-az

--- a/controllers/hazelcast/cache_controller.go
+++ b/controllers/hazelcast/cache_controller.go
@@ -40,9 +40,9 @@ func NewCacheReconciler(c client.Client, log logr.Logger, s *runtime.Scheme, pht
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=caches,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=caches/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=caches/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=caches,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=caches/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=caches/finalizers,verbs=update,namespace=watched
 
 func (r *CacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast-cache", req.NamespacedName)

--- a/controllers/hazelcast/cronhotbackup_controller.go
+++ b/controllers/hazelcast/cronhotbackup_controller.go
@@ -49,9 +49,9 @@ func NewCronHotBackupReconciler(
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=cronhotbackups,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=cronhotbackups/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=cronhotbackups/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=cronhotbackups,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=cronhotbackups/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=cronhotbackups/finalizers,verbs=update,namespace=watched
 
 func (r *CronHotBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	logger := r.Log.WithValues("hazelcast-hot-backup", req.NamespacedName)

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -52,24 +52,24 @@ func NewHazelcastReconciler(c client.Client, log logr.Logger, s *runtime.Scheme,
 	}
 }
 
-// Role related to Operator UUID
-//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get,namespace=system
 // Openshift related permissions
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // Role related to CRs
-//+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts/finalizers,verbs=update,namespace=system
-// Roles inherited from permissions Hazelcast needs
+//+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=hazelcasts/finalizers,verbs=update,namespace=watched
+// ClusterRole inherited from permissions Hazelcast needs
 //+kubebuilder:rbac:groups="",resources=endpoints;pods;nodes;services,verbs=get;list
-//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=watch;list,namespace=system
-// Role related to Reconcile()
-//+kubebuilder:rbac:groups="",resources=events;services;serviceaccounts;configmaps;pods,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get;list,namespace=system
-//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete,namespace=system
-// ClusterRole related to Reconcile()
+// Role inherited from permissions Hazelcast needs for persistence
+//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=watch;list,namespace=watched
+// ClusterRole related to Reconcile() to be able to give Hazelcast ClusterRole permissions
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// Role related to Reconcile() to be able to give Hazelcast Role permissions
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+// Role related to Reconcile()
+//+kubebuilder:rbac:groups="",resources=events;services;serviceaccounts;configmaps;pods,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;watch;get;list,namespace=watched
 
 func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast", req.NamespacedName)

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -52,9 +52,9 @@ func NewHotBackupReconciler(c client.Client, log logr.Logger, pht chan struct{},
 }
 
 // Role related to CRs
-//+kubebuilder:rbac:groups=hazelcast.com,resources=hotbackups,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=hotbackups/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=hotbackups/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=hotbackups,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=hotbackups/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=hotbackups/finalizers,verbs=update,namespace=watched
 
 func (r *HotBackupReconciler) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, err error) {
 	logger := r.Log.WithValues("hazelcast-hot-backup", req.NamespacedName)

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -49,9 +49,9 @@ func NewMapReconciler(c client.Client, log logr.Logger, s *runtime.Scheme, pht c
 
 const retryAfterForMap = 5 * time.Second
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=maps,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=maps/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=maps/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=maps,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=maps/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=maps/finalizers,verbs=update,namespace=watched
 
 func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast-map", req.NamespacedName)

--- a/controllers/hazelcast/multimap_controller.go
+++ b/controllers/hazelcast/multimap_controller.go
@@ -38,9 +38,9 @@ func NewMultiMapReconciler(c client.Client, log logr.Logger, s *runtime.Scheme, 
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=multimaps,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=multimaps/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=multimaps/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=multimaps,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=multimaps/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=multimaps/finalizers,verbs=update,namespace=watched
 
 func (r *MultiMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast-multimap", req.NamespacedName)

--- a/controllers/hazelcast/queue_controller.go
+++ b/controllers/hazelcast/queue_controller.go
@@ -37,9 +37,9 @@ func NewQueueReconciler(c client.Client, log logr.Logger, s *runtime.Scheme, pht
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=queues,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=queues/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=queues/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=queues,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=queues/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=queues/finalizers,verbs=update,namespace=watched
 
 func (r *QueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast-queue", req.NamespacedName)

--- a/controllers/hazelcast/replicatedmap_controller.go
+++ b/controllers/hazelcast/replicatedmap_controller.go
@@ -38,9 +38,9 @@ func NewReplicatedMapReconciler(c client.Client, log logr.Logger, s *runtime.Sch
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=replicatedmaps,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=replicatedmaps/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=replicatedmaps/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=replicatedmaps,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=replicatedmaps/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=replicatedmaps/finalizers,verbs=update,namespace=watched
 
 func (r *ReplicatedMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast-replicatedmap", req.NamespacedName)

--- a/controllers/hazelcast/topic_controller.go
+++ b/controllers/hazelcast/topic_controller.go
@@ -38,9 +38,9 @@ func NewTopicReconciler(c client.Client, log logr.Logger, s *runtime.Scheme, pht
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=topics,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=topics/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=topics/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=topics,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=topics/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=topics/finalizers,verbs=update,namespace=watched
 
 func (r *TopicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("hazelcast-topic", req.NamespacedName)

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -51,9 +51,9 @@ func NewWanReplicationReconciler(client client.Client, log logr.Logger, scheme *
 	}
 }
 
-//+kubebuilder:rbac:groups=hazelcast.com,resources=wanreplications,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=wanreplications/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=wanreplications/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=wanreplications,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=wanreplications/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=wanreplications/finalizers,verbs=update,namespace=watched
 
 func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.WithValues("name", req.Name, "namespace", req.NamespacedName)

--- a/controllers/managementcenter/managementcenter_controller.go
+++ b/controllers/managementcenter/managementcenter_controller.go
@@ -39,13 +39,13 @@ func NewManagementCenterReconciler(c client.Client, log logr.Logger, s *runtime.
 }
 
 // Role related to CRs
-//+kubebuilder:rbac:groups=hazelcast.com,resources=managementcenters,verbs=get;list;watch;create;update;patch;delete,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=managementcenters/status,verbs=get;update;patch,namespace=system
-//+kubebuilder:rbac:groups=hazelcast.com,resources=managementcenters/finalizers,verbs=update,namespace=system
+//+kubebuilder:rbac:groups=hazelcast.com,resources=managementcenters,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=managementcenters/status,verbs=get;update;patch,namespace=watched
+//+kubebuilder:rbac:groups=hazelcast.com,resources=managementcenters/finalizers,verbs=update,namespace=watched
 // Role related to Reconcile()
-// duplicated in hazelcast_contoller.go +kubebuilder:rbac:groups="",resources=events;services;serviceaccounts;pods,verbs=get;list;watch;create;update;patch;delete,namespace=system
-// duplicated in hazelcast_contoller.go +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete,namespace=system
-// duplicated in hazelcast_contoller.go +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete,namespace=system
+// duplicated in hazelcast_contoller.go +kubebuilder:rbac:groups="",resources=events;services;serviceaccounts;pods,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+// duplicated in hazelcast_contoller.go +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete,namespace=watched
+// duplicated in hazelcast_contoller.go +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete,namespace=watched
 
 func (r *ManagementCenterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("management-center", req.NamespacedName)

--- a/helm-charts/hazelcast-platform-operator/templates/role.yaml
+++ b/helm-charts/hazelcast-platform-operator/templates/role.yaml
@@ -23,7 +23,6 @@ rules:
     - patch
     - update
     - watch
----
 - apiGroups:
     - ""
   resources:

--- a/helm-charts/hazelcast-platform-operator/templates/role.yaml
+++ b/helm-charts/hazelcast-platform-operator/templates/role.yaml
@@ -6,6 +6,25 @@ metadata:
     {{- include "hazelcast-platform-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+    - apps
+  resources:
+    - deployments
+  verbs:
+    - get
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+- apiGroups:
     - ""
   resources:
     - configmaps
@@ -33,25 +52,7 @@ rules:
 - apiGroups:
     - apps
   resources:
-    - deployments
-  verbs:
-    - get
-- apiGroups:
-    - apps
-  resources:
     - statefulsets
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - coordination.k8s.io
-  resources:
-    - leases
   verbs:
     - create
     - delete

--- a/main.go
+++ b/main.go
@@ -41,7 +41,12 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete,namespace=system
+// Role related to leader election
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete,namespace=operator-namespace
+// Role related to Operator UUID
+//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get,namespace=operator-namespace
+// ClusterRole related to Webhooks
+//+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=update;get;watch;list
 
 func main() {
 	var metricsAddr string

--- a/test/e2e/hazelcast_persistence_test.go
+++ b/test/e2e/hazelcast_persistence_test.go
@@ -84,6 +84,44 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 		assertHotBackupSuccess(hotBackup, 1*Minute)
 	})
 
+	DescribeTable("should trigger corresponding action when startupActionSpecified", Label("slow"),
+		func(action hazelcastv1alpha1.PersistenceStartupAction, dataPolicy hazelcastv1alpha1.DataRecoveryPolicyType) {
+			if !ee {
+				Skip("This test will only run in EE configuration")
+			}
+			setLabelAndCRName("hp-2")
+			clusterSize := int32(3)
+
+			hazelcast := hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
+			CreateHazelcastCR(hazelcast)
+			evaluateReadyMembers(hzLookupKey)
+
+			By("creating HotBackup CR")
+			t := Now()
+			hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
+			Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
+			assertHotBackupSuccess(hotBackup, 1*Minute)
+
+			seq := GetBackupSequence(t, hzLookupKey)
+			RemoveHazelcastCR(hazelcast)
+
+			By("creating new Hazelcast cluster from existing backup with 2 members")
+			baseDir := "/data/hot-restart/hot-backup/backup-" + seq
+
+			hazelcast = hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
+			hazelcast.Spec.Persistence.BaseDir = baseDir
+			hazelcast.Spec.ClusterSize = &[]int32{2}[0]
+			hazelcast.Spec.Persistence.DataRecoveryTimeout = 60
+			hazelcast.Spec.Persistence.ClusterDataRecoveryPolicy = dataPolicy
+			hazelcast.Spec.Persistence.StartupAction = action
+			CreateHazelcastCR(hazelcast)
+			evaluateReadyMembers(hzLookupKey)
+			assertClusterStatePortForward(context.Background(), hazelcast, localPort, codecTypes.ClusterStateActive)
+		},
+		Entry("ForceStart", Label("slow"), hazelcastv1alpha1.ForceStart, hazelcastv1alpha1.FullRecovery),
+		Entry("PartialStart", Label("slow"), hazelcastv1alpha1.PartialStart, hazelcastv1alpha1.MostRecent),
+	)
+
 	It("should trigger multiple HotBackups with CronHotBackup", Label("slow"), func() {
 		if !ee {
 			Skip("This test will only run in EE configuration")
@@ -161,44 +199,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Label("hz_pers
 		hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
 		backupRestore(hazelcast, hotBackup, false)
 	})
-
-	DescribeTable("should trigger corresponding action when startupActionSpecified", Label("slow"),
-		func(action hazelcastv1alpha1.PersistenceStartupAction, dataPolicy hazelcastv1alpha1.DataRecoveryPolicyType) {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-			setLabelAndCRName("hp-2")
-			clusterSize := int32(3)
-
-			hazelcast := hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
-			CreateHazelcastCR(hazelcast)
-			evaluateReadyMembers(hzLookupKey)
-
-			By("creating HotBackup CR")
-			t := Now()
-			hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
-			Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
-			assertHotBackupSuccess(hotBackup, 1*Minute)
-
-			seq := GetBackupSequence(t, hzLookupKey)
-			RemoveHazelcastCR(hazelcast)
-
-			By("creating new Hazelcast cluster from existing backup with 2 members")
-			baseDir := "/data/hot-restart/hot-backup/backup-" + seq
-
-			hazelcast = hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
-			hazelcast.Spec.Persistence.BaseDir = baseDir
-			hazelcast.Spec.ClusterSize = &[]int32{2}[0]
-			hazelcast.Spec.Persistence.DataRecoveryTimeout = 60
-			hazelcast.Spec.Persistence.ClusterDataRecoveryPolicy = dataPolicy
-			hazelcast.Spec.Persistence.StartupAction = action
-			CreateHazelcastCR(hazelcast)
-			evaluateReadyMembers(hzLookupKey)
-			assertClusterStatePortForward(context.Background(), hazelcast, localPort, codecTypes.ClusterStateActive)
-		},
-		Entry("ForceStart", Label("slow"), hazelcastv1alpha1.ForceStart, hazelcastv1alpha1.FullRecovery),
-		Entry("PartialStart", Label("slow"), hazelcastv1alpha1.PartialStart, hazelcastv1alpha1.MostRecent),
-	)
 
 	DescribeTable("should successfully restore from LocalBackup-HostPath-HotBackupResourceName", Label("slow"), func(hostPath string, singleNode bool) {
 		if !ee {


### PR DESCRIPTION
## Description

There are two kinds of roles the operator needs. 
- Roles needed only for the namespace operator runs in
- Roles needed for namespaces operator watches.

This PR separates them visually, so when we generate ClusterRoles in the future we won't mistakenly create ClusterRoles for roles needed only for operator namespace.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
