### PR TITLE
fix sidecar agent naming in tests

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -94,7 +94,7 @@ func SidecarAgentLogs(t Time, lk types.NamespacedName) io.ReadCloser {
 		}, &corev1.PodLogOptions{
 			Follow:    true,
 			SinceTime: &metav1.Time{Time: t},
-			Container: "backup-agent",
+			Container: "sidecar-agent",
 		})
 	})
 	return logs


### PR DESCRIPTION
## Description

We renamed backup-agent as sidecar-agent but forgot to fix it in tests.

## User Impact
