### PR TITLE
Use Hz version 5.2.3-SNAPSHOT

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -55,7 +55,7 @@ type HazelcastSpec struct {
 	Repository string `json:"repository,omitempty"`
 
 	// Version of Hazelcast Platform.
-	// +kubebuilder:default:="latest-snapshot"
+	// +kubebuilder:default:="5.2.3-SNAPSHOT"
 	// +optional
 	Version string `json:"version,omitempty"`
 

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -1599,7 +1599,7 @@ spec:
                     type: string
                 type: object
               version:
-                default: latest-snapshot
+                default: 5.2.3-SNAPSHOT
                 description: Version of Hazelcast Platform.
                 type: string
             type: object

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -1852,7 +1852,7 @@ spec:
                     type: string
                 type: object
               version:
-                default: latest-snapshot
+                default: 5.2.3-SNAPSHOT
                 description: Version of Hazelcast Platform.
                 type: string
             type: object

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -82,7 +82,7 @@ const (
 	// HazelcastEERepo image repository for Hazelcast EE
 	HazelcastEERepo = "docker.io/hazelcast/hazelcast-enterprise"
 	// HazelcastVersion version of Hazelcast image
-	HazelcastVersion = "latest-snapshot"
+	HazelcastVersion = "5.2.3-SNAPSHOT"
 	// HazelcastImagePullPolicy pull policy for Hazelcast Platform image
 	HazelcastImagePullPolicy = corev1.PullIfNotPresent
 )


### PR DESCRIPTION
## Description

Change default Hazelcast version to 5.2.3-SNAPSHOT instead of latest-snapshot

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
