### PR TITLE
Fixing flaky expose externally e2e test

### DIFF
--- a/test/e2e/hazelcast_expose_externally_test.go
+++ b/test/e2e/hazelcast_expose_externally_test.go
@@ -143,13 +143,14 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 					Expect(svcLoadBalancerIngress.IP).Should(Equal(clientPublicIp))
 				} else {
 					hostname := svcLoadBalancerIngress.Hostname
-					var addressMatched bool
-					Eventually(func() error {
+					Eventually(func() bool {
 						matched, err := DnsLookupAddressMatched(ctx, hostname, clientPublicIp)
-						addressMatched = matched
-						return err
-					}, 3*Minute, interval).Should(BeNil())
-					Expect(addressMatched).Should(BeTrue())
+						if err != nil {
+							return false
+						}
+						return matched
+					}, 3*Minute, interval).Should(BeTrue())
+
 				}
 				continue memberLoop
 			}


### PR DESCRIPTION
## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

Fixing expose externally e2e flaky test 
`should create Hazelcast cluster exposed with LoadBalancer services and allow connecting with Hazelcast smart client`

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
