### PR TITLE
[CN-674]: Native Memory Support for Cache

### DIFF
--- a/api/v1alpha1/cache_types.go
+++ b/api/v1alpha1/cache_types.go
@@ -25,6 +25,11 @@ type CacheSpec struct {
 	// +kubebuilder:default:=false
 	// +optional
 	PersistenceEnabled bool `json:"persistenceEnabled"`
+
+	// InMemoryFormat specifies in which format data will be stored in your cache
+	// +kubebuilder:default:=BINARY
+	// +optional
+	InMemoryFormat InMemoryFormatType `json:"inMemoryFormat,omitempty"`
 }
 
 // CacheStatus defines the observed state of Cache

--- a/api/v1alpha1/cache_validation.go
+++ b/api/v1alpha1/cache_validation.go
@@ -1,0 +1,10 @@
+package v1alpha1
+
+import "errors"
+
+func ValidateNotUpdatableCacheFields(current *CacheSpec, last *CacheSpec) error {
+	if current.InMemoryFormat != last.InMemoryFormat {
+		return errors.New("inMemoryFormat cannot be updated")
+	}
+	return nil
+}

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -1,0 +1,16 @@
+package v1alpha1
+
+// InMemoryFormatType represents the format options for storing the data in the map/cache.
+// +kubebuilder:validation:Enum=BINARY;OBJECT;NATIVE
+type InMemoryFormatType string
+
+const (
+	// InMemoryFormatBinary Data will be stored in serialized binary format.
+	InMemoryFormatBinary InMemoryFormatType = "BINARY"
+
+	// InMemoryFormatObject Data will be stored in deserialized form.
+	InMemoryFormatObject InMemoryFormatType = "OBJECT"
+
+	// InMemoryFormatNative Data will be stored in the map that uses Hazelcast's High-Density Memory Store feature.
+	InMemoryFormatNative InMemoryFormatType = "NATIVE"
+)

--- a/api/v1alpha1/map_types.go
+++ b/api/v1alpha1/map_types.go
@@ -272,22 +272,6 @@ const (
 	InitialModeEager InitialModeType = "EAGER"
 )
 
-// InMemoryFormatType represents the format options for storing the data in the map.
-// For now, we are not exposing NATIVE format type since currently there is no support for High-Density Memory Store feature in the operator.
-// +kubebuilder:validation:Enum=BINARY;OBJECT
-type InMemoryFormatType string
-
-const (
-	// InMemoryFormatBinary Data will be stored in serialized binary format.
-	InMemoryFormatBinary InMemoryFormatType = "BINARY"
-
-	// InMemoryFormatObject Data will be stored in deserialized form.
-	InMemoryFormatObject InMemoryFormatType = "OBJECT"
-
-	// InMemoryFormatNative Data will be stored in the map that uses Hazelcast's High-Density Memory Store feature.
-	InMemoryFormatNative InMemoryFormatType = "NATIVE"
-)
-
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 

--- a/config/crd/bases/hazelcast.com_caches.yaml
+++ b/config/crd/bases/hazelcast.com_caches.yaml
@@ -65,6 +65,15 @@ spec:
                   resource.
                 minLength: 1
                 type: string
+              inMemoryFormat:
+                default: BINARY
+                description: InMemoryFormat specifies in which format data will be
+                  stored in your cache
+                enum:
+                - BINARY
+                - OBJECT
+                - NATIVE
+                type: string
               keyType:
                 description: Class name of the key type
                 type: string

--- a/config/crd/bases/hazelcast.com_maps.yaml
+++ b/config/crd/bases/hazelcast.com_maps.yaml
@@ -135,6 +135,7 @@ spec:
                 enum:
                 - BINARY
                 - OBJECT
+                - NATIVE
                 type: string
               indexes:
                 description: Indexes to be created for the map data. You can learn

--- a/config/crd/bases/hazelcast.com_replicatedmaps.yaml
+++ b/config/crd/bases/hazelcast.com_replicatedmaps.yaml
@@ -64,6 +64,7 @@ spec:
                 enum:
                 - BINARY
                 - OBJECT
+                - NATIVE
                 type: string
               name:
                 description: Name of the ReplicatedMap config to be created. If empty,

--- a/controllers/hazelcast/cache_controller.go
+++ b/controllers/hazelcast/cache_controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/util"
 	"reflect"
 	"time"
 
@@ -121,6 +122,10 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if !persisted {
 		return updateDSStatus(ctx, r.Client, c, dsPersistingStatus(1*time.Second).withMessage("Waiting for Cache Config to be persisted."))
+	}
+
+	if util.IsPhoneHomeEnabled() && !util.IsSuccessfullyApplied(c) {
+		go func() { r.phoneHomeTrigger <- struct{}{} }()
 	}
 
 	return finalSetupDS(ctx, r.Client, r.phoneHomeTrigger, c, logger)

--- a/controllers/hazelcast/common.go
+++ b/controllers/hazelcast/common.go
@@ -1,0 +1,27 @@
+package hazelcast
+
+import (
+	"encoding/json"
+	"fmt"
+
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
+)
+
+func requireNativeMemory(h *hazelcastv1alpha1.Hazelcast) error {
+	s, ok := h.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]
+	if !ok {
+		return fmt.Errorf("hazelcast resource %s is not successfully started yet", h.Name)
+	}
+
+	lastSpec := &hazelcastv1alpha1.HazelcastSpec{}
+	if err := json.Unmarshal([]byte(s), lastSpec); err != nil {
+		return fmt.Errorf("last successful spec for Hazelcast resource %s is not formatted correctly", h.Name)
+	}
+
+	if !lastSpec.NativeMemory.IsEnabled() {
+		return fmt.Errorf("native memory is not enabled for the Hazelcast resource %s", h.Name)
+	}
+
+	return nil
+}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1039,7 +1039,7 @@ func createCacheConfig(c *hazelcastv1alpha1.Cache) config.Cache {
 		ManagementEnabled: n.DefaultCacheManagementEnabled,
 		ReadThrough:       n.DefaultCacheReadThrough,
 		WriteThrough:      n.DefaultCacheWriteThrough,
-		InMemoryFormat:    n.DefaultCacheInMemoryFormat,
+		InMemoryFormat:    string(cs.InMemoryFormat),
 		MergePolicy: config.MergePolicy{
 			ClassName: n.DefaultCacheMergePolicy,
 			BatchSize: n.DefaultCacheMergeBatchSize,

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -192,29 +192,6 @@ func (r *MapReconciler) executeFinalizer(ctx context.Context, m *hazelcastv1alph
 	return nil
 }
 
-func ValidatePersistence(pe bool, h *hazelcastv1alpha1.Hazelcast) error {
-	if !pe {
-		return nil
-	}
-	s, ok := h.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]
-
-	if !ok {
-		return fmt.Errorf("hazelcast resource %s is not successfully started yet", h.Name)
-	}
-
-	lastSpec := &hazelcastv1alpha1.HazelcastSpec{}
-	err := json.Unmarshal([]byte(s), lastSpec)
-	if err != nil {
-		return fmt.Errorf("last successful spec for Hazelcast resource %s is not formatted correctly", h.Name)
-	}
-
-	if !lastSpec.Persistence.IsEnabled() {
-		return fmt.Errorf("persistence is not enabled for the Hazelcast resource %s", h.Name)
-	}
-
-	return nil
-}
-
 func getHazelcastClient(ctx context.Context, cs hzclient.ClientRegistry, hzName, hzNamespace string) (hzclient.Client, error) {
 	hzcl, err := cs.GetOrCreate(ctx, types.NamespacedName{Name: hzName, Namespace: hzNamespace})
 	if err != nil {
@@ -419,22 +396,4 @@ func (r *MapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hazelcastv1alpha1.Map{}).
 		Complete(r)
-}
-
-func requireNativeMemory(h *hazelcastv1alpha1.Hazelcast) error {
-	s, ok := h.ObjectMeta.Annotations[n.LastSuccessfulSpecAnnotation]
-	if !ok {
-		return fmt.Errorf("hazelcast resource %s is not successfully started yet", h.Name)
-	}
-
-	lastSpec := &hazelcastv1alpha1.HazelcastSpec{}
-	if err := json.Unmarshal([]byte(s), lastSpec); err != nil {
-		return fmt.Errorf("last successful spec for Hazelcast resource %s is not formatted correctly", h.Name)
-	}
-
-	if !lastSpec.NativeMemory.IsEnabled() {
-		return fmt.Errorf("native memory is not enabled for the Hazelcast resource %s", h.Name)
-	}
-
-	return nil
 }

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -65,6 +65,15 @@ spec:
                   resource.
                 minLength: 1
                 type: string
+              inMemoryFormat:
+                default: BINARY
+                description: InMemoryFormat specifies in which format data will be
+                  stored in your cache
+                enum:
+                - BINARY
+                - OBJECT
+                - NATIVE
+                type: string
               keyType:
                 description: Class name of the key type
                 type: string
@@ -3447,6 +3456,7 @@ spec:
                 enum:
                 - BINARY
                 - OBJECT
+                - NATIVE
                 type: string
               indexes:
                 description: Indexes to be created for the map data. You can learn
@@ -3892,6 +3902,7 @@ spec:
                 enum:
                 - BINARY
                 - OBJECT
+                - NATIVE
                 type: string
               name:
                 description: Name of the ReplicatedMap config to be created. If empty,

--- a/internal/phonehome/phonehome.go
+++ b/internal/phonehome/phonehome.go
@@ -97,8 +97,6 @@ type PhoneHomeData struct {
 	TopicCount                    int                    `json:"tc"`
 	HighAvailabilityMode          []string               `json:"ha"`
 	NativeMemoryCount             int                    `json:"nmc"`
-	NativeMemoryMapCount          int                    `json:"nmmc"`
-	NativeMemoryCacheCount        int                    `json:"nmcc"`
 }
 
 type ExposeExternally struct {
@@ -112,13 +110,16 @@ type ExposeExternally struct {
 }
 
 type Map struct {
-	Count            int `json:"c"`
-	PersistenceCount int `json:"pc"`
-	MapStoreCount    int `json:"msc"`
+	Count             int `json:"c"`
+	PersistenceCount  int `json:"pc"`
+	MapStoreCount     int `json:"msc"`
+	NativeMemoryCount int `json:"nmc"`
 }
 
 type Cache struct {
-	Count int `json:"c"`
+	Count             int `json:"c"`
+	PersistenceCount  int `json:"pc"`
+	NativeMemoryCount int `json:"nmc"`
 }
 
 type BackupAndRestore struct {
@@ -355,12 +356,13 @@ func (phm *PhoneHomeData) fillMapMetrics(cl client.Client) {
 	phm.Map.Count = createdMapCount
 	phm.Map.PersistenceCount = persistedMapCount
 	phm.Map.MapStoreCount = mapStoreMapCount
-	phm.NativeMemoryMapCount = nativeMemoryMapCount
+	phm.Map.NativeMemoryCount = nativeMemoryMapCount
 }
 
 func (phm *PhoneHomeData) fillCacheMetrics(cl client.Client) {
 	createdCacheCount := 0
 	nativeMemoryCacheCount := 0
+	persistedCacheCount := 0
 
 	l := &hazelcastv1alpha1.CacheList{}
 	err := cl.List(context.Background(), l, listOptions()...)
@@ -373,10 +375,14 @@ func (phm *PhoneHomeData) fillCacheMetrics(cl client.Client) {
 		if c.Spec.InMemoryFormat == hazelcastv1alpha1.InMemoryFormatNative {
 			nativeMemoryCacheCount += 1
 		}
+		if c.Spec.PersistenceEnabled {
+			persistedCacheCount += 1
+		}
 	}
 
 	phm.Cache.Count = createdCacheCount
-	phm.NativeMemoryCacheCount = nativeMemoryCacheCount
+	phm.Cache.PersistenceCount = persistedCacheCount
+	phm.Cache.NativeMemoryCount = nativeMemoryCacheCount
 }
 
 func (phm *PhoneHomeData) fillWanReplicationMetrics(cl client.Client) {

--- a/internal/phonehome/phonehome.go
+++ b/internal/phonehome/phonehome.go
@@ -160,6 +160,7 @@ func newPhoneHomeData(cl client.Client, opInfo *OperatorInfo) PhoneHomeData {
 	phd.fillHazelcastMetrics(cl, opInfo.ClientRegistry)
 	phd.fillMCMetrics(cl)
 	phd.fillMapMetrics(cl)
+	phd.fillCacheMetrics(cl)
 	phd.fillWanReplicationMetrics(cl)
 	phd.fillHotBackupMetrics(cl)
 	phd.fillMultiMapMetrics(cl)

--- a/internal/protocol/types/cache_config.go
+++ b/internal/protocol/types/cache_config.go
@@ -23,7 +23,7 @@ type CacheConfigInput struct {
 	CacheWriterFactory                string
 	CacheLoader                       string
 	CacheWriter                       string
-	InMemoryFormat                    InMemoryFormat
+	InMemoryFormat                    InMemoryFormat `xml:"in-memory-format"`
 	SplitBrainProtectionName          string
 	PartitionLostListenerConfigs      []ListenerConfigHolder
 	ExpiryPolicyFactoryClassName      string

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -482,6 +482,7 @@ var (
 				DataStructureSpec: hazelcastv1alpha1.DataStructureSpec{
 					HazelcastResourceName: hzName,
 				},
+				InMemoryFormat: hazelcastv1alpha1.InMemoryFormatBinary,
 			},
 		}
 	}

--- a/test/e2e/hazelcast_cache_test.go
+++ b/test/e2e/hazelcast_cache_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Hazelcast Cache Config", Label("cache"), func() {
 		Expect(cacheConfig.BackupCount).Should(Equal(n.DefaultCacheBackupCount))
 		Expect(cacheConfig.AsyncBackupCount).Should(Equal(n.DefaultCacheAsyncBackupCount))
 		Expect(cacheConfig.StatisticsEnabled).Should(Equal(n.DefaultCacheStatisticsEnabled))
-		Expect(cacheConfig.InMemoryFormat).Should(Equal(c.Spec.InMemoryFormat))
+		Expect(string(cacheConfig.InMemoryFormat)).Should(Equal(string(c.Spec.InMemoryFormat)))
 	})
 
 	It("should fail to update Cache Config", Label("fast"), func() {

--- a/test/e2e/hazelcast_cache_test.go
+++ b/test/e2e/hazelcast_cache_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Hazelcast Cache Config", Label("cache"), func() {
 		Expect(cacheConfig.BackupCount).Should(Equal(n.DefaultCacheBackupCount))
 		Expect(cacheConfig.AsyncBackupCount).Should(Equal(n.DefaultCacheAsyncBackupCount))
 		Expect(cacheConfig.StatisticsEnabled).Should(Equal(n.DefaultCacheStatisticsEnabled))
+		Expect(cacheConfig.InMemoryFormat).Should(Equal(hazelcastcomv1alpha1.EncodeInMemoryFormat[c.Spec.InMemoryFormat]))
 	})
 
 	It("should fail to update Cache Config", Label("fast"), func() {

--- a/test/e2e/hazelcast_cache_test.go
+++ b/test/e2e/hazelcast_cache_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Hazelcast Cache Config", Label("cache"), func() {
 		Expect(cacheConfig.BackupCount).Should(Equal(n.DefaultCacheBackupCount))
 		Expect(cacheConfig.AsyncBackupCount).Should(Equal(n.DefaultCacheAsyncBackupCount))
 		Expect(cacheConfig.StatisticsEnabled).Should(Equal(n.DefaultCacheStatisticsEnabled))
-		Expect(cacheConfig.InMemoryFormat).Should(Equal(hazelcastcomv1alpha1.EncodeInMemoryFormat[c.Spec.InMemoryFormat]))
+		Expect(cacheConfig.InMemoryFormat).Should(Equal(c.Spec.InMemoryFormat))
 	})
 
 	It("should fail to update Cache Config", Label("fast"), func() {

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -871,6 +871,24 @@ var _ = Describe("Hazelcast controller", func() {
 				Expect(ms.EntryListeners).To(BeNil())
 				Delete(m)
 			})
+			It("should create Map CR with native memory configuration", Label("fast"), func() {
+				m := &hazelcastv1alpha1.Map{
+					ObjectMeta: GetRandomObjectMeta(),
+					Spec: hazelcastv1alpha1.MapSpec{
+						DataStructureSpec: hazelcastv1alpha1.DataStructureSpec{
+							HazelcastResourceName: "hazelcast",
+						},
+						InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
+					},
+				}
+				By("creating Map CR successfully")
+				Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
+				ms := m.Spec
+
+				By("checking the CR values with native memory")
+				Expect(ms.InMemoryFormat).To(Equal(hazelcastv1alpha1.InMemoryFormatNative))
+				Delete(m)
+			})
 		})
 	})
 
@@ -1368,6 +1386,7 @@ var _ = Describe("Hazelcast controller", func() {
 						DataStructureSpec: hazelcastv1alpha1.DataStructureSpec{
 							HazelcastResourceName: "hazelcast",
 						},
+						InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
 					},
 				}
 				By("creating Cache CR successfully")
@@ -1381,6 +1400,23 @@ var _ = Describe("Hazelcast controller", func() {
 				Expect(qs.HazelcastResourceName).To(Equal("hazelcast"))
 				Expect(qs.KeyType).To(Equal(""))
 				Expect(qs.ValueType).To(Equal(""))
+			})
+			It("should create Cache CR with native memory configuration", Label("fast"), func() {
+				q := &hazelcastv1alpha1.Cache{
+					ObjectMeta: GetRandomObjectMeta(),
+					Spec: hazelcastv1alpha1.CacheSpec{
+						DataStructureSpec: hazelcastv1alpha1.DataStructureSpec{
+							HazelcastResourceName: "hazelcast",
+						},
+						InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
+					},
+				}
+				By("creating Cache CR successfully")
+				Expect(k8sClient.Create(context.Background(), q)).Should(Succeed())
+				qs := q.Spec
+
+				By("checking the CR values with native memory")
+				Expect(qs.InMemoryFormat).To(Equal(hazelcastv1alpha1.InMemoryFormatNative))
 			})
 		})
 	})


### PR DESCRIPTION
## Description

Adds native memory support for Cache CR.

## User Impact
If user enabled native memory on related Hazelcast resource, then she/he can enable it for any Cache CR by using following configuration:

```
apiVersion: hazelcast.com/v1alpha1
kind: Cache
metadata:
  name: cache-sample
spec:
  hazelcastResourceName: hazelcast
  inMemoryFormat: NATIVE
```