### PR TITLE
[CN-746]: Version Diff Tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,10 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.10 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hazelcast/hazelcast-go-client v1.3.1 h1:t+TNkugtRv1s+gnmGZ86t3I/N5L58SRCYZgGUpH5+zE=

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,16 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=

--- a/tools/version-diff-tool/main.go
+++ b/tools/version-diff-tool/main.go
@@ -1,21 +1,47 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"github.com/hashicorp/go-version"
 	"github.com/tidwall/sjson"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sigs.k8s.io/yaml"
 	"strings"
 )
 
 const (
+	// File names
+	outputFileName          = `diff_%s_%s.txt`
+	descriptionlessFileName = `r%s`
+	bundleFileName          = `bundle-%s.yaml`
+	openAPIFileName         = `open-api-%s`
+
+	// Splitters
+	schemaSplitter = `---`
+
+	// Links
+	bundleDownloadLink = `https://repository.hazelcast.com/operator/` + bundleFileName
+
+	// Helm related
+	helmInstall      = `helm install operator hazelcast/hazelcast-platform-operator --dry-run --set installCRDs=true > ` + bundleFileName
+	helmChartVersion = "5.6"
+
+	// yq commands
 	crdNamesSelector   = `yq '.. | select(has("singular")).singular' %s`
 	schemaSelector     = `yq '.. | select(has("schema")).schema' %s`
-	descriptionDeleter = `yq 'del(.. | select(has("description")).description)' %s > r%s`
-	openAPIYAML        = `openapi: 3.0.0
+	descriptionDeleter = `yq 'del(.. | select(has("description")).description)' %s > ` + descriptionlessFileName
+	flatten            = `yq eval '.. | select((tag == "!!map" or tag == "!!seq") | not) | (path | join(".")) + "=" + .' kdiff.yaml | sed 's/components.schemas.//g' | sed 's/properties.//g' | sed 's/modified.//g' | sed 's/stringsdiff.//g'`
+
+	// oasdiff commands
+	diff = `oasdiff -base %s -revision %s > kdiff.yaml`
+
+	// Open API YAML
+	openAPIYAML = `openapi: 3.0.0
 info:
   version: 1.0.0
   title: Sample API
@@ -23,231 +49,249 @@ info:
 components:
   schemas:
 `
-	diff    = `oasdiff -base %s -revision %s > kdiff.yaml`
-	flatten = `yq eval '.. | select((tag == "!!map" or tag == "!!seq") | not) | (path | join(".")) + "=" + .' kdiff.yaml`
 )
 
 func main() {
-
-	cmd := exec.Command("git", "for-each-ref", `--format='%(refname)'`, "refs/tags")
-	out, err := cmd.CombinedOutput()
+	base, revision, err := parseParams()
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("an error occurred while parsing parameters: %s", err.Error()))
 	}
 
-	tags := findTags(string(out))
-	yamlFileNames, err := downloadBundleYAMLs(tags)
+	baseBundle, err := downloadBundleYAML(base)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("an error occurred while downloading base bundle yaml: %s", err.Error()))
 	}
 
-	yamlFileNames = []string{"bundle-5.3.yaml", "bundle-5.4.yaml"}
-	_, err = createOpenAPISpec(yamlFileNames)
+	revBundle, err := downloadBundleYAML(revision)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("an error occurred while downloading revision bundle yaml: %s", err.Error()))
 	}
 
-	err = compareSpecs("open-api-bundle-5.3.yaml", "open-api-bundle-5.4.yaml")
+	baseSpec, err := createOpenAPISpec(baseBundle)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("an error occurred while creating base api spec: %s", err.Error()))
 	}
 
-	err = formatDiff()
+	revSpec, err := createOpenAPISpec(revBundle)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("an error occurred while creating revision api spec: %s", err.Error()))
 	}
+
+	diffFile, err := compareSpecs(baseSpec, revSpec)
+	if err != nil {
+		panic(fmt.Errorf("an error occurred while comparing specs: %s", err.Error()))
+	}
+
+	err = cleanup()
+	if err != nil {
+		panic(fmt.Errorf("an error occurred while cleaning up: %s", err.Error()))
+	}
+
+	fmt.Println("Spec diff is extracted to file: " + diffFile)
 }
 
-func findTags(tags string) []string {
+func parseParams() (string, string, error) {
+	var base, revision string
+
+	flag.StringVar(&base, "base", "", "base yaml")
+	flag.StringVar(&revision, "revision", "", "revision yaml")
+	flag.Parse()
+
+	if base != "" && revision != "" {
+		_, err := version.NewVersion(base)
+		if err != nil {
+			return "", "", err
+		}
+		_, err = version.NewVersion(revision)
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		cmd := exec.Command("git", "for-each-ref", `--format='%(refname)'`, "refs/tags")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", "", err
+		}
+
+		base, revision = findTags(string(out))
+	}
+
+	return base, revision, nil
+}
+
+func findTags(tags string) (string, string) {
 	tags = strings.ReplaceAll(tags, "'", "")
 	tags = strings.ReplaceAll(tags, "refs/tags/v", "")
 	tagList := strings.Split(tags, "\n")
 
-	var detectedTags []string
-	for i := len(tagList) - 1; i > 0; i-- {
-		if tagList[i] != "" {
-			detectedTags = append(detectedTags, tagList[i])
-		}
-		if len(detectedTags) == 2 {
-			break
-		}
-	}
+	revision := tagList[len(tagList)-1]
+	base := tagList[len(tagList)-2]
 
-	return detectedTags
+	return base, revision
 }
 
-func downloadBundleYAMLs(tags []string) ([]string, error) {
-	var fileNames []string
+func downloadBundleYAML(v string) (string, error) {
+	helmVersion, _ := version.NewVersion(helmChartVersion)
+	vv, _ := version.NewVersion(v) // versions already validated, so ignore error
 
-	for _, t := range tags {
-		//TODO: semantic version comparison (> 5.5)
-		// https://repository.hazelcast.com/operator/bundle-5.5.yaml
-		// helm install operator hazelcast/hazelcast-platform-operator --dry-run --debug --set installCRDs=true > 5.6.yaml
-
-		resp, err := http.Get(fmt.Sprintf("https://repository.hazelcast.com/operator/bundle-%s.yaml", t))
-		if err != nil {
-			return []string{}, err
-		}
-
-		f, err := os.Create(fmt.Sprintf("bundle-%s.yaml", t))
-		if err != nil {
-			return []string{}, err
-		}
-
-		_, err = io.Copy(f, resp.Body)
-		if err != nil {
-			return []string{}, err
-		}
-
-		fileNames = append(fileNames, f.Name())
-	}
-
-	return fileNames, nil
-}
-
-type parsedYAML struct {
-	fileName string
-	crdNames []string
-	schemas  []string
-}
-
-func createOpenAPISpec(yamlFiles []string) ([]string, error) {
-	var yamls []parsedYAML
-
-	for _, y := range yamlFiles {
-		cmd := exec.Command("bash", "-c", fmt.Sprintf(descriptionDeleter, y, y))
+	if vv.GreaterThanOrEqual(helmVersion) {
+		cmd := exec.Command("bash", "-c", fmt.Sprintf(helmInstall, v))
 		_, err := cmd.CombinedOutput()
 		if err != nil {
-			return []string{}, err
+			return "", err
 		}
-
-		descriptionLessFileName := "r" + y
-
-		cmd = exec.Command("bash", "-c", fmt.Sprintf(crdNamesSelector, descriptionLessFileName))
-		o2, err := cmd.CombinedOutput()
-		if err != nil {
-			return []string{}, err
-		}
-
-		cmd = exec.Command("bash", "-c", fmt.Sprintf(schemaSelector, descriptionLessFileName))
-		o3, err := cmd.CombinedOutput()
-		if err != nil {
-			return []string{}, err
-		}
-
-		p := parsedYAML{
-			fileName: y,
-			crdNames: strings.Split(string(o2), "---"),
-			schemas:  strings.Split(string(o3), "---"),
-		}
-
-		// clean up some fields to make them the same format
-		for i := range p.crdNames {
-			p.crdNames[i] = strings.ReplaceAll(p.crdNames[i], "\n", "")
-		}
-
-		for i := range p.schemas {
-			p.schemas[i] = strings.ReplaceAll(p.schemas[i], "openAPIV3Schema:\n", "")
-		}
-
-		yamls = append(yamls, p)
+		return fmt.Sprintf(bundleFileName, v), nil
 	}
 
-	mergeCRDNamesAndSchemas(yamls)
+	resp, err := http.Get(fmt.Sprintf(bundleDownloadLink, v))
+	if err != nil {
+		return "", err
+	}
 
-	return []string{}, nil
+	f, err := os.Create(fmt.Sprintf(bundleFileName, v))
+	if err != nil {
+		return "", err
+	}
+
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
 }
 
-func mergeCRDNamesAndSchemas(yamls []parsedYAML) error {
-	specs := make(map[string][]byte) // fileName -> openAPISpec YAML
-
-	for _, y := range yamls {
-		var wholeSchema []byte
-		for i := range y.schemas {
-			s, err := yaml.YAMLToJSON([]byte(y.schemas[i]))
-			if err != nil {
-				return err
-			}
-
-			wholeSchema, err = sjson.SetRawBytes(wholeSchema, y.crdNames[i], s)
-			if err != nil {
-				return err
-			}
-		}
-
-		specs[y.fileName] = wholeSchema
-	}
-
-	j1, err := yaml.YAMLToJSON([]byte(openAPIYAML))
-	if err != nil {
-		return err
-	}
-
-	json1, err := sjson.SetRawBytes(j1, "components.schemas", specs[yamls[0].fileName])
-	if err != nil {
-		return err
-	}
-
-	yaml1, err := yaml.JSONToYAML(json1)
-	if err != nil {
-		return err
-	}
-
-	file1, err := os.Create("open-api-" + yamls[0].fileName)
-	if err != nil {
-		return err
-	}
-	defer file1.Close()
-	_, err = file1.WriteString(string(yaml1))
-	if err != nil {
-		return err
-	}
-
-	j2, err := yaml.YAMLToJSON([]byte(openAPIYAML))
-	if err != nil {
-		return err
-	}
-
-	json2, err := sjson.SetRawBytes(j2, "components.schemas", specs[yamls[1].fileName])
-	if err != nil {
-		return err
-	}
-
-	yaml2, err := yaml.JSONToYAML(json2)
-	if err != nil {
-		return err
-	}
-
-	file2, err := os.Create("open-api-" + yamls[1].fileName)
-	if err != nil {
-		return err
-	}
-	defer file2.Close()
-	_, err = file2.WriteString(string(yaml2))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func compareSpecs(file1, file2 string) error {
-	cmd := exec.Command("bash", "-c", fmt.Sprintf(diff, file1, file2))
+func createOpenAPISpec(yaml string) (string, error) {
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(descriptionDeleter, yaml, yaml))
 	_, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+
+	cmd = exec.Command("bash", "-c", fmt.Sprintf(crdNamesSelector, fmt.Sprintf(descriptionlessFileName, yaml)))
+	o1, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	cmd = exec.Command("bash", "-c", fmt.Sprintf(schemaSelector, fmt.Sprintf(descriptionlessFileName, yaml)))
+	o2, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	crdNames := strings.Split(string(o1), schemaSplitter)
+	for i := range crdNames {
+		crdNames[i] = strings.ReplaceAll(crdNames[i], "\n", "")
+	}
+
+	schemas := strings.Split(string(o2), schemaSplitter)
+	for i := range schemas {
+		schemas[i] = strings.ReplaceAll(schemas[i], "openAPIV3Schema:\n", "")
+	}
+
+	n, err := mergeCRDNamesAndSchemas(yaml, crdNames, schemas)
+	if err != nil {
+		return "", err
+	}
+
+	return n, nil
 }
 
-func formatDiff() error {
+func mergeCRDNamesAndSchemas(fileName string, crdNames, schemas []string) (string, error) {
+	var wholeSchema []byte
+	for i := range schemas {
+		s, err := yaml.YAMLToJSON([]byte(schemas[i]))
+		if err != nil {
+			return "", err
+		}
+
+		wholeSchema, err = sjson.SetRawBytes(wholeSchema, crdNames[i], s)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	j, err := yaml.YAMLToJSON([]byte(openAPIYAML))
+	if err != nil {
+		return "", err
+	}
+
+	js, err := sjson.SetRawBytes(j, "components.schemas", wholeSchema)
+	if err != nil {
+		return "", err
+	}
+
+	y, err := yaml.JSONToYAML(js)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Create(fmt.Sprintf(openAPIFileName, fileName))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	_, err = f.WriteString(string(y))
+	if err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func compareSpecs(base, rev string) (string, error) {
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(diff, base, rev))
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	diffFile, err := formatDiff(base, rev)
+	if err != nil {
+		return "", err
+	}
+	return diffFile, nil
+}
+
+func formatDiff(base, rev string) (string, error) {
 	cmd := exec.Command("bash", "-c", flatten)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Create(fmt.Sprintf(outputFileName, base, rev))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(string(output))
+	if err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func cleanup() error {
+	wd, err := os.Getwd()
+	if err != nil {
 		return err
 	}
 
-	fmt.Println(output)
-
+	err = filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".yaml" {
+			os.Remove(info.Name())
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/tools/version-diff-tool/main.go
+++ b/tools/version-diff-tool/main.go
@@ -28,7 +28,7 @@ const (
 	bundleDownloadLink = `https://repository.hazelcast.com/operator/` + bundleFileName
 
 	// Helm related
-	helmInstall      = `helm install operator hazelcast/hazelcast-platform-operator --dry-run --set installCRDs=true > ` + bundleFileName
+	helmInstall      = `helm template operator hazelcast/hazelcast-platform-operator-crds --version=%s > ` + bundleFileName
 	helmChartVersion = "5.6"
 
 	// yq commands
@@ -135,7 +135,7 @@ func downloadBundleYAML(v string) (string, error) {
 	vv, _ := version.NewVersion(v) // versions already validated, so ignore error
 
 	if vv.GreaterThanOrEqual(helmVersion) {
-		cmd := exec.Command("bash", "-c", fmt.Sprintf(helmInstall, v))
+		cmd := exec.Command("bash", "-c", fmt.Sprintf(helmInstall, v, v))
 		_, err := cmd.CombinedOutput()
 		if err != nil {
 			return "", err

--- a/tools/version-diff-tool/main.go
+++ b/tools/version-diff-tool/main.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"fmt"
+	"github.com/tidwall/sjson"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"sigs.k8s.io/yaml"
+	"strings"
+)
+
+const (
+	crdNamesSelector   = `yq '.. | select(has("singular")).singular' %s`
+	schemaSelector     = `yq '.. | select(has("schema")).schema' %s`
+	descriptionDeleter = `yq 'del(.. | select(has("description")).description)' %s > r%s`
+	openAPIYAML        = `openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Sample API
+  description: A sample API to illustrate OpenAPI concepts
+components:
+  schemas:
+`
+	diff    = `oasdiff -base %s -revision %s > kdiff.yaml`
+	flatten = `yq eval '.. | select((tag == "!!map" or tag == "!!seq") | not) | (path | join(".")) + "=" + .' kdiff.yaml`
+)
+
+func main() {
+
+	cmd := exec.Command("git", "for-each-ref", `--format='%(refname)'`, "refs/tags")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		panic(err)
+	}
+
+	tags := findTags(string(out))
+	yamlFileNames, err := downloadBundleYAMLs(tags)
+	if err != nil {
+		panic(err)
+	}
+
+	yamlFileNames = []string{"bundle-5.3.yaml", "bundle-5.4.yaml"}
+	_, err = createOpenAPISpec(yamlFileNames)
+	if err != nil {
+		panic(err)
+	}
+
+	err = compareSpecs("open-api-bundle-5.3.yaml", "open-api-bundle-5.4.yaml")
+	if err != nil {
+		panic(err)
+	}
+
+	err = formatDiff()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func findTags(tags string) []string {
+	tags = strings.ReplaceAll(tags, "'", "")
+	tags = strings.ReplaceAll(tags, "refs/tags/v", "")
+	tagList := strings.Split(tags, "\n")
+
+	var detectedTags []string
+	for i := len(tagList) - 1; i > 0; i-- {
+		if tagList[i] != "" {
+			detectedTags = append(detectedTags, tagList[i])
+		}
+		if len(detectedTags) == 2 {
+			break
+		}
+	}
+
+	return detectedTags
+}
+
+func downloadBundleYAMLs(tags []string) ([]string, error) {
+	var fileNames []string
+
+	for _, t := range tags {
+		//TODO: semantic version comparison (> 5.5)
+		// https://repository.hazelcast.com/operator/bundle-5.5.yaml
+		// helm install operator hazelcast/hazelcast-platform-operator --dry-run --debug --set installCRDs=true > 5.6.yaml
+
+		resp, err := http.Get(fmt.Sprintf("https://repository.hazelcast.com/operator/bundle-%s.yaml", t))
+		if err != nil {
+			return []string{}, err
+		}
+
+		f, err := os.Create(fmt.Sprintf("bundle-%s.yaml", t))
+		if err != nil {
+			return []string{}, err
+		}
+
+		_, err = io.Copy(f, resp.Body)
+		if err != nil {
+			return []string{}, err
+		}
+
+		fileNames = append(fileNames, f.Name())
+	}
+
+	return fileNames, nil
+}
+
+type parsedYAML struct {
+	fileName string
+	crdNames []string
+	schemas  []string
+}
+
+func createOpenAPISpec(yamlFiles []string) ([]string, error) {
+	var yamls []parsedYAML
+
+	for _, y := range yamlFiles {
+		cmd := exec.Command("bash", "-c", fmt.Sprintf(descriptionDeleter, y, y))
+		_, err := cmd.CombinedOutput()
+		if err != nil {
+			return []string{}, err
+		}
+
+		descriptionLessFileName := "r" + y
+
+		cmd = exec.Command("bash", "-c", fmt.Sprintf(crdNamesSelector, descriptionLessFileName))
+		o2, err := cmd.CombinedOutput()
+		if err != nil {
+			return []string{}, err
+		}
+
+		cmd = exec.Command("bash", "-c", fmt.Sprintf(schemaSelector, descriptionLessFileName))
+		o3, err := cmd.CombinedOutput()
+		if err != nil {
+			return []string{}, err
+		}
+
+		p := parsedYAML{
+			fileName: y,
+			crdNames: strings.Split(string(o2), "---"),
+			schemas:  strings.Split(string(o3), "---"),
+		}
+
+		// clean up some fields to make them the same format
+		for i := range p.crdNames {
+			p.crdNames[i] = strings.ReplaceAll(p.crdNames[i], "\n", "")
+		}
+
+		for i := range p.schemas {
+			p.schemas[i] = strings.ReplaceAll(p.schemas[i], "openAPIV3Schema:\n", "")
+		}
+
+		yamls = append(yamls, p)
+	}
+
+	mergeCRDNamesAndSchemas(yamls)
+
+	return []string{}, nil
+}
+
+func mergeCRDNamesAndSchemas(yamls []parsedYAML) error {
+	specs := make(map[string][]byte) // fileName -> openAPISpec YAML
+
+	for _, y := range yamls {
+		var wholeSchema []byte
+		for i := range y.schemas {
+			s, err := yaml.YAMLToJSON([]byte(y.schemas[i]))
+			if err != nil {
+				return err
+			}
+
+			wholeSchema, err = sjson.SetRawBytes(wholeSchema, y.crdNames[i], s)
+			if err != nil {
+				return err
+			}
+		}
+
+		specs[y.fileName] = wholeSchema
+	}
+
+	j1, err := yaml.YAMLToJSON([]byte(openAPIYAML))
+	if err != nil {
+		return err
+	}
+
+	json1, err := sjson.SetRawBytes(j1, "components.schemas", specs[yamls[0].fileName])
+	if err != nil {
+		return err
+	}
+
+	yaml1, err := yaml.JSONToYAML(json1)
+	if err != nil {
+		return err
+	}
+
+	file1, err := os.Create("open-api-" + yamls[0].fileName)
+	if err != nil {
+		return err
+	}
+	defer file1.Close()
+	_, err = file1.WriteString(string(yaml1))
+	if err != nil {
+		return err
+	}
+
+	j2, err := yaml.YAMLToJSON([]byte(openAPIYAML))
+	if err != nil {
+		return err
+	}
+
+	json2, err := sjson.SetRawBytes(j2, "components.schemas", specs[yamls[1].fileName])
+	if err != nil {
+		return err
+	}
+
+	yaml2, err := yaml.JSONToYAML(json2)
+	if err != nil {
+		return err
+	}
+
+	file2, err := os.Create("open-api-" + yamls[1].fileName)
+	if err != nil {
+		return err
+	}
+	defer file2.Close()
+	_, err = file2.WriteString(string(yaml2))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func compareSpecs(file1, file2 string) error {
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(diff, file1, file2))
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func formatDiff() error {
+	cmd := exec.Command("bash", "-c", flatten)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(output)
+
+	return nil
+}


### PR DESCRIPTION
## Description

Prints api spec differences between version numbers.

Example 1 - if you provide versions:
`version-diff-tool -base=5.2 -revision=5.3` will print diff to `diff_open-api-bundle-5.2.yaml_open-api-bundle-5.3.yaml.txt`

Example 2 - if you don't provide versions, it will compare the latest 2 versions:
`version-diff-tool` will print diff to `diff_open-api-bundle-5.5.yaml_open-api-bundle-5.6.yaml.txt`
