### PR TITLE
[CN-791] Make service ports and rbac permissions updatable

### DIFF
--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -404,6 +404,8 @@ func (r *HazelcastReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&hazelcastv1alpha1.Hazelcast{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.ServiceAccount{}).
 		Watches(&source.Channel{Source: r.triggerReconcileChan}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, handler.EnqueueRequestsFromMapFunc(r.podUpdates)).

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -50,7 +50,6 @@ func (r *ManagementCenterReconciler) reconcileService(ctx context.Context, mc *h
 		ObjectMeta: metadata(mc),
 		Spec: corev1.ServiceSpec{
 			Selector: labels(mc),
-			Ports:    ports(),
 		},
 	}
 
@@ -60,6 +59,7 @@ func (r *ManagementCenterReconciler) reconcileService(ctx context.Context, mc *h
 	}
 
 	opResult, err := util.CreateOrUpdate(ctx, r.Client, service, func() error {
+		service.Spec.Ports = ports()
 		service.Spec.Type = mc.Spec.ExternalConnectivity.ManagementCenterServiceType()
 		return nil
 	})

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	cloud.google.com/go/bigquery v1.43.0
-	github.com/aws/smithy-go v1.13.4
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
@@ -53,6 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.2 // indirect
+	github.com/aws/smithy-go v1.13.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -1654,7 +1654,7 @@ var _ = Describe("Hazelcast controller", func() {
 	})
 
 	// WanReplication CR configuration and controller tests
-	FContext("Hazelcast RBAC Permission updates", func() {
+	Context("Hazelcast RBAC Permission updates", func() {
 		When("RBAC permissions are overridden by a client", func() {
 			It("should override changes with operator ones", Label("fast"), func() {
 				hz := &hazelcastv1alpha1.Hazelcast{

--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
@@ -842,7 +840,7 @@ var _ = Describe("Hazelcast controller", func() {
 		When("Memory is configured", func() {
 			It("should set memory with percentages", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultSpecValues, ee)
-				p := ptr.String("10")
+				p := pointer.String("10")
 				spec.JVM = &hazelcastv1alpha1.JVMConfiguration{
 					Memory: &hazelcastv1alpha1.JVMMemoryConfiguration{
 						InitialRAMPercentage: p,
@@ -870,7 +868,7 @@ var _ = Describe("Hazelcast controller", func() {
 				gcArg := "-XX:MaxGCPauseMillis=200"
 				spec.JVM = &hazelcastv1alpha1.JVMConfiguration{
 					GC: &hazelcastv1alpha1.JVMGCConfiguration{
-						Logging:   ptr.Bool(true),
+						Logging:   pointer.Bool(true),
 						Collector: &s,
 						Args:      []string{gcArg},
 					},


### PR DESCRIPTION
## Description

When operator upgrade happened and if the new operator version assigned new ports to services or permissions to rbac resources, they were not updated. This PR fixes the issue by making them updatable.

## User Impact

Service ports and rbac permission are now able to be updated when operator version upgrade happens
