### PR TITLE
Fix watchedNamespaces variable and manager options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ DEBUG_ENABLED ?= false
 RELEASE_NAME ?= v1
 CRD_RELEASE_NAME ?= hazelcast-platform-operator-crds
 DEPLOYMENT_NAME := $(RELEASE_NAME)-hazelcast-platform-operator
-STRING_SET_VALUES := developerModeEnabled=$(DEVELOPER_MODE_ENABLED),phoneHomeEnabled=$(PHONE_HOME_ENABLED),installCRDs=$(INSTALL_CRDS),image.imageOverride=$(IMG),watchedNamespace='{$(NAMESPACE)}',debug.enabled=$(DEBUG_ENABLED)
+STRING_SET_VALUES := developerModeEnabled=$(DEVELOPER_MODE_ENABLED),phoneHomeEnabled=$(PHONE_HOME_ENABLED),installCRDs=$(INSTALL_CRDS),image.imageOverride=$(IMG),watchedNamespaces='{$(NAMESPACE)}',debug.enabled=$(DEBUG_ENABLED)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -92,7 +92,7 @@ func validateLicense(h *Hazelcast) error {
 		err := kubeclient.Get(context.Background(), secretName, &secret)
 		if kerrors.IsNotFound(err) {
 			// we care only about not found error
-			return errors.New("Hazelcast Enterprise licenseKeySecret secret is not found")
+			return errors.New("Hazelcast Enterprise licenseKeySecret is not found")
 		}
 	}
 

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -92,7 +92,7 @@ func validateLicense(h *Hazelcast) error {
 		err := kubeclient.Get(context.Background(), secretName, &secret)
 		if kerrors.IsNotFound(err) {
 			// we care only about not found error
-			return errors.New("secret not found")
+			return errors.New("Hazelcast Enterprise licenseKeySecret secret is not found")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		setupLog.Info("No namespace specified in the NAMESPACE env variable! Operator might be running locally")
 	}
 
-	setManagerWathedNamespaces(mgrOptions, operatorNamespace)
+	setManagerWathedNamespaces(&mgrOptions, operatorNamespace)
 
 	cfg := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(cfg, mgrOptions)
@@ -328,7 +328,7 @@ func setupWithWebhookOrDie(mgr ctrl.Manager) {
 	}
 }
 
-func setManagerWathedNamespaces(mgrOptions ctrl.Options, operatorNamespace string) {
+func setManagerWathedNamespaces(mgrOptions *ctrl.Options, operatorNamespace string) {
 	watchedNamespaces := strings.Split(os.Getenv(n.WatchedNamespacesEnv), ",")
 	switch {
 	case len(watchedNamespaces) == 1 && util.IsWatchingAllNamespaces(watchedNamespaces[0]):


### PR DESCRIPTION
## Description

`wachedNamespaces` variable in Makefile had missing `s`. Also manager parameter in `setManagerWathedNamespaces` was not a pointer, so changes in the options struct had no effect.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
