### PR TITLE
Limit MC resources

### DIFF
--- a/test/e2e/management_center_test.go
+++ b/test/e2e/management_center_test.go
@@ -64,6 +64,10 @@ var _ = Describe("Management-Center", Label("mc"), func() {
 		It("Should create ManagementCenter resources", Label("fast"), func() {
 			setLabelAndCRName("mc-1")
 			mc := mcconfig.Default(mcLookupKey, ee, labels)
+			mc.Spec.Resources = corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("1Gi")},
+			}
 			create(mc)
 
 			By("checking if it created PVC with correct size", func() {
@@ -95,6 +99,10 @@ var _ = Describe("Management-Center", Label("mc"), func() {
 		It("Should create ManagementCenter resources and no PVC", Label("fast"), func() {
 			setLabelAndCRName("mc-2")
 			mc := mcconfig.PersistenceDisabled(mcLookupKey, ee, labels)
+			mc.Spec.Resources = corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse("1Gi")},
+			}
 			create(mc)
 
 			By("checking if PVC doesn't exist", func() {


### PR DESCRIPTION
## Description

This PR will fix the MC tests related to the error: 
`0/3 nodes are available: 3 Insufficient memory. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.`