### PR TITLE
[CN-687] Custom Logger support for the go client

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -53,7 +53,7 @@ docker_build_with_restart(
   ],
 )
 
-# This does not apply the operator deployment, it is done by docker_build_with_restart commmand
+# This does not apply the operator deployment, it is done by docker_build_with_restart command
 k8s_yaml(local("""make -s deploy-tilt IMG=%s INSTALL_CRDS=true DEBUG_ENABLED=%s \
               NAMESPACE=$(kubectl config view --minify --output \"jsonpath={..namespace}\")""" % (image_name,debug_enabled)))
 

--- a/controllers/hazelcast/fakes_test.go
+++ b/controllers/hazelcast/fakes_test.go
@@ -48,7 +48,7 @@ type fakeHzClientRegistry struct {
 	Clients sync.Map
 }
 
-func (cr *fakeHzClientRegistry) Create(ctx context.Context, h *hazelcastv1alpha1.Hazelcast) (hzclient.Client, error) {
+func (cr *fakeHzClientRegistry) Create(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, l logr.Logger) (hzclient.Client, error) {
 	ns := types.NamespacedName{Namespace: h.Namespace, Name: h.Name}
 	client, ok := cr.Get(ns)
 	if !ok {
@@ -57,8 +57,8 @@ func (cr *fakeHzClientRegistry) Create(ctx context.Context, h *hazelcastv1alpha1
 	return client, nil
 }
 
-func (ssr *fakeHzClientRegistry) Set(ns types.NamespacedName, cl hzclient.Client) {
-	ssr.Clients.Store(ns, cl)
+func (cr *fakeHzClientRegistry) Set(ns types.NamespacedName, cl hzclient.Client) {
+	cr.Clients.Store(ns, cl)
 }
 
 func (cr *fakeHzClientRegistry) Get(ns types.NamespacedName) (hzclient.Client, bool) {

--- a/controllers/hazelcast/fakes_test.go
+++ b/controllers/hazelcast/fakes_test.go
@@ -48,7 +48,7 @@ type fakeHzClientRegistry struct {
 	Clients sync.Map
 }
 
-func (cr *fakeHzClientRegistry) GetOrCreate(ctx context.Context, nn types.NamespacedName, l logr.Logger) (hzclient.Client, error) {
+func (cr *fakeHzClientRegistry) GetOrCreate(ctx context.Context, nn types.NamespacedName) (hzclient.Client, error) {
 	client, ok := cr.Get(nn)
 	if !ok {
 		return client, fmt.Errorf("Fake client was not set before test")

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -212,7 +212,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	cl, err := r.clientRegistry.GetOrCreate(ctx, req.NamespacedName,logger)
+	cl, err := r.clientRegistry.GetOrCreate(ctx, req.NamespacedName, logger)
 	if err != nil {
 		return r.update(ctx, h, pendingPhase(retryAfter).withMessage(err.Error()))
 	}
@@ -251,7 +251,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	externalAddrs := util.GetExternalAddresses(ctx, r.Client, h, logger)
 	return r.update(ctx, h, r.runningPhaseWithStatus(req).
 		withExternalAddresses(externalAddrs).
-		withMessage(clientConnectionMessage(r.clientRegistry, req)))
+		withMessage(clientConnectionMessage(r.clientRegistry, req, logger)))
 }
 
 func (r *HazelcastReconciler) podUpdates(pod client.Object) []reconcile.Request {
@@ -304,8 +304,8 @@ func getHazelcastCRName(pod *corev1.Pod) (string, bool) {
 	}
 }
 
-func clientConnectionMessage(cs hzclient.ClientRegistry, req ctrl.Request) string {
-	c, err := cs.GetOrCreate(context.Background(), req.NamespacedName)
+func clientConnectionMessage(cs hzclient.ClientRegistry, req ctrl.Request, logger logr.Logger) string {
+	c, err := cs.GetOrCreate(context.Background(), req.NamespacedName, logger)
 	if err != nil {
 		return "Operator failed to create connection to cluster, some features might be unavailable."
 	}

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -212,7 +212,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	cl, err := r.clientRegistry.Create(ctx, h)
+	cl, err := r.clientRegistry.Create(ctx, h, logger)
 	if err != nil {
 		return r.update(ctx, h, pendingPhase(retryAfter).withMessage(err.Error()))
 	}

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -212,7 +212,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	cl, err := r.clientRegistry.GetOrCreate(ctx, req.NamespacedName, logger)
+	cl, err := r.clientRegistry.GetOrCreate(ctx, req.NamespacedName)
 	if err != nil {
 		return r.update(ctx, h, pendingPhase(retryAfter).withMessage(err.Error()))
 	}
@@ -251,7 +251,7 @@ func (r *HazelcastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	externalAddrs := util.GetExternalAddresses(ctx, r.Client, h, logger)
 	return r.update(ctx, h, r.runningPhaseWithStatus(req).
 		withExternalAddresses(externalAddrs).
-		withMessage(clientConnectionMessage(r.clientRegistry, req, logger)))
+		withMessage(clientConnectionMessage(r.clientRegistry, req)))
 }
 
 func (r *HazelcastReconciler) podUpdates(pod client.Object) []reconcile.Request {
@@ -304,8 +304,8 @@ func getHazelcastCRName(pod *corev1.Pod) (string, bool) {
 	}
 }
 
-func clientConnectionMessage(cs hzclient.ClientRegistry, req ctrl.Request, logger logr.Logger) string {
-	c, err := cs.GetOrCreate(context.Background(), req.NamespacedName, logger)
+func clientConnectionMessage(cs hzclient.ClientRegistry, req ctrl.Request) string {
+	c, err := cs.GetOrCreate(context.Background(), req.NamespacedName)
 	if err != nil {
 		return "Operator failed to create connection to cluster, some features might be unavailable."
 	}

--- a/internal/hazelcast-client/client.go
+++ b/internal/hazelcast-client/client.go
@@ -115,12 +115,12 @@ func (cl *HazelcastClient) ClusterId() hztypes.UUID {
 	return ci.ClusterID()
 }
 
-func (c *HazelcastClient) Shutdown(ctx context.Context) error {
-	if c.client == nil {
+func (cl *HazelcastClient) Shutdown(ctx context.Context) error {
+	if cl.client == nil {
 		return nil
 	}
 
-	if err := c.client.Shutdown(ctx); err != nil {
+	if err := cl.client.Shutdown(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/internal/hazelcast-client/config.go
+++ b/internal/hazelcast-client/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
-	"github.com/hazelcast/hazelcast-go-client/logger"
+	hzlogger "github.com/hazelcast/hazelcast-go-client/logger"
 	hztypes "github.com/hazelcast/hazelcast-go-client/types"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
@@ -20,10 +20,10 @@ const (
 	AgentPort = 8443
 )
 
-func BuildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
+func BuildConfig(h *hazelcastv1alpha1.Hazelcast, logger hzlogger.Logger) hazelcast.Config {
 	config := hazelcast.Config{
-		Logger: logger.Config{
-			Level: logger.OffLevel,
+		Logger: hzlogger.Config{
+			CustomLogger: logger,
 		},
 		Cluster: cluster.Config{
 			ConnectionStrategy: cluster.ConnectionStrategyConfig{

--- a/internal/hazelcast-client/config_test_unit.go
+++ b/internal/hazelcast-client/config_test_unit.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/cluster"
-	"github.com/hazelcast/hazelcast-go-client/logger"
+	hzlogger "github.com/hazelcast/hazelcast-go-client/logger"
 	hztypes "github.com/hazelcast/hazelcast-go-client/types"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
@@ -22,10 +22,10 @@ const (
 	AgentPort = 8080
 )
 
-func BuildConfig(h *hazelcastv1alpha1.Hazelcast) hazelcast.Config {
+func BuildConfig(h *hazelcastv1alpha1.Hazelcast, logger hzlogger.Logger) hazelcast.Config {
 	config := hazelcast.Config{
-		Logger: logger.Config{
-			Level: logger.OffLevel,
+		Logger: hzlogger.Config{
+			CustomLogger: logger,
 		},
 		Cluster: cluster.Config{
 			ConnectionStrategy: cluster.ConnectionStrategyConfig{

--- a/internal/hazelcast-client/logger.go
+++ b/internal/hazelcast-client/logger.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/hazelcast/hazelcast-go-client/logger"
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/util"
+)
+
+type LogrHzClientLoggerAdapter struct {
+	logger logr.Logger
+	weight logger.Weight
+}
+
+func NewLogrHzClientLoggerAdapter(l logr.Logger, level logger.Level, h *hazelcastv1alpha1.Hazelcast) (*LogrHzClientLoggerAdapter, error) {
+	w, err := logger.WeightForLogLevel(level)
+	clientLogger := l.WithName(fmt.Sprintf("hz-client-%s-%s", h.Name, h.Spec.ClusterName)).
+		WithValues("cluster", h.Spec.ClusterName)
+	return &LogrHzClientLoggerAdapter{
+		logger: clientLogger,
+		weight: w,
+	}, err
+}
+
+func (l *LogrHzClientLoggerAdapter) Log(weight logger.Weight, formatter func() string) {
+	if weight <= l.weight {
+		l.Logger(weight).Info(formatter())
+	}
+}
+
+func (l *LogrHzClientLoggerAdapter) Logger(weight logger.Weight) logr.Logger {
+	if weight <= logger.WeightFatal {
+		return l.logger.V(util.PanicLevel)
+	} else if weight <= logger.WeightError {
+		return l.logger.V(util.ErrorLevel)
+	} else if weight <= logger.WeightWarn {
+		return l.logger.V(util.WarnLevel)
+	} else if weight <= logger.WeightInfo {
+		return l.logger.V(util.InfoLevel)
+	} else {
+		return l.logger.V(util.DebugLevel)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -148,9 +148,11 @@ func main() {
 		}
 	}
 
+	controllerLogger := ctrl.Log.WithName("controllers")
+
 	if err = hazelcast.NewHazelcastReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Hazelcast"),
+		controllerLogger.WithName("Hazelcast"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,
@@ -162,7 +164,7 @@ func main() {
 
 	if err = managementcenter.NewManagementCenterReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Management Center"),
+		controllerLogger.WithName("Management Center"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 	).SetupWithManager(mgr); err != nil {
@@ -172,7 +174,7 @@ func main() {
 
 	if err = hazelcast.NewHotBackupReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("HotBackup"),
+		controllerLogger.WithName("HotBackup"),
 		phoneHomeTrigger,
 		mtlsClient,
 		cr,
@@ -184,7 +186,7 @@ func main() {
 
 	if err = hazelcast.NewMapReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Map"),
+		controllerLogger.WithName("Map"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,
@@ -195,7 +197,7 @@ func main() {
 
 	if err = hazelcast.NewWanReplicationReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("WanReplication"),
+		controllerLogger.WithName("WanReplication"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		mtlsClient,
@@ -208,7 +210,7 @@ func main() {
 
 	if err = hazelcast.NewCronHotBackupReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("CronHotBackup"),
+		controllerLogger.WithName("CronHotBackup"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 	).SetupWithManager(mgr); err != nil {
@@ -218,7 +220,7 @@ func main() {
 
 	if err = hazelcast.NewMultiMapReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("MultiMap"),
+		controllerLogger.WithName("MultiMap"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,
@@ -228,7 +230,7 @@ func main() {
 
 	if err = hazelcast.NewTopicReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Topic"),
+		controllerLogger.WithName("Topic"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,
@@ -239,7 +241,7 @@ func main() {
 
 	if err = hazelcast.NewReplicatedMapReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("ReplicatedMap"),
+		controllerLogger.WithName("ReplicatedMap"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,
@@ -250,7 +252,7 @@ func main() {
 
 	if err = hazelcast.NewQueueReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Queue"),
+		controllerLogger.WithName("Queue"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,
@@ -261,7 +263,7 @@ func main() {
 
 	if err = hazelcast.NewCacheReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Cache"),
+		controllerLogger.WithName("Cache"),
 		mgr.GetScheme(),
 		phoneHomeTrigger,
 		cr,

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -86,9 +86,11 @@ var _ = BeforeSuite(func() {
 	cs := &hzclient.HazelcastClientRegistry{K8sClient: k8sClient}
 	ssm := &hzclient.HzStatusServiceRegistry{}
 
+	controllerLogger := ctrl.Log.WithName("controllers")
+
 	err = hazelcast.NewHazelcastReconciler(
 		k8sManager.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Hazelcast"),
+		controllerLogger.WithName("Hazelcast"),
 		k8sManager.GetScheme(),
 		nil,
 		cs,
@@ -98,7 +100,7 @@ var _ = BeforeSuite(func() {
 
 	err = managementcenter.NewManagementCenterReconciler(
 		k8sManager.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Management Center"),
+		controllerLogger.WithName("Management Center"),
 		k8sManager.GetScheme(),
 		nil,
 	).SetupWithManager(k8sManager)
@@ -106,7 +108,7 @@ var _ = BeforeSuite(func() {
 
 	err = hazelcast.NewMapReconciler(
 		k8sManager.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Map"),
+		controllerLogger.WithName("Map"),
 		k8sManager.GetScheme(),
 		nil,
 		cs,
@@ -115,7 +117,7 @@ var _ = BeforeSuite(func() {
 
 	err = hazelcast.NewHotBackupReconciler(
 		k8sManager.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Hot Backup"),
+		controllerLogger.WithName("Hot Backup"),
 		nil,
 		nil,
 		cs,
@@ -125,7 +127,7 @@ var _ = BeforeSuite(func() {
 
 	err = hazelcast.NewCronHotBackupReconciler(
 		k8sManager.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("Cron Hot Backup"),
+		controllerLogger.WithName("Cron Hot Backup"),
 		k8sManager.GetScheme(),
 		nil,
 	).SetupWithManager(k8sManager)


### PR DESCRIPTION
## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

Implementing Hazelcast client custom logger adapter for `logr` library which is used in the operator.

For now, it is only for debug-purpose. So there is no config field to set the level of Hz client logger. The level is set to `logger.InfoLevel` in hard-coded way.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
