### PR TITLE
[CN-551] Trigger WanReplication with Hazelcast resource when new map is created

### DIFF
--- a/api/v1alpha1/map_types.go
+++ b/api/v1alpha1/map_types.go
@@ -284,7 +284,7 @@ const (
 	MapFailed  MapConfigState = "Failed"
 	MapSuccess MapConfigState = "Success"
 	MapPending MapConfigState = "Pending"
-	// Map config is added into all members but waiting for map to be persisten into ConfigMap
+	// Map config is added into all members but waiting for map to be persistent into ConfigMap
 	MapPersisting  MapConfigState = "Persisting"
 	MapTerminating MapConfigState = "Terminating"
 )

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -850,7 +850,6 @@ func (r *WanReplicationReconciler) beingSuccessfulMapUpdates(m client.Object) []
 						Namespace: wan.Namespace,
 					},
 				})
-				break
 			}
 		}
 	}

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		_ = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
 	})
 
-	It("should make WanReplication enabled for the maps which are created after the wan", Label("slow"), func() {
+	It("should start WanReplication for the maps which are created after the Wan CR", Label("slow"), func() {
 		if !ee {
 			Skip("This test will only run in EE configuration")
 		}
@@ -469,13 +469,14 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
 		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusFailed)
 
+		assertWanStatusMapCount(wan, 2)
+
 		// Creating the map after the WanReplication CR
 		mapCr = hazelcastconfig.DefaultMap(types.NamespacedName{Name: mapAfterWanCR, Namespace: mapLookupKey.Namespace}, hzSource, labels)
 		Expect(k8sClient.Create(context.Background(), mapCr)).Should(Succeed())
 		assertMapStatus(mapCr, hazelcastcomv1alpha1.MapSuccess)
 
 		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
-		assertWanStatusMapCount(wan, 2)
 	})
 
 })

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -374,6 +374,14 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		}, ee, labels)
 		hzSourceCr.Spec.ClusterName = hzSource
 		hzSourceCr.Spec.ClusterSize = pointer.Int32(1)
+		hzSourceCr.Spec.AdvancedNetwork.WAN = []hazelcastcomv1alpha1.WANConfig{
+			{
+				Port:        5710,
+				PortCount:   0,
+				ServiceType: "NodePort",
+				Name:        "tokyo",
+			},
+		}
 		CreateHazelcastCRWithoutCheck(hzSourceCr)
 		evaluateReadyMembers(types.NamespacedName{Name: hzSource, Namespace: hzSrcLookupKey.Namespace})
 
@@ -383,6 +391,14 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		}, ee, labels)
 		hzTargetCr.Spec.ClusterName = hzTarget
 		hzTargetCr.Spec.ClusterSize = pointer.Int32(1)
+		hzTargetCr.Spec.AdvancedNetwork.WAN = []hazelcastcomv1alpha1.WANConfig{
+			{
+				Port:        5710,
+				PortCount:   0,
+				ServiceType: "NodePort",
+				Name:        "tokyo",
+			},
+		}
 		CreateHazelcastCRWithoutCheck(hzTargetCr)
 		evaluateReadyMembers(types.NamespacedName{Name: hzTarget, Namespace: hzTrgLookupKey.Namespace})
 
@@ -447,6 +463,14 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		}, ee, labels)
 		hzSourceCr.Spec.ClusterName = hzSource
 		hzSourceCr.Spec.ClusterSize = pointer.Int32(1)
+		hzSourceCr.Spec.AdvancedNetwork.WAN = []hazelcastcomv1alpha1.WANConfig{
+			{
+				Port:        5710,
+				PortCount:   0,
+				ServiceType: "NodePort",
+				Name:        "tokyo",
+			},
+		}
 		CreateHazelcastCRWithoutCheck(hzSourceCr)
 		evaluateReadyMembers(types.NamespacedName{Name: hzSource, Namespace: hzSrcLookupKey.Namespace})
 
@@ -456,6 +480,14 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		}, ee, labels)
 		hzTargetCr.Spec.ClusterName = hzTarget
 		hzTargetCr.Spec.ClusterSize = pointer.Int32(1)
+		hzTargetCr.Spec.AdvancedNetwork.WAN = []hazelcastcomv1alpha1.WANConfig{
+			{
+				Port:        5710,
+				PortCount:   0,
+				ServiceType: "NodePort",
+				Name:        "tokyo",
+			},
+		}
 		CreateHazelcastCRWithoutCheck(hzTargetCr)
 		evaluateReadyMembers(types.NamespacedName{Name: hzTarget, Namespace: hzTrgLookupKey.Namespace})
 

--- a/test/e2e/hazelcast_wan_test.go
+++ b/test/e2e/hazelcast_wan_test.go
@@ -468,15 +468,14 @@ var _ = Describe("Hazelcast WAN", Label("hz_wan"), func() {
 		)
 		Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
 		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusFailed)
-
-		assertWanStatusMapCount(wan, 2)
-
+		
 		// Creating the map after the WanReplication CR
 		mapCr = hazelcastconfig.DefaultMap(types.NamespacedName{Name: mapAfterWanCR, Namespace: mapLookupKey.Namespace}, hzSource, labels)
 		Expect(k8sClient.Create(context.Background(), mapCr)).Should(Succeed())
 		assertMapStatus(mapCr, hazelcastcomv1alpha1.MapSuccess)
 
 		wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
+		assertWanStatusMapCount(wan, 2)
 	})
 
 })

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -908,7 +908,7 @@ func createWanResources(ctx context.Context, hzMapResources map[string][]string,
 		for _, mapCrName := range mapCrNames {
 			m := hazelcastconfig.DefaultMap(types.NamespacedName{Name: mapCrName, Namespace: ns}, hzCrName, labels)
 			mapCrs[mapCrName] = m
-			Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, m)).Should(Succeed())
 		}
 	}
 
@@ -928,7 +928,7 @@ func createWanConfig(ctx context.Context, lk types.NamespacedName, target *hazel
 		resources,
 		labels,
 	)
-	Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
+	Expect(k8sClient.Create(ctx, wan)).Should(Succeed())
 	wan = assertWanStatus(wan, hazelcastcomv1alpha1.WanStatusSuccess)
 	wan = assertWanStatusMapCount(wan, mapCount)
 	return wan
@@ -940,13 +940,13 @@ func CreateMcForClusters(ctx context.Context, hzCrs ...*hazelcastcomv1alpha1.Haz
 		clusters = append(clusters, hazelcastcomv1alpha1.HazelcastClusterConfig{Name: hz.Spec.ClusterName, Address: hzclient.HazelcastUrl(hz)})
 	}
 	mc := mcconfig.WithClusterConfig(mcLookupKey, ee, clusters, labels)
-	Expect(k8sClient.Create(context.Background(), mc)).Should(Succeed())
+	Expect(k8sClient.Create(ctx, mc)).Should(Succeed())
 }
 
 func createMapCRWithMapName(ctx context.Context, mapCrName, mapName string, hzLookupKey types.NamespacedName) *hazelcastcomv1alpha1.Map {
 	m := hazelcastconfig.DefaultMap(types.NamespacedName{Name: mapCrName, Namespace: hzLookupKey.Namespace}, hzLookupKey.Name, labels)
 	m.Spec.Name = mapName
-	Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
+	Expect(k8sClient.Create(ctx, m)).Should(Succeed())
 	assertMapStatus(m, hazelcastcomv1alpha1.MapSuccess)
 	return m
 }


### PR DESCRIPTION
## Description

It triggers the WanReplication CR’s reconciler when a new map is created in given Hazelcast in order to start WanReplication for newly created maps. 

## User Impact

WanReplication feature can be activated even for the Map CRs which are created after their WanReplication CR.
