### PR TITLE
Decrease the image build time and add option to re-run tests with rep…

### DIFF
--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -7,6 +7,10 @@ on:
 env:
   GCP_PROJECT_ID: hazelcast-33
   GKE_ZONE: europe-west1-b
+  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   create-gke-cluster:
@@ -51,23 +55,61 @@ jobs:
     name: Get Image
     runs-on: ubuntu-latest
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build and push image to ttl.sh
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
-            IMG=ttl.sh/$(uuidgen):2h
-            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-            make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-            make docker-push IMG=$IMG
+            echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
             echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Build Image
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   gke-e2e-backup-tests:
     name: Run E2E Backup tests
@@ -108,6 +150,13 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           project_id: ${{ env.GCP_PROJECT_ID }}
           location: ${{ env.GKE_ZONE }}
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Deploy Operator to GKE
         run: |

--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -61,17 +61,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -102,14 +94,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   gke-e2e-backup-tests:
     name: Run E2E Backup tests

--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           preflight: "latest"
           source: github
+          skip_cache: true
 
       - name: Set Environment Variables And Job Outputs
         id: setup-envs
@@ -64,17 +65,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache-aks
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -95,13 +88,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.setup-envs.outputs.CONTAINER_IMAGE }}
-          cache-from: type=local,src=/tmp/.buildx-cache-aks
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-aks-new
-
-      - name: Move Docker Cache
-        run: |
-          rm -rf /tmp/.buildx-cache-aks
-          mv /tmp/.buildx-cache-aks-new /tmp/.buildx-cache-aks
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
       - name: Initiating a Container Scan
         run: |
@@ -182,9 +170,12 @@ jobs:
         with:
           preflight: "latest"
           source: github
+          skip_cache: true
+
       - uses: redhat-actions/openshift-tools-installer@v1
         with:
           opm: "latest"
+          skip_cache: true
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -258,10 +249,12 @@ jobs:
         with:
           preflight: "latest"
           source: github
+          skip_cache: true
 
       - uses: redhat-actions/openshift-tools-installer@v1
         with:
           operator-sdk: "latest"
+          skip_cache: true
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2

--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -15,6 +15,9 @@ env:
   PFLT_PYXIS_API_TOKEN: ${{ secrets.RHEL_API_KEY }}
   NAMESPACE: oc-test-operator-${{ github.run_id }}
   PARDOT_ID: redhat
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   test_container:
@@ -26,7 +29,7 @@ jobs:
     outputs:
       RELEASE_VERSION: ${{ steps.setup-envs.outputs.RELEASE_VERSION }}
       CONTAINER_IMAGE: ${{ steps.setup-envs.outputs.CONTAINER_IMAGE }}
-      CONTAINER_IMAGE_DIGEST: ${{ steps.push-operator-image.outputs.CONTAINER_IMAGE_DIGEST }}
+      CONTAINER_IMAGE_DIGEST: ${{ steps.build-image.outputs.digest }}
     steps:
       - name: Checkout to hazelcast-operator
         uses: actions/checkout@v3
@@ -41,8 +44,8 @@ jobs:
         id: setup-envs
         run: |
           if [[ ${{ github.event_name == 'schedule' }} == true ]]; then
-              echo "RELEASE_VERSION=7.8.0" >> $GITHUB_ENV
-              echo "RELEASE_VERSION=7.8.0" >> $GITHUB_OUTPUT
+              echo "RELEASE_VERSION=1.0.0" >> $GITHUB_ENV
+              echo "RELEASE_VERSION=1.0.0" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
               echo "RELEASE_VERSION=${{ github.event.inputs.RELEASE_VERSION }}" >> $GITHUB_ENV
               echo "RELEASE_VERSION=${{ github.event.inputs.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
@@ -50,8 +53,7 @@ jobs:
               echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
               echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
           fi
-              CONTAINER_REPOSITORY=$(uuidgen)
-              CONTAINER_IMAGE=ttl.sh/$CONTAINER_REPOSITORY:1h
+              CONTAINER_IMAGE=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d
               echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> $GITHUB_ENV
               echo "CONTAINER_IMAGE=${CONTAINER_IMAGE}" >> $GITHUB_OUTPUT
 
@@ -60,18 +62,46 @@ jobs:
           NUMBER='(0|[1-9][0-9]*)'
           echo ${RELEASE_VERSION} | egrep "^$NUMBER.$NUMBER(.$NUMBER)?$"
 
-      - name: Build Operator Image
-        run: |
-          echo "Building the operator image"
-          make docker-build-ci IMG=$CONTAINER_IMAGE VERSION=${RELEASE_VERSION} PARDOT_ID=${PARDOT_ID}
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
 
-      - name: Push Operator Image to ttl.sh
-        id: push-operator-image
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache-aks
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Build Image
+        id: build-image
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.setup-envs.outputs.CONTAINER_IMAGE }}
+          cache-from: type=local,src=/tmp/.buildx-cache-aks
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-aks-new
+
+      - name: Move Docker Cache
         run: |
-          echo "Pushing the operator image to ttl.sh repository"
-          make docker-push IMG=$CONTAINER_IMAGE
-          CONTAINER_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${CONTAINER_IMAGE} | cut -d'@' -f2)
-          echo "CONTAINER_IMAGE_DIGEST=${CONTAINER_IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          rm -rf /tmp/.buildx-cache-aks
+          mv /tmp/.buildx-cache-aks-new /tmp/.buildx-cache-aks
 
       - name: Initiating a Container Scan
         run: |
@@ -89,6 +119,13 @@ jobs:
       CONTAINER_IMAGE: ${{ needs.test_container.outputs.CONTAINER_IMAGE }}
     runs-on: ubuntu-latest
     steps:
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
       - name: Run OpenSCAP Vulnerability Scan
         id: vulnerabilityScan
         uses: appleboy/ssh-action@v0.1.6
@@ -149,13 +186,20 @@ jobs:
         with:
           opm: "latest"
 
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
       - name: Set Environment Variables And Job Outputs
         id: build-bundle-outputs
         run: |
           BUNDLE_VERSION=$( make print-bundle-version VERSION=${RELEASE_VERSION} )
-          BUNDLE_REPOSITORY=$(uuidgen)
-          BUNDLE_IMAGE=ttl.sh/$BUNDLE_REPOSITORY:1h
-          PFLT_INDEXIMAGE=ttl.sh/$BUNDLE_REPOSITORY-index:1h
+          BUNDLE_REPOSITORY=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen)
+          BUNDLE_IMAGE=$BUNDLE_REPOSITORY:5d
+          PFLT_INDEXIMAGE=$BUNDLE_REPOSITORY-index:5d
           echo "BUNDLE_VERSION=${BUNDLE_VERSION}" >> $GITHUB_ENV
           echo "BUNDLE_REPOSITORY=${BUNDLE_REPOSITORY}" >> $GITHUB_ENV
           echo "BUNDLE_IMAGE=${BUNDLE_IMAGE}" >> $GITHUB_ENV
@@ -219,10 +263,12 @@ jobs:
         with:
           operator-sdk: "latest"
 
-      - name: Login to Docker Hub Registry
-        run: |
-          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | \
-            docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Login to OCP and Create New Project
         id: project_creation
@@ -254,7 +300,6 @@ jobs:
     with:
       RELEASE_VERSION: ${{ needs.test_container.outputs.RELEASE_VERSION }}
     secrets: inherit
-
 
   clean_up_artifacts:
     if: always()

--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -263,19 +263,19 @@ jobs:
         with:
           operator-sdk: "latest"
 
-      - name: Login to OCP and Create New Project
-        id: project_creation
-        run: |
-          oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
-          oc new-project ${NAMESPACE}
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
-
       - name: Authenticate to GAR
         uses: docker/login-action@v2
         with:
           registry: us-east1-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Login to OCP and Create New Project
+        id: project_creation
+        run: |
+          oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
+          oc new-project ${NAMESPACE}
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Initiating an Operator Bundle Scan
         run: |

--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -263,19 +263,19 @@ jobs:
         with:
           operator-sdk: "latest"
 
-      - name: Authenticate to GAR
-        uses: docker/login-action@v2
-        with:
-          registry: us-east1-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GKE_SA_KEY }}
-
       - name: Login to OCP and Create New Project
         id: project_creation
         run: |
           oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
           oc new-project ${NAMESPACE}
           echo "exit_code=$?" >> $GITHUB_OUTPUT
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Initiating an Operator Bundle Scan
         run: |

--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -54,14 +54,14 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
 
       - name: Cache Docker Layers
         uses: actions/cache@v3.2.3
         with:
-          path: /tmp/.buildx-cache-aks
+          path: /tmp/.buildx-cache
           key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-multi-buildx
@@ -89,8 +89,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache-aks
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-aks-new
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
       - name: Move Docker Cache
         run: |

--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -130,13 +130,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Authenticate to GAR
-        uses: docker/login-action@v2
-        with:
-          registry: us-east1-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GKE_SA_KEY }}
-
       - name: Azure login
         uses: azure/login@v1
         with:
@@ -146,6 +139,13 @@ jobs:
         run: |-
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           az aks get-credentials --resource-group "${AZURE_RESOURCE_GROUP}" --name "${CLUSTER_NAME}"
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Deploy CRDs
         if: matrix.edition == 'ee'

--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -5,6 +5,9 @@ on:
 
 env:
   AZURE_RESOURCE_GROUP: operator-test
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   prepare-env:
@@ -45,18 +48,54 @@ jobs:
     name: Get Image
     runs-on: ubuntu-latest
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build and push image to ttl.sh
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache-aks
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
-          IMG=ttl.sh/$(uuidgen):2h
-          echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-          make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-          make docker-push IMG=$IMG
+          echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
+
+      - name: Build Image
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache-aks
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-aks-new
+
+      - name: Move Docker Cache
+        run: |
+          rm -rf /tmp/.buildx-cache-aks
+          mv /tmp/.buildx-cache-aks-new /tmp/.buildx-cache-aks
 
   aks-e2e-tests:
     name: Run e2e test on AKS
@@ -90,6 +129,13 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Azure login
         uses: azure/login@v1

--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -130,6 +130,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
       - name: Azure login
         uses: azure/login@v1
         with:

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -6,6 +6,9 @@ on:
 env:
   AWS_REGION: us-east-1
   DELETE_EKS_STACK_TIMEOUT_IN_MINS: "15"
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   prepare-env:
@@ -65,18 +68,54 @@ jobs:
     name: Get Image
     runs-on: ubuntu-latest
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build and push image to ttl.sh
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
-          IMG=ttl.sh/$(uuidgen):2h
-          echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-          make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-          make docker-push IMG=$IMG
+          echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
+
+      - name: Build Image
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   eks-e2e-tests:
     name: Run e2e test on EKS
@@ -117,6 +156,13 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Update kubeconfig
         run: |-

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -163,6 +163,7 @@ jobs:
           aws eks update-kubeconfig --name "${CLUSTER_NAME}"
 
       - name: Helm Registry Login
+        run: |-
           cat ${{ secrets.GKE_SA_KEY }} | helm registry login -u _json_key --password-stdin \
           https://us-east1-docker.pkg.dev
 

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -74,17 +74,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -109,13 +101,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   eks-e2e-tests:
     name: Run e2e test on EKS

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -157,6 +157,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
       - name: Update kubeconfig
         run: |-
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -162,10 +162,12 @@ jobs:
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           aws eks update-kubeconfig --name "${CLUSTER_NAME}"
 
-      - name: Helm Registry Login
-        run: |-
-          echo ${{ secrets.GKE_SA_KEY }} | helm registry login -u _json_key --password-stdin \
-          https://us-east1-docker.pkg.dev
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Deploy CRDs
         if: matrix.edition == 'ee'

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Helm Registry Login
         run: |-
-          cat ${{ secrets.GKE_SA_KEY }} | helm registry login -u _json_key --password-stdin \
+          echo ${{ secrets.GKE_SA_KEY }} | helm registry login -u _json_key --password-stdin \
           https://us-east1-docker.pkg.dev
 
       - name: Deploy CRDs

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -157,17 +157,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Authenticate to GAR
-        uses: docker/login-action@v2
-        with:
-          registry: us-east1-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GKE_SA_KEY }}
-
       - name: Update kubeconfig
         run: |-
           CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
           aws eks update-kubeconfig --name "${CLUSTER_NAME}"
+
+      - name: Helm Registry Login
+          cat ${{ secrets.GKE_SA_KEY }} | helm registry login -u _json_key --password-stdin \
+          https://us-east1-docker.pkg.dev
 
       - name: Deploy CRDs
         if: matrix.edition == 'ee'

--- a/.github/workflows/e2e-gke.yaml
+++ b/.github/workflows/e2e-gke.yaml
@@ -6,6 +6,9 @@ on:
 env:
   GCP_PROJECT_ID: hazelcast-33
   GKE_ZONE: europe-west1-b
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   create-gke-cluster:
@@ -50,18 +53,54 @@ jobs:
     name: Get Image
     runs-on: ubuntu-latest
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build and push image to ttl.sh
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
-          IMG=ttl.sh/$(uuidgen):2h
-          echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-          make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-          make docker-push IMG=$IMG
+          echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
+
+      - name: Build Image
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   gke-e2e-tests:
     name: Run e2e test on GKE
@@ -99,6 +138,13 @@ jobs:
         uses: "google-github-actions/auth@v1.0.0"
         with:
           credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Connect to the GKE cluster
         uses: 'google-github-actions/get-gke-credentials@v1'

--- a/.github/workflows/e2e-gke.yaml
+++ b/.github/workflows/e2e-gke.yaml
@@ -163,8 +163,6 @@ jobs:
           kubectl config set-context --current --namespace=$NAMESPACE
 
           DEPLOY_NAME=${RELEASE_NAME}-hazelcast-platform-operator
-          echo "DEPLOY_NAME=${DEPLOY_NAME}" >> $GITHUB_ENV
-
           make install-operator IMG=$IMG NAMESPACE=$NAMESPACE RELEASE_NAME=$RELEASE_NAME
           kubectl rollout status deployment $DEPLOY_NAME
 

--- a/.github/workflows/e2e-gke.yaml
+++ b/.github/workflows/e2e-gke.yaml
@@ -59,17 +59,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -94,13 +86,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   gke-e2e-tests:
     name: Run e2e test on GKE

--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -10,6 +10,9 @@ env:
   OCP_USERNAME: ${{ secrets.OCP_USERNAME }}
   OCP_PASSWORD: ${{ secrets.OCP_PASSWORD }}
   GRAFANA_NAMESPACE: grafana
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   check-and-restart-nodes:
@@ -33,6 +36,59 @@ jobs:
           source .github/scripts/utils.sh
           oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
           wait_for_instance_restarted $RESTART_OCP_NODE_TIMEOUT
+
+  get-image:
+    name: Get Image
+    runs-on: ubuntu-latest
+    outputs:
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
+        run: |
+          echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
+
+      - name: Build Image
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   grafana-setup:
     name: Setup Grafana agent
@@ -88,7 +144,7 @@ jobs:
   ocp-e2e-tests:
     name: Run e2e test on OCP
     runs-on: ubuntu-latest
-    needs: grafana-setup
+    needs: [grafana-setup, get-image]
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +156,7 @@ jobs:
       HZ_LICENSE_KEY: ${{ secrets.HZ_LICENSE_KEY }}
       NAMESPACE: oc-e2e-test-operator-${{ matrix.edition }}-${{ github.run_id }}
       RELEASE_NAME: hp-${{ matrix.edition }}-${{ github.run_id }}
+      IMG: ${{ needs.get-image.outputs.IMG }}
     steps:
       - name: Checkout to hazelcast-operator
         uses: actions/checkout@v3
@@ -118,17 +175,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Build Image
-        run: |
-          IMG=ttl.sh/$(uuidgen):2h
-          echo "IMG=${IMG}" >> $GITHUB_ENV
-
-          make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-          make docker-push IMG=$IMG
-
       - name: Update kubeconfig
         run: |-
-            oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
+          oc login ${OCP_CLUSTER_URL} -u=${OCP_USERNAME} -p=${OCP_PASSWORD} --insecure-skip-tls-verify
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Deploy CRDs
         if: matrix.edition == 'ee'
@@ -189,6 +245,7 @@ jobs:
     name: Remove Unused Images From The Local Store
     runs-on: ubuntu-latest
     needs: ocp-e2e-tests
+    timeout-minutes: 10
     if: always()
     timeout-minutes: 10
     env:
@@ -232,7 +289,7 @@ jobs:
   slack_notify:
     name: Slack Notify
     needs: [ 'ocp-e2e-tests' ]
-    if: always() &&  needs.ocp-e2e-tests.result != 'success' 
+    if: always() &&  needs.ocp-e2e-tests.result != 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: 8398a7/action-slack@a189acbf0b7ea434558662ae25a0de71df69a435

--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -247,7 +247,6 @@ jobs:
     needs: ocp-e2e-tests
     timeout-minutes: 10
     if: always()
-    timeout-minutes: 10
     env:
       GRAFANA_NS: "grafana-${{ github.run_id }}"
     steps:

--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -47,17 +47,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -82,13 +74,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   grafana-setup:
     name: Setup Grafana agent

--- a/.github/workflows/generate-test-report.yaml
+++ b/.github/workflows/generate-test-report.yaml
@@ -126,10 +126,3 @@ jobs:
         run: |
           source .github/scripts/utils.sh
           cleanup_page_publish_runs ${GITHUB_REPOSITORY} "pages-build-deployment" ${{ github.run_number }} $CLEANUP_TIMEOUT
-
-      - name: Delete Test Artifact
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: |
-            test-suites
-            test-report-${{ inputs.WORKFLOW_ID }}

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -57,7 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       IMG: ${{ steps.get-image-tag.outputs.IMG }}
-      VERSION: ${{ steps.get-image-tag.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v3
 
@@ -82,16 +81,14 @@ jobs:
           username: _json_key
           password: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Generate Image Name and Version
+      - name: Generate Image Name
         id: get-image-tag
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
-            echo "VERSION=${{github.sha}}" >> $GITHUB_OUTPUT
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
             echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-            echo "VERSION=latest-snapshot" >> $GITHUB_OUTPUT
           fi
 
       - name: Build Image
@@ -101,7 +98,7 @@ jobs:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
-            version=${{ steps.get-image-tag.outputs.VERSION }}
+            version=${{github.sha}}
             pardotID=dockerhub
           file: Dockerfile
           push: true

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       IMG: ${{ steps.get-image-tag.outputs.IMG }}
+      VERSION: ${{ steps.get-image-tag.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v3
 
@@ -81,14 +82,16 @@ jobs:
           username: _json_key
           password: ${{ secrets.GKE_SA_KEY }}
 
-      - name: Generate Image Name
+      - name: Generate Image Name and Version
         id: get-image-tag
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
             echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
+            echo "VERSION=${{github.sha}}" >> $GITHUB_OUTPUT
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
             echo "IMG=${IMG}" >> $GITHUB_OUTPUT
+            echo "VERSION=latest-snapshot" >> $GITHUB_OUTPUT
           fi
 
       - name: Build Image
@@ -98,7 +101,7 @@ jobs:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
-            version=${{github.sha}}
+            version=${{ steps.get-image-tag.outputs.VERSION }}
             pardotID=dockerhub
           file: Dockerfile
           push: true

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -62,17 +62,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -103,14 +95,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   gke-ph-tests:
     name: Run PhoneHome tests

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -8,6 +8,10 @@ env:
   GCP_PROJECT_ID: hazelcast-33
   GKE_ZONE: europe-west1-b
   BIG_QUERY_TABLE: hazelcast-33.callHome.operator_info
+  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   create-gke-cluster:
@@ -52,26 +56,61 @@ jobs:
     name: Get Image
     runs-on: ubuntu-latest
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
-      VERSION: ${{ steps.build-img.outputs.VERSION }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build and push image to ttl.sh
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
-            IMG=ttl.sh/$(uuidgen):2h
-            make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-            make docker-push IMG=$IMG
-            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-            echo "VERSION=${{github.sha}}" >> $GITHUB_OUTPUT
+            echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
             echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-            echo "VERSION=latest-snapshot" >> $GITHUB_OUTPUT
           fi
+
+      - name: Build Image
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   gke-ph-tests:
     name: Run PhoneHome tests
@@ -114,6 +153,13 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           project_id: ${{ env.GCP_PROJECT_ID }}
           location: ${{ env.GKE_ZONE }}
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
 
       - name: Deploy Operator to GKE
         run: |

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -9,29 +9,71 @@ env:
   GKE_ZONE: europe-west1-b
   NUMBER_OF_NODES: 3
   GCP_NETWORK: operator-test-network
+  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 jobs:
   get-image:
     name: Get Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build And Push Image To ttl.sh
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
-            IMG=ttl.sh/$(uuidgen):2h
-            echo "IMG=${IMG}" >> $GITHUB_OUTPUT
-            make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-            make docker-push IMG=$IMG
+            echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
           else
             IMG=hazelcast/hazelcast-platform-operator:latest-snapshot
             echo "IMG=${IMG}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Build Image
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   create-gke-cluster:
     name: Create GKE Cluster
@@ -119,6 +161,13 @@ jobs:
           project_id: ${{ env.GCP_PROJECT_ID }}
           location: ${{ env.GKE_ZONE }}
 
+      - name: Authenticate to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
       - name: Deploy CRDs
         if: matrix.namespace == 'trg-ns'
         run: make install-crds
@@ -203,9 +252,9 @@ jobs:
 
       - name: Merge KUBECONFIG Files
         run: |
-           KUBECONFIG="$FIRST_KUBECONFIG:$SECOND_KUBECONFIG"
-           kubectl config view --raw > ${GITHUB_WORKSPACE}/kubeconfig
-           echo "KUBECONFIG="${GITHUB_WORKSPACE}/kubeconfig"" >> $GITHUB_ENV
+          KUBECONFIG="$FIRST_KUBECONFIG:$SECOND_KUBECONFIG"
+          kubectl config view --raw > ${GITHUB_WORKSPACE}/kubeconfig
+          echo "KUBECONFIG="${GITHUB_WORKSPACE}/kubeconfig"" >> $GITHUB_ENV
 
       - name: Run Wan Test
         run: |-

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -25,17 +25,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Authenticate to GAR
         uses: docker/login-action@v2
@@ -66,14 +58,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   create-gke-cluster:
     name: Create GKE Cluster

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -66,9 +66,10 @@ jobs:
           make docker-build-ci IMG=${IMAGE_NAME} VERSION=${RELEASE_VERSION}
 
       - name: Login to Docker Hub
-        run: |
-          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | \
-            docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push Operator Image
         id: push-operator-image
@@ -328,9 +329,10 @@ jobs:
           }'
 
       - name: Login to Docker Hub
-        run: |
-          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | \
-          docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Making Previous Docker Image Tag As 'latest'
         run: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -98,6 +98,7 @@ jobs:
         with:
           preflight: "latest"
           source: github
+          skip_cache: true
 
       - name: Test and Submit Container Results to Red Hat
         run: |

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -29,9 +29,10 @@ jobs:
         run: make docker-build IMG="hazelcast/hazelcast-platform-operator:latest-snapshot" VERSION="latest-snapshot"
 
       - name: Login to Docker Hub
-        run: |
-          echo "${{ secrets.DOCKERHUB_PASSWORD }}" \
-            | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push Operator Image
         run: make docker-push IMG="hazelcast/hazelcast-platform-operator:latest-snapshot"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -355,7 +355,7 @@ jobs:
           --namespace ${{ env.NAMESPACE }} \
           --from-literal=google-credentials-path='${{ secrets.GKE_SA_KEY }}'
 
-      - name: Login to GAR
+      - name: Authenticate to GAR
         uses: docker/login-action@v2
         with:
           registry: us-east1-docker.pkg.dev

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,6 +21,9 @@ env:
   NR_OF_SUITES: 5
   GOBIN: ${{ github.workspace }}/bin
   GINKGO_VERSION: v2.1.6
+  GAR_REGION: us-east1
+  GAR_PROJECT: hazelcast-33
+  GAR_REPO: hazelcast-platform-operator
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -150,18 +153,54 @@ jobs:
     if: ( !cancelled() && github.event_name == 'pull_request' )
     timeout-minutes: 10
     outputs:
-      IMG: ${{ steps.build-img.outputs.IMG }}
+      IMG: ${{ steps.get-image-tag.outputs.IMG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Build And Push Image
-        id: build-img
+      - name: Set Up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+
+      - name: Cache Docker Layers
+        uses: actions/cache@v3.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Login to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Generate Image Name
+        id: get-image-tag
         run: |
-           IMG=ttl.sh/$(uuidgen):2h
-           make docker-build-ci IMG=$IMG VERSION=${{github.sha}}
-           make docker-push IMG=$IMG
-           echo "IMG=${IMG}" >> $GITHUB_OUTPUT
+          echo "IMG=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/$(uuidgen):5d" >> $GITHUB_OUTPUT
+
+      - name: Build Image
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            version=${{github.sha}}
+            pardotID=dockerhub
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.get-image-tag.outputs.IMG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   kind-e2e-tests:
     name: Run E2E tests
@@ -316,6 +355,13 @@ jobs:
           --namespace ${{ env.NAMESPACE }} \
           --from-literal=google-credentials-path='${{ secrets.GKE_SA_KEY }}'
 
+      - name: Login to GAR
+        uses: docker/login-action@v2
+        with:
+          registry: us-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GKE_SA_KEY }}
+
       - name: Load Image
         run: |
           docker pull $IMG
@@ -349,6 +395,7 @@ jobs:
         with:
           name: test-report-pr
           path: allure-results/pr/
+          retention-days: 5
 
   report-generation:
     needs: ["kind-e2e-tests"]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -159,17 +159,9 @@ jobs:
 
       - name: Set Up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2.4.0
         with:
           install: true
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Login to GAR
         uses: docker/login-action@v2
@@ -194,13 +186,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.get-image-tag.outputs.IMG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
+          cache-to: type=registry,ref=${{ env.GAR_REGION }}-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REPO }}/${{ hashFiles('Dockerfile','main.go','api/**','controllers/**','internal/**','licenses/**','**/go.mod','**/go.sum') }}:14d
 
   kind-e2e-tests:
     name: Run E2E tests


### PR DESCRIPTION
## Description

- Add the option to rerun the failed test with the ability to re-generate an allure report. Retention policy for the report: 5 days. After this period becomes impossible to re-run the tests.
- Decreased time for image build from 3.40m up to 30s
- Changed ttl.sh registry to Google Artifact Registry with default removing policy up to 5 days. The cleanup workflow is here https://github.com/hazelcast/DevOps/pull/245
