### PR TITLE
Fix CreateOrUpdate function usage

### DIFF
--- a/api/v1alpha1/map_validation.go
+++ b/api/v1alpha1/map_validation.go
@@ -109,7 +109,13 @@ func indexConfigEquals(a, b IndexConfig) bool {
 		return false
 	}
 
-	if a.BitmapIndexOptions != b.BitmapIndexOptions {
+	// if both a and b not nil
+	if (a.BitmapIndexOptions != nil) && (b.BitmapIndexOptions != nil) {
+		return *a.BitmapIndexOptions != *b.BitmapIndexOptions
+	}
+
+	// If one of a and b not nil
+	if (a.BitmapIndexOptions != nil) || (b.BitmapIndexOptions != nil) {
 		return false
 	}
 	return true

--- a/controllers/hazelcast/data_structure_controller.go
+++ b/controllers/hazelcast/data_structure_controller.go
@@ -220,7 +220,7 @@ func updateLastSuccessfulConfigurationDS(ctx context.Context, c client.Client, o
 	if err != nil {
 		return err
 	}
-	opResult, err := util.CreateOrUpdate(ctx, c, obj, func() error {
+	opResult, err := util.Update(ctx, c, obj, func() error {
 		annotations := obj.GetAnnotations()
 		if annotations == nil {
 			annotations = map[string]string{}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -2146,7 +2146,7 @@ func (r *HazelcastReconciler) updateLastSuccessfulConfiguration(ctx context.Cont
 		return err
 	}
 
-	opResult, err := util.CreateOrUpdate(ctx, r.Client, h, func() error {
+	opResult, err := util.Update(ctx, r.Client, h, func() error {
 		if h.ObjectMeta.Annotations == nil {
 			ans := map[string]string{}
 			h.ObjectMeta.Annotations = ans

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -387,7 +387,7 @@ func (r *MapReconciler) updateLastSuccessfulConfiguration(ctx context.Context, m
 		return err
 	}
 
-	opResult, err := util.CreateOrUpdate(ctx, r.Client, m, func() error {
+	opResult, err := util.Update(ctx, r.Client, m, func() error {
 		if m.ObjectMeta.Annotations == nil {
 			m.ObjectMeta.Annotations = map[string]string{}
 		}

--- a/controllers/hazelcast/wanreplication_controller.go
+++ b/controllers/hazelcast/wanreplication_controller.go
@@ -741,7 +741,7 @@ func (r *WanReplicationReconciler) updateLastSuccessfulConfiguration(ctx context
 		return err
 	}
 
-	opResult, err := util.CreateOrUpdate(ctx, r.Client, wan, func() error {
+	opResult, err := util.Update(ctx, r.Client, wan, func() error {
 		if wan.ObjectMeta.Annotations == nil {
 			wan.ObjectMeta.Annotations = map[string]string{}
 		}

--- a/controllers/managementcenter/managementcenter_controller.go
+++ b/controllers/managementcenter/managementcenter_controller.go
@@ -154,7 +154,7 @@ func (r *ManagementCenterReconciler) updateLastSuccessfulConfiguration(ctx conte
 		return err
 	}
 
-	opResult, err := util.CreateOrUpdate(ctx, r.Client, h, func() error {
+	opResult, err := util.Update(ctx, r.Client, h, func() error {
 		if h.ObjectMeta.Annotations == nil {
 			h.ObjectMeta.Annotations = map[string]string{}
 		}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,34 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 		return controllerutil.CreateOrUpdate(ctx, c, obj, f)
 	}
 	return opResult, err
+}
+
+func Update(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	key := client.ObjectKeyFromObject(obj)
+	existing := obj.DeepCopyObject() //nolint
+	if err := mutate(f, key, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	if equality.Semantic.DeepEqual(existing, obj) {
+		return controllerutil.OperationResultNone, nil
+	}
+
+	if err := c.Update(ctx, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	return controllerutil.OperationResultUpdated, nil
+}
+
+// mutate wraps a MutateFn and applies validation to its result.
+func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) error {
+	if err := f(); err != nil {
+		return err
+	}
+	if newKey := client.ObjectKeyFromObject(obj); key != newKey {
+		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
+	}
+	return nil
 }
 
 func CreateOrGet(ctx context.Context, c client.Client, key client.ObjectKey, obj client.Object) error {


### PR DESCRIPTION
## Description

CreateOrUpdate function was used for updating the CR annotations. However, function had a logic where an `Invalid` error forced the resource to be deleted. When used with webhooks, for example, a Map CR could get deleted when its annotation gets updated. This was what I faced because of a bug in Map validation.

I fixed both of the issues in this PR

## User Impact

Bug in map validation is fixed and data structure CR updates no longer unexpectedly deletes the updated CR.
