### PR TITLE
[CN-713] Add phonehome for watched namespace type

### DIFF
--- a/internal/util/operator_info.go
+++ b/internal/util/operator_info.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
+)
+
+type WatchedNsType string
+
+const (
+	WatchedNsTypeAll    WatchedNsType = "All"
+	WatchedNsTypeMulti  WatchedNsType = "Multi"
+	WatchedNsTypeSingle WatchedNsType = "Single"
+	WatchedNsTypeOwn    WatchedNsType = "Own"
+)
+
+func WatchedNamespaceType() WatchedNsType {
+	watchedNamespaces := WatchedNamespaces()
+	operatorNamespace := OperatorNamespace()
+	if operatorNamespace == "" {
+		return WatchedNsTypeAll
+	}
+
+	switch {
+	case len(watchedNamespaces) == 1 && (watchedNamespaces[0] == "" || watchedNamespaces[0] == "*"):
+		return WatchedNsTypeAll
+	case len(watchedNamespaces) == 1 && watchedNamespaces[0] == operatorNamespace:
+		return WatchedNsTypeOwn
+	case len(watchedNamespaces) == 1 && watchedNamespaces[0] != operatorNamespace:
+		return WatchedNsTypeSingle
+	case len(watchedNamespaces) > 1:
+		return WatchedNsTypeMulti
+	default:
+		return WatchedNsTypeAll
+	}
+
+}
+
+func WatchedNamespaces() []string {
+	return strings.Split(os.Getenv(n.WatchedNamespacesEnv), ",")
+}
+
+func OperatorNamespace() string {
+	return os.Getenv(n.NamespaceEnv)
+}
+
+func OperatorVersion() string {
+	return os.Getenv(n.OperatorVersionEnv)
+}
+
+func PardotID() string {
+	return os.Getenv(n.PardotIDEnv)
+}
+
+func OperatorID(c *rest.Config) types.UID {
+	uid, err := operatorDeploymentID(c)
+	if err == nil {
+		return uid
+	}
+
+	return uuid.NewUUID()
+}
+
+func operatorDeploymentID(c *rest.Config) (types.UID, error) {
+	ns := OperatorNamespace()
+	podName := os.Getenv(n.PodNameEnv)
+
+	if ns == "" || podName == "" {
+		return "", fmt.Errorf("%s or %s is not defined", n.NamespaceEnv, n.PodNameEnv)
+	}
+	client, err := kubernetes.NewForConfig(c)
+	if err != nil {
+		return "", err
+	}
+
+	var d *appsv1.Deployment
+	d, err = client.AppsV1().Deployments(ns).Get(context.TODO(), DeploymentName(podName), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return d.UID, nil
+}
+
+func DeploymentName(podName string) string {
+	s := strings.Split(podName, "-")
+	return strings.Join(s[:len(s)-2], "-")
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -13,9 +13,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -174,49 +171,6 @@ func IsDeveloperModeEnabled() bool {
 	return strings.ToLower(value) == "true"
 }
 
-func GetOperatorVersion() string {
-	return os.Getenv(n.OperatorVersionEnv)
-}
-
-func GetPardotID() string {
-	return os.Getenv(n.PardotIDEnv)
-}
-
-func GetOperatorID(c *rest.Config) types.UID {
-	uid, err := getOperatorDeploymentUID(c)
-	if err == nil {
-		return uid
-	}
-
-	return uuid.NewUUID()
-}
-
-func getOperatorDeploymentUID(c *rest.Config) (types.UID, error) {
-	ns, okNS := os.LookupEnv(n.NamespaceEnv)
-	podName, okPN := os.LookupEnv(n.PodNameEnv)
-
-	if !okNS || !okPN {
-		return "", fmt.Errorf("%s or %s is not defined", n.NamespaceEnv, n.PodNameEnv)
-	}
-	client, err := kubernetes.NewForConfig(c)
-	if err != nil {
-		return "", err
-	}
-
-	var d *appsv1.Deployment
-	d, err = client.AppsV1().Deployments(ns).Get(context.TODO(), DeploymentName(podName), metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	return d.UID, nil
-}
-
-func DeploymentName(podName string) string {
-	s := strings.Split(podName, "-")
-	return strings.Join(s[:len(s)-2], "-")
-}
-
 type ExternalAddresser interface {
 	metav1.Object
 	ExternalAddressEnabled() bool
@@ -295,10 +249,6 @@ func IsApplied(obj client.Object) bool {
 func IsSuccessfullyApplied(obj client.Object) bool {
 	_, ok := obj.GetAnnotations()[n.LastSuccessfulSpecAnnotation]
 	return ok
-}
-
-func IsWatchingAllNamespaces(ns string) bool {
-	return ns == "" || ns == "*"
 }
 
 func NodeDiscoveryEnabled() bool {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"os"
-	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -82,7 +81,7 @@ func main() {
 		setupLog.Info("No namespace specified in the NAMESPACE env variable! Operator might be running locally")
 	}
 
-	setManagerWathedNamespaces(&mgrOptions, operatorNamespace)
+	watchedNamespaceType := setManagerWathedNamespaces(&mgrOptions, operatorNamespace)
 
 	cfg := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(cfg, mgrOptions)
@@ -105,19 +104,20 @@ func main() {
 	cr := &hzclient.HazelcastClientRegistry{K8sClient: mgr.GetClient()}
 	ssm := &hzclient.HzStatusServiceRegistry{}
 
-	var metrics *phonehome.Metrics
+	var operatorInfo *phonehome.OperatorInfo
 	var phoneHomeTrigger chan struct{}
 	if util.IsPhoneHomeEnabled() {
 		phoneHomeTrigger = make(chan struct{}, 10)
-		metrics = &phonehome.Metrics{
-			UID:             util.GetOperatorID(cfg),
-			CreatedAt:       time.Now(),
-			PardotID:        util.GetPardotID(),
-			Version:         util.GetOperatorVersion(),
-			K8sDistribution: platform.GetDistribution(),
-			K8sVersion:      platform.GetVersion(),
-			Trigger:         phoneHomeTrigger,
-			ClientRegistry:  cr,
+		operatorInfo = &phonehome.OperatorInfo{
+			UID:                  util.OperatorID(cfg),
+			CreatedAt:            time.Now(),
+			PardotID:             util.PardotID(),
+			Version:              util.OperatorVersion(),
+			K8sDistribution:      platform.GetDistribution(),
+			K8sVersion:           platform.GetVersion(),
+			Trigger:              phoneHomeTrigger,
+			ClientRegistry:       cr,
+			WatchedNamespaceType: watchedNamespaceType,
 		}
 	}
 
@@ -261,7 +261,7 @@ func main() {
 	}
 
 	if util.IsPhoneHomeEnabled() {
-		phonehome.Start(mgr.GetClient(), metrics)
+		phonehome.Start(mgr.GetClient(), operatorInfo)
 	}
 
 	setupLog.Info("starting manager")
@@ -328,18 +328,24 @@ func setupWithWebhookOrDie(mgr ctrl.Manager) {
 	}
 }
 
-func setManagerWathedNamespaces(mgrOptions *ctrl.Options, operatorNamespace string) {
-	watchedNamespaces := strings.Split(os.Getenv(n.WatchedNamespacesEnv), ",")
-	switch {
-	case len(watchedNamespaces) == 1 && util.IsWatchingAllNamespaces(watchedNamespaces[0]):
+func setManagerWathedNamespaces(mgrOptions *ctrl.Options, operatorNamespace string) util.WatchedNsType {
+	watchedNamespaces := util.WatchedNamespaces()
+	watchedNamespaceType := util.WatchedNamespaceType()
+
+	switch watchedNamespaceType {
+	case util.WatchedNsTypeAll:
 		setupLog.Info("Watching all namespaces")
-	case len(watchedNamespaces) == 1 && watchedNamespaces[0] == operatorNamespace:
-		setupLog.Info("Watching a single namespace", "namespace", watchedNamespaces[0])
+	case util.WatchedNsTypeOwn:
+		setupLog.Info("Watching own namespace", "namespace", watchedNamespaces[0])
 		mgrOptions.Namespace = watchedNamespaces[0]
-	default:
+	case util.WatchedNsTypeSingle, util.WatchedNsTypeMulti:
 		setupLog.Info("Watching namespaces", "watched_namespaces", watchedNamespaces, "operator_namespace", operatorNamespace)
 		// Operator should be able watch resources in its own namespace
 		watchedNamespaces = append(watchedNamespaces, operatorNamespace)
 		mgrOptions.NewCache = cache.MultiNamespacedCacheBuilder(watchedNamespaces)
+	default:
+		setupLog.Info("Watching all namespaces by default")
 	}
+
+	return watchedNamespaceType
 }


### PR DESCRIPTION
## Description

Defaulted to watching all namespaces when either `NAMESPACE` or `WATCHED_NAMESPACES` variables are empty.

In the table watched ns type will show up as following:

![image](https://user-images.githubusercontent.com/44066377/217278310-b622b5fb-df8d-43ff-ace0-194e47599d05.png)


## User Impact

When either `NAMESPACE` or `WATCHED_NAMESPACES`, operator will watch all namespaces. 
