### PR TITLE
[CN-802]: Add MC Config

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -174,10 +174,6 @@ type ManagementCenterConfig struct {
 	// +kubebuilder:default:=false
 	// +optional
 	DataAccessEnabled bool `json:"dataAccessEnabled,omitempty"`
-
-	// To restrict access only to trusted instances of Management Center, you can define the trusted IP addresses.
-	// +optional
-	TrustedInterfaces []string `json:"trustedInterfaces,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=NODE;ZONE

--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -152,6 +152,32 @@ type HazelcastSpec struct {
 	// +optional
 	// +kubebuilder:default:={}
 	AdvancedNetwork AdvancedNetwork `json:"advancedNetwork,omitempty"`
+
+	// Hazelcast Management Center Configuration
+	// +optional
+	// +kubebuilder:default:={}
+	ManagementCenterConfig ManagementCenterConfig `json:"managementCenter,omitempty"`
+}
+
+type ManagementCenterConfig struct {
+	// Allows you to execute scripts that can automate interactions with the cluster.
+	// +kubebuilder:default:=false
+	// +optional
+	ScriptingEnabled bool `json:"scriptingEnabled,omitempty"`
+
+	// Allows you to execute commands from a built-in console in the user interface.
+	// +kubebuilder:default:=false
+	// +optional
+	ConsoleEnabled bool `json:"consoleEnabled,omitempty"`
+
+	// Allows you to access contents of Hazelcast data structures via SQL Browser or Map Browser.
+	// +kubebuilder:default:=false
+	// +optional
+	DataAccessEnabled bool `json:"dataAccessEnabled,omitempty"`
+
+	// To restrict access only to trusted instances of Management Center, you can define the trusted IP addresses.
+	// +optional
+	TrustedInterfaces []string `json:"trustedInterfaces,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=NODE;ZONE

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -301,12 +301,6 @@ spec:
                     description: Allows you to execute scripts that can automate interactions
                       with the cluster.
                     type: boolean
-                  trustedInterfaces:
-                    description: To restrict access only to trusted instances of Management
-                      Center, you can define the trusted IP addresses.
-                    items:
-                      type: string
-                    type: array
                 type: object
               nativeMemory:
                 description: Hazelcast Native Memory (HD Memory) configuration

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -283,6 +283,31 @@ spec:
                 - TRACE
                 - ALL
                 type: string
+              managementCenter:
+                description: Hazelcast Management Center Configuration
+                properties:
+                  consoleEnabled:
+                    default: false
+                    description: Allows you to execute commands from a built-in console
+                      in the user interface.
+                    type: boolean
+                  dataAccessEnabled:
+                    default: false
+                    description: Allows you to access contents of Hazelcast data structures
+                      via SQL Browser or Map Browser.
+                    type: boolean
+                  scriptingEnabled:
+                    default: false
+                    description: Allows you to execute scripts that can automate interactions
+                      with the cluster.
+                    type: boolean
+                  trustedInterfaces:
+                    description: To restrict access only to trusted instances of Management
+                      Center, you can define the trusted IP addresses.
+                    items:
+                      type: string
+                    type: array
+                type: object
               nativeMemory:
                 description: Hazelcast Native Memory (HD Memory) configuration
                 properties:

--- a/config/samples/_v1alpha1_hazelcast_mc_monitoring_config.yaml
+++ b/config/samples/_v1alpha1_hazelcast_mc_monitoring_config.yaml
@@ -1,0 +1,15 @@
+apiVersion: hazelcast.com/v1alpha1
+kind: Hazelcast
+metadata:
+  name: hazelcast
+spec:
+  clusterSize: 3
+  repository: 'docker.io/hazelcast/hazelcast-enterprise'
+  version: '5.2.1'
+  licenseKeySecret: hazelcast-license-key
+  managementCenter:
+    scriptingEnabled: true
+    consoleEnabled: true
+    dataAccessEnabled: true
+    trustedInterfaces:
+      - 192.168.1.*

--- a/config/samples/_v1alpha1_hazelcast_mc_monitoring_config.yaml
+++ b/config/samples/_v1alpha1_hazelcast_mc_monitoring_config.yaml
@@ -11,5 +11,3 @@ spec:
     scriptingEnabled: true
     consoleEnabled: true
     dataAccessEnabled: true
-    trustedInterfaces:
-      - 192.168.1.*

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -783,6 +783,13 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 		}
 	}
 
+	cfg.ManagementCenter = config.ManagementCenterConfig{
+		ScriptingEnabled:  h.Spec.ManagementCenterConfig.ScriptingEnabled,
+		ConsoleEnabled:    h.Spec.ManagementCenterConfig.ConsoleEnabled,
+		DataAccessEnabled: h.Spec.ManagementCenterConfig.DataAccessEnabled,
+		TrustedInterfaces: h.Spec.ManagementCenterConfig.TrustedInterfaces,
+	}
+
 	return cfg
 }
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -787,7 +787,6 @@ func hazelcastConfigMapStruct(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 		ScriptingEnabled:  h.Spec.ManagementCenterConfig.ScriptingEnabled,
 		ConsoleEnabled:    h.Spec.ManagementCenterConfig.ConsoleEnabled,
 		DataAccessEnabled: h.Spec.ManagementCenterConfig.DataAccessEnabled,
-		TrustedInterfaces: h.Spec.ManagementCenterConfig.TrustedInterfaces,
 	}
 
 	return cfg

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -554,12 +554,6 @@ spec:
                     description: Allows you to execute scripts that can automate interactions
                       with the cluster.
                     type: boolean
-                  trustedInterfaces:
-                    description: To restrict access only to trusted instances of Management
-                      Center, you can define the trusted IP addresses.
-                    items:
-                      type: string
-                    type: array
                 type: object
               nativeMemory:
                 description: Hazelcast Native Memory (HD Memory) configuration

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -536,6 +536,31 @@ spec:
                 - TRACE
                 - ALL
                 type: string
+              managementCenter:
+                description: Hazelcast Management Center Configuration
+                properties:
+                  consoleEnabled:
+                    default: false
+                    description: Allows you to execute commands from a built-in console
+                      in the user interface.
+                    type: boolean
+                  dataAccessEnabled:
+                    default: false
+                    description: Allows you to access contents of Hazelcast data structures
+                      via SQL Browser or Map Browser.
+                    type: boolean
+                  scriptingEnabled:
+                    default: false
+                    description: Allows you to execute scripts that can automate interactions
+                      with the cluster.
+                    type: boolean
+                  trustedInterfaces:
+                    description: To restrict access only to trusted instances of Management
+                      Center, you can define the trusted IP addresses.
+                    items:
+                      type: string
+                    type: array
+                type: object
               nativeMemory:
                 description: Hazelcast Native Memory (HD Memory) configuration
                 properties:

--- a/internal/config/hazelcast.go
+++ b/internal/config/hazelcast.go
@@ -23,6 +23,14 @@ type Hazelcast struct {
 	PartitionGroup           PartitionGroup                      `yaml:"partition-group,omitempty"`
 	NativeMemory             NativeMemory                        `yaml:"native-memory,omitempty"`
 	AdvancedNetwork          AdvancedNetwork                     `yaml:"advanced-network,omitempty"`
+	ManagementCenter         ManagementCenterConfig              `yaml:"management-center,omitempty"`
+}
+
+type ManagementCenterConfig struct {
+	ScriptingEnabled  bool     `yaml:"scripting-enabled,omitempty"`
+	ConsoleEnabled    bool     `yaml:"console-enabled,omitempty"`
+	DataAccessEnabled bool     `yaml:"data-access-enabled,omitempty"`
+	TrustedInterfaces []string `yaml:"trusted-interfaces,omitempty"`
 }
 
 type AdvancedNetwork struct {

--- a/internal/config/hazelcast.go
+++ b/internal/config/hazelcast.go
@@ -27,10 +27,9 @@ type Hazelcast struct {
 }
 
 type ManagementCenterConfig struct {
-	ScriptingEnabled  bool     `yaml:"scripting-enabled,omitempty"`
-	ConsoleEnabled    bool     `yaml:"console-enabled,omitempty"`
-	DataAccessEnabled bool     `yaml:"data-access-enabled,omitempty"`
-	TrustedInterfaces []string `yaml:"trusted-interfaces,omitempty"`
+	ScriptingEnabled  bool `yaml:"scripting-enabled,omitempty"`
+	ConsoleEnabled    bool `yaml:"console-enabled,omitempty"`
+	DataAccessEnabled bool `yaml:"data-access-enabled,omitempty"`
 }
 
 type AdvancedNetwork struct {

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -1278,7 +1278,7 @@ var _ = Describe("Hazelcast controller", func() {
 
 	Context("Hazelcast CR Management Center configuration", func() {
 		When("Management Center property is configured", func() {
-			FIt("should be enabled", Label("fast"), func() {
+			It("should be enabled", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultSpecValues, ee)
 				spec.ManagementCenterConfig = hazelcastv1alpha1.ManagementCenterConfig{
 					ScriptingEnabled:  true,

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -1284,7 +1284,6 @@ var _ = Describe("Hazelcast controller", func() {
 					ScriptingEnabled:  true,
 					ConsoleEnabled:    true,
 					DataAccessEnabled: true,
-					TrustedInterfaces: []string{"192.168.1.*"},
 				}
 				hz := &hazelcastv1alpha1.Hazelcast{
 					ObjectMeta: GetRandomObjectMeta(),
@@ -1303,8 +1302,7 @@ var _ = Describe("Hazelcast controller", func() {
 					}
 
 					mc := config.Hazelcast.ManagementCenter
-					return mc.DataAccessEnabled && mc.ScriptingEnabled && mc.ConsoleEnabled &&
-						len(mc.TrustedInterfaces) == 1
+					return mc.DataAccessEnabled && mc.ScriptingEnabled && mc.ConsoleEnabled
 				}, timeout, interval).Should(BeTrue())
 
 				Delete(hz)


### PR DESCRIPTION
## Description

Enables MC Configuration in the following document:
https://docs.hazelcast.com/hazelcast/5.2/maintain-cluster/monitoring#management-center

## User Impact
User can configure Management Center monitoring parameters. Example configuration:
```
apiVersion: hazelcast.com/v1alpha1
kind: Hazelcast
metadata:
  name: hazelcast
spec:
  clusterSize: 3
  repository: 'docker.io/hazelcast/hazelcast-enterprise'
  version: '5.2.1'
  licenseKeySecret: hazelcast-license-key
  managementCenter:
    scriptingEnabled: true
    consoleEnabled: true
    dataAccessEnabled: true
```