### PR TITLE
[CN-779] Update Hazelcast Go client to 1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hazelcast/hazelcast-go-client v1.3.2
+	github.com/hazelcast/hazelcast-go-client v1.4.0
 	github.com/hazelcast/platform-operator-agent v0.1.16
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -412,10 +412,10 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hazelcast/hazelcast-go-client v1.3.2 h1:RSaEoL5NIoPZuKbHWXcgYO12xZW8Br63DYhMENXVRCo=
-github.com/hazelcast/hazelcast-go-client v1.3.2/go.mod h1:JH7sI0kvMSlJJ5D+YFRg/J/P41MRPffzCt0bN9LYd0M=
 github.com/hazelcast/platform-operator-agent v0.1.16 h1:FuiYAB8ViRwIWJGvd43Hn1KHpK19JFjuX3sItsfd4C0=
 github.com/hazelcast/platform-operator-agent v0.1.16/go.mod h1:Za1b73yBvA+HL1Q2LuAaY7XzMUVdBCliqCm9Lb65zuo=
+github.com/hazelcast/hazelcast-go-client v1.4.0 h1:8+fvcG+Owf5mi3qezc8FN9CG6Vpb6x8tqKTb9nXrQWk=
+github.com/hazelcast/hazelcast-go-client v1.4.0/go.mod h1:PJ38lqXJ18S0YpkrRznPDlUH8GnnMAQCx3jpQtBPZ6Q=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-go-client/tree/release-v1.4.0
