### PR TITLE
Merge watched and operator namespace roles for bundle generation 

### DIFF
--- a/.github/workflows/certification-tests-and-release.yaml
+++ b/.github/workflows/certification-tests-and-release.yaml
@@ -204,7 +204,7 @@ jobs:
       OCP_CLUSTER_URL: ${{ secrets.OCP_CLUSTER_URL }}
       OCP_USERNAME: ${{ secrets.OCP_USERNAME }}
       OCP_PASSWORD: ${{ secrets.OCP_PASSWORD }}
-      KUBECONFIG: ""
+      KUBECONFIG: $HOME/.kube/config
     steps:
       - name: Checkout to hazelcast-operator
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ clean-up-namespace: ## Clean up all the resources that were created by the opera
 	$(KUBECTL) delete namespace $(NAMESPACE) --wait=true --timeout 2m
 
 .PHONY: bundle
-bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+bundle: operator-sdk manifests kustomize yq ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	($(YQ) 'select(.kind == "ClusterRole")  | .' config/rbac/role.yaml && \

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,11 @@ clean-up-namespace: ## Clean up all the resources that were created by the opera
 bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	($(YQ) 'select(.kind == "ClusterRole")  | .' config/rbac/role.yaml && \
+	 echo "---" && \
+	 $(YQ)  eval-all '. | select(.kind == "Role" ) | . as $$item ireduce ({}; . *+ $$item) '  config/rbac/role.yaml) > config/rbac/role.yaml.new && mv config/rbac/role.yaml.new config/rbac/role.yaml
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
+	$(MAKE) manifests # Revert changes done for generating bundle
 	sed -i  "s|containerImage: REPLACE_IMG|containerImage: $(IMG)|" bundle/manifests/hazelcast-platform-operator.clusterserviceversion.yaml
 	sed -i  "s|createdAt: REPLACE_DATE|createdAt: \"$$(date +%F)T11:59:59Z\"|" bundle/manifests/hazelcast-platform-operator.clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework

--- a/config/manager/disable_phone_home.yaml
+++ b/config/manager/disable_phone_home.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: "/spec/template/spec/containers/0/env/-"
-  value:
-    name: "PHONE_HOME_ENABLED"
-    value: "false"

--- a/config/manager/enable_developer_mode.yaml
+++ b/config/manager/enable_developer_mode.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: "/spec/template/spec/containers/0/env/-"
-  value:
-    name: "DEVELOPER_MODE_ENABLED"
-    value: "true"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,7 +8,3 @@ images:
 - name: controller
   newName: hazelcast/hazelcast-platform-operator
   newTag: latest-snapshot
-patches:
-- path: remove_security_context.yaml
-  target:
-    kind: Deployment

--- a/config/manager/remove_security_context.yaml
+++ b/config/manager/remove_security_context.yaml
@@ -1,3 +1,0 @@
-- op: remove
-  path: "/spec/template/spec/securityContext"
-  

--- a/config/samples/_v1alpha1_topic.yaml
+++ b/config/samples/_v1alpha1_topic.yaml
@@ -1,7 +1,7 @@
 apiVersion: hazelcast.com/v1alpha1
 kind: Topic
 metadata:
-  name: topic-sample2
+  name: topic-sample
 spec:
   hazelcastResourceName: hazelcast
   globalOrderingEnabled: true


### PR DESCRIPTION
## Description

Bundle generator failed when `role.yaml` file had two `Role` resources with the same name. Merged the `rules` section of them into one `Role` resource.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
