### PR TITLE
Set operator image tag to 5.6 in helm chart

### DIFF
--- a/helm-charts/hazelcast-platform-operator/values.yaml
+++ b/helm-charts/hazelcast-platform-operator/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: hazelcast/hazelcast-platform-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest-snapshot
+  tag: 5.6
 
 developerModeEnabled: false
 phoneHomeEnabled: true


### PR DESCRIPTION
## Description

I've missed setting the fixed operator version in the operator chart. The chart release is already updated and fixed but the chart repo needs to be updated.