### PR TITLE
Fix make tilt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,12 +249,13 @@ sync-manifests: manifests yq
 # Move role rules into helm template
 	role=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/role.yaml \
 		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "operator-namespace") | .rules' \
-		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "watched") | .rules') ;\
-		echo "$$role" > $(OPERATOR_CHART)/templates/role.yaml
+		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "watched") | .rules');\
+		 echo "$$role" > "$(OPERATOR_CHART)/templates/role.yaml"
+
 # Move clusterrole rules into helm template
-	@clusterrole=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/clusterrole.yaml \
-		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "ClusterRole") | .rules') ;\
-		echo "$$clusterrole" > $(OPERATOR_CHART)/templates/clusterrole.yaml
+	clusterrole=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/clusterrole.yaml \
+			&& cat config/rbac/role.yaml | $(YQ) 'select(.kind == "ClusterRole") | .rules');\
+	  		echo "$$clusterrole" > "$(OPERATOR_CHART)/templates/clusterrole.yaml"
 
 install-crds: helm sync-manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config. NOTE: 'default' namespace is used for the CRD chart release since we are checking if the CRDs is installed before, then we are skipping CRDs installation. To be able to achieve this, we need static CRD_RELEASE_NAME and namespace
 	$(HELM) upgrade --install $(CRD_RELEASE_NAME) $(CRD_CHART) -n default ;\

--- a/Makefile
+++ b/Makefile
@@ -247,13 +247,13 @@ sync-manifests: manifests yq
 # Move CRDs into helm template
 	@cat config/crd/bases/* >> all-crds.yaml && mv all-crds.yaml $(CRD_CHART)/templates/
 # Move role rules into helm template
-	role=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/role.yaml \
+	@role=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/role.yaml \
 		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "operator-namespace") | .rules' \
 		 && cat config/rbac/role.yaml | $(YQ) 'select(.kind == "Role" and .metadata.namespace == "watched") | .rules');\
 		 echo "$$role" > "$(OPERATOR_CHART)/templates/role.yaml"
 
 # Move clusterrole rules into helm template
-	clusterrole=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/clusterrole.yaml \
+	@clusterrole=$$(awk '{print; if (match($$0,"rules:")) exit}' $(OPERATOR_CHART)/templates/clusterrole.yaml \
 			&& cat config/rbac/role.yaml | $(YQ) 'select(.kind == "ClusterRole") | .rules');\
 	  		echo "$$clusterrole" > "$(OPERATOR_CHART)/templates/clusterrole.yaml"
 


### PR DESCRIPTION
## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

When I run `make sync-manifests` command, it works well and output is as expected. However, when this `make sync-manifests` command is executed from `tilt`, its output is slightly different.

```
 →     - securitycontextconstraints
 →   verbs:
 →     - use
 → ---
 → # Source: hazelcast-platform-operator/templates/crrsterrole.yaml
 → apiVersion: rbac.authorization.k8s.io/v1
 → kind: ClusterRole
 → metadata:
 →   name: v1-hazelcast-platform-operator
 →   labels:
 →     helm.sh/chart: hazelcast-platform-operator-5.6.0
 →     app.kubernetes.io/name: hazelcast-platform-operator
 →     app.kubernetes.io/instance: v1
```

The name of cluster role file is changed to `crrsterrole.yaml` unexpectedly.

```
Traceback (most recent call last):
  /Users/semih/hazelcast/operator/hazelcast-platform-operator/Tiltfile:57:9: in <toplevel>
Error in k8s_yaml: Duplicate YAML: ClusterRole v1-hazelcast-platform-operator
Ignore this error with k8s_yaml(..., allow_duplicates=True)
YAML originally registered at: Traceback (most recent call last):
    /Users/semih/hazelcast/operator/hazelcast-platform-operator/Tiltfile:57:9: in <toplevel>
    <builtin>: in k8s_yaml
```

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
