### PR TITLE
[CN-773] joining default port to endpoints

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -311,12 +311,12 @@ func (c *UserCodeDeploymentConfig) IsConfigMapEnabled() bool {
 
 type AgentConfiguration struct {
 	// Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
-	// +kubebuilder:default:="docker.io/semihbkr/hazelcast-platform-operator-agent"
+	// +kubebuilder:default:="docker.io/hazelcast/platform-operator-agent"
 	// +optional
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Hazelcast Platform Operator Agent.
-	// +kubebuilder:default:="CN-773"
+	// +kubebuilder:default:="0.1.16"
 	// +optional
 	Version string `json:"version,omitempty"`
 }

--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -311,12 +311,12 @@ func (c *UserCodeDeploymentConfig) IsConfigMapEnabled() bool {
 
 type AgentConfiguration struct {
 	// Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
-	// +kubebuilder:default:="docker.io/hazelcast/platform-operator-agent"
+	// +kubebuilder:default:="docker.io/semihbkr/hazelcast-platform-operator-agent"
 	// +optional
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Hazelcast Platform Operator Agent.
-	// +kubebuilder:default:="0.1.15"
+	// +kubebuilder:default:="CN-773"
 	// +optional
 	Version string `json:"version,omitempty"`
 }

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -90,11 +90,11 @@ spec:
                 description: B&R Agent configurations
                 properties:
                   repository:
-                    default: docker.io/semihbkr/hazelcast-platform-operator-agent
+                    default: docker.io/hazelcast/platform-operator-agent
                     description: Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
                     type: string
                   version:
-                    default: CN-773
+                    default: 0.1.16
                     description: Version of Hazelcast Platform Operator Agent.
                     type: string
                 type: object

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -90,11 +90,11 @@ spec:
                 description: B&R Agent configurations
                 properties:
                   repository:
-                    default: docker.io/hazelcast/platform-operator-agent
+                    default: docker.io/semihbkr/hazelcast-platform-operator-agent
                     description: Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
                     type: string
                   version:
-                    default: 0.1.15
+                    default: CN-773
                     description: Version of Hazelcast Platform Operator Agent.
                     type: string
                 type: object

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -754,7 +754,6 @@ func (r *WanReplicationReconciler) checkWanEndpoint(ctx context.Context, wan *ha
 	for i, endpoint := range endpoints {
 		_, _, err := net.SplitHostPort(endpoint)
 		if err != nil {
-			//TODO update default port after advanced network -> 5710
 			endpoint = net.JoinHostPort(endpoint, "5701")
 		}
 		endpoints[i] = endpoint

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -119,6 +120,10 @@ func (r *WanReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err != nil {
 			return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 		}
+	}
+
+	if err := r.checkWanEndpoint(ctx, wan); err != nil {
+		return updateWanStatus(ctx, r.Client, wan, wanFailedStatus(err).withMessage(err.Error()))
 	}
 
 	err = r.stopWanRepForRemovedResources(ctx, wan, hzClientMap, r.clientRegistry)
@@ -337,13 +342,28 @@ func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ct
 				return err
 			}
 
-			err = p.TryDial(ctx, wan.Spec.Endpoints)
+			err = p.TryDial(ctx, splitEndpoints(wan.Spec.Endpoints))
 			if err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func splitEndpoints(endpointsStr string) []string {
+	endpoints := make([]string, 0)
+	for _, endpoint := range strings.Split(endpointsStr, ",") {
+		endpoint = strings.TrimSpace(endpoint)
+		if len(endpoint) != 0 {
+			endpoints = append(endpoints, endpoint)
+		}
+	}
+	return endpoints
+}
+
+func joinEndpoints(endpoints []string) string {
+	return strings.Join(endpoints, ",")
 }
 
 func (r *WanReplicationReconciler) getMapsGroupByHazelcastName(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) (map[string][]hazelcastv1alpha1.Map, error) {
@@ -638,11 +658,8 @@ func (r *WanReplicationReconciler) addWanRepFinalizerToMap(ctx context.Context, 
 	}
 
 	controllerutil.AddFinalizer(m, n.WanRepMapFinalizer)
-	if err := r.Update(ctx, m); err != nil {
-		return err
-	}
 
-	return nil
+	return r.Update(ctx, m)
 }
 
 func (r *WanReplicationReconciler) validateWanConfigPersistence(ctx context.Context, wan *hazelcastv1alpha1.WanReplication, hzClientMap map[string][]hazelcastv1alpha1.Map) (bool, error) {
@@ -729,6 +746,25 @@ func (r *WanReplicationReconciler) updateLastSuccessfulConfiguration(ctx context
 		r.Logger.Info("Operation result", "WanReplication Annotation", wan.Name, "result", opResult)
 	}
 	return err
+}
+
+// mutating function
+func (r *WanReplicationReconciler) checkWanEndpoint(ctx context.Context, wan *hazelcastv1alpha1.WanReplication) error {
+	endpoints := splitEndpoints(wan.Spec.Endpoints)
+	for i, endpoint := range endpoints {
+		_, _, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			//TODO update default port after advanced network -> 5710
+			endpoint = net.JoinHostPort(endpoint, "5701")
+		}
+		endpoints[i] = endpoint
+	}
+	endpointsStr := joinEndpoints(endpoints)
+	if wan.Spec.Endpoints == endpointsStr {
+		return nil
+	}
+	wan.Spec.Endpoints = endpointsStr
+	return r.Client.Update(ctx, wan)
 }
 
 type LogKey string

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hazelcast/hazelcast-go-client v1.3.2
-	github.com/hazelcast/platform-operator-agent v0.1.13
+	github.com/hazelcast/platform-operator-agent v0.0.0-20230315182407-e2d8aaf64451
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/openshift/api v0.0.0-20220715133027-dab5b363ebd1
@@ -106,8 +106,8 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.23.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
+	go.uber.org/zap v1.24.0 // indirect
 	gocloud.dev v0.24.0 // indirect
 	golang.org/x/crypto v0.2.0 // indirect
 	golang.org/x/net v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hazelcast/hazelcast-go-client v1.3.2
-	github.com/hazelcast/platform-operator-agent v0.0.0-20230315182407-e2d8aaf64451
+	github.com/hazelcast/platform-operator-agent v0.1.16
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/openshift/api v0.0.0-20220715133027-dab5b363ebd1

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hazelcast/hazelcast-go-client v1.3.2 h1:RSaEoL5NIoPZuKbHWXcgYO12xZW8Br63DYhMENXVRCo=
 github.com/hazelcast/hazelcast-go-client v1.3.2/go.mod h1:JH7sI0kvMSlJJ5D+YFRg/J/P41MRPffzCt0bN9LYd0M=
-github.com/hazelcast/platform-operator-agent v0.1.13 h1:WL2KhGLYEj/g7mkdAeggTLVFhUnJH3llEM3VAdM4Cfg=
-github.com/hazelcast/platform-operator-agent v0.1.13/go.mod h1:UWuQSKswAATg7XPMG0epopV7RNhe9eql1QHK6uhGflA=
+github.com/hazelcast/platform-operator-agent v0.0.0-20230315182407-e2d8aaf64451 h1:nQeWHOwy0Y2zD9hFq+EJ8SgWlhoyTde/pJM8RF4LXxs=
+github.com/hazelcast/platform-operator-agent v0.0.0-20230315182407-e2d8aaf64451/go.mod h1:Za1b73yBvA+HL1Q2LuAaY7XzMUVdBCliqCm9Lb65zuo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -627,12 +627,12 @@ go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
-go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
-go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
+go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
-go.uber.org/zap v1.23.0 h1:OjGQ5KQDEUawVHxNwQgPpiypGHOxo2mNZsOqTak4fFY=
-go.uber.org/zap v1.23.0/go.mod h1:D+nX8jyLsMHMYrln8A0rJjFt/T/9/bGgIhAqxv5URuY=
+go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
+go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 gocloud.dev v0.24.0 h1:cNtHD07zQQiv02OiwwDyVMuHmR7iQt2RLkzoAgz7wBs=
 gocloud.dev v0.24.0/go.mod h1:uA+als++iBX5ShuG4upQo/3Zoz49iIPlYUWHV5mM8w8=
 golang.org/x/arch v0.0.0-20180920145803-b19384d3c130/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hazelcast/hazelcast-go-client v1.3.2 h1:RSaEoL5NIoPZuKbHWXcgYO12xZW8Br63DYhMENXVRCo=
 github.com/hazelcast/hazelcast-go-client v1.3.2/go.mod h1:JH7sI0kvMSlJJ5D+YFRg/J/P41MRPffzCt0bN9LYd0M=
-github.com/hazelcast/platform-operator-agent v0.0.0-20230315182407-e2d8aaf64451 h1:nQeWHOwy0Y2zD9hFq+EJ8SgWlhoyTde/pJM8RF4LXxs=
-github.com/hazelcast/platform-operator-agent v0.0.0-20230315182407-e2d8aaf64451/go.mod h1:Za1b73yBvA+HL1Q2LuAaY7XzMUVdBCliqCm9Lb65zuo=
+github.com/hazelcast/platform-operator-agent v0.1.16 h1:FuiYAB8ViRwIWJGvd43Hn1KHpK19JFjuX3sItsfd4C0=
+github.com/hazelcast/platform-operator-agent v0.1.16/go.mod h1:Za1b73yBvA+HL1Q2LuAaY7XzMUVdBCliqCm9Lb65zuo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -343,11 +343,11 @@ spec:
                 description: B&R Agent configurations
                 properties:
                   repository:
-                    default: docker.io/semihbkr/hazelcast-platform-operator-agent
+                    default: docker.io/hazelcast/platform-operator-agent
                     description: Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
                     type: string
                   version:
-                    default: CN-773
+                    default: 0.1.16
                     description: Version of Hazelcast Platform Operator Agent.
                     type: string
                 type: object

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -343,11 +343,11 @@ spec:
                 description: B&R Agent configurations
                 properties:
                   repository:
-                    default: docker.io/hazelcast/platform-operator-agent
+                    default: docker.io/semihbkr/hazelcast-platform-operator-agent
                     description: Repository to pull Hazelcast Platform Operator Agent(https://github.com/hazelcast/platform-operator-agent)
                     type: string
                   version:
-                    default: 0.1.15
+                    default: CN-773
                     description: Version of Hazelcast Platform Operator Agent.
                     type: string
                 type: object

--- a/internal/dialer/dialer.go
+++ b/internal/dialer/dialer.go
@@ -38,7 +38,7 @@ func NewDialer(config *Config) (*Dialer, error) {
 	}, nil
 }
 
-func (p *Dialer) TryDial(ctx context.Context, endpoints string) error {
+func (p *Dialer) TryDial(ctx context.Context, endpoints []string) error {
 	dialResp, _, err := p.service.TryDial(ctx, &sidecar.DialRequest{
 		Endpoints: endpoints,
 	})

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -947,6 +947,37 @@ var _ = Describe("Hazelcast controller", func() {
 		})
 	})
 
+	Context("WanReplication CR configuration", func() {
+		When("endpoints are configured without port", func() {
+			It("should set default port to endpoints", Label("fast"), func() {
+				endpoints := "10.0.0.1,10.0.0.2,10.0.0.3"
+				wan := &hazelcastv1alpha1.WanReplication{
+					ObjectMeta: GetRandomObjectMeta(),
+					Spec: hazelcastv1alpha1.WanReplicationSpec{
+						Resources: []hazelcastv1alpha1.ResourceSpec{
+							{
+								Name: "hazelcast",
+								Kind: hazelcastv1alpha1.ResourceKindHZ,
+							},
+						},
+						TargetClusterName: "dev",
+						Endpoints:         endpoints,
+					},
+				}
+				By("creating WanReplication CR successfully")
+				Expect(k8sClient.Create(context.Background(), wan)).Should(Succeed())
+				Eventually(func() string {
+					newWan := hazelcastv1alpha1.WanReplication{}
+					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: wan.Name, Namespace: wan.Namespace}, &newWan)
+					if err != nil {
+						return ""
+					}
+					return newWan.Spec.Endpoints
+				}, timeout, interval).Should(Equal("10.0.0.1:5701,10.0.0.2:5701,10.0.0.3:5701"))
+			})
+		})
+	})
+
 	Context("Resources context", func() {
 		When("Resources are used", func() {
 			It("should be set to Container spec", Label("fast"), func() {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -100,8 +100,8 @@ var _ = BeforeSuite(func() {
 		nil,
 		cs,
 		ssm,
-		mtls.NewHttpClientRegistry()).
-		SetupWithManager(k8sManager)
+		mtls.NewHttpClientRegistry(),
+	).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = managementcenter.NewManagementCenterReconciler(
@@ -136,6 +136,17 @@ var _ = BeforeSuite(func() {
 		controllerLogger.WithName("Cron Hot Backup"),
 		k8sManager.GetScheme(),
 		nil,
+	).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = hazelcast.NewWanReplicationReconciler(
+		k8sManager.GetClient(),
+		controllerLogger.WithName("WanReplication"),
+		k8sManager.GetScheme(),
+		nil,
+		mtls.NewHttpClientRegistry(),
+		cs,
+		ssm,
 	).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

Add default port 5701 to the wan target endpoints if not declared by user.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->

If port number is not specified in WanReplication endpoints, the default Hazelcast port '5701' is joined to the endpoints.
