### PR TITLE
[CN-811] Make Hz container ports dynamically updatable correctly

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -349,12 +349,8 @@ func (r *HazelcastReconciler) reconcileService(ctx context.Context, h *hazelcast
 	}
 
 	opResult, err := util.CreateOrUpdate(ctx, r.Client, service, func() error {
-		service.Spec.Ports = hazelcastPort()
 		service.Spec.Type = serviceType(h)
-		if serviceType(h) == corev1.ServiceTypeClusterIP {
-			// dirty hack to prevent the error when changing the service type
-			service.Spec.Ports[0].NodePort = 0
-		}
+		service.Spec.Ports = util.EnrichServiceNodePorts(hazelcastPort(), service.Spec.Ports)
 		return nil
 	})
 	if opResult != controllerutil.OperationResultNone {
@@ -390,7 +386,7 @@ func (r *HazelcastReconciler) createServicesForWanConfig(ctx context.Context, h 
 		}
 
 		opResult, _ := util.CreateOrUpdate(ctx, r.Client, service, func() error {
-			service.Spec.Ports = ports
+			service.Spec.Ports = util.EnrichServiceNodePorts(ports, service.Spec.Ports)
 			service.Spec.Type = w.ServiceType
 			return nil
 		})
@@ -434,7 +430,7 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 		}
 
 		opResult, err := util.CreateOrUpdate(ctx, r.Client, service, func() error {
-			service.Spec.Ports = []corev1.ServicePort{clientPort()}
+			service.Spec.Ports = util.EnrichServiceNodePorts([]corev1.ServicePort{clientPort()}, service.Spec.Ports)
 			service.Spec.Type = h.Spec.ExposeExternally.MemberAccessServiceType()
 			return nil
 		})

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -58,7 +58,6 @@ func (r *ManagementCenterReconciler) reconcileService(ctx context.Context, mc *h
 		ObjectMeta: metadata(mc),
 		Spec: corev1.ServiceSpec{
 			Selector: labels(mc),
-			Ports:    ports(),
 		},
 	}
 
@@ -69,6 +68,7 @@ func (r *ManagementCenterReconciler) reconcileService(ctx context.Context, mc *h
 
 	opResult, err := util.CreateOrUpdate(ctx, r.Client, service, func() error {
 		service.Spec.Type = mc.Spec.ExternalConnectivity.ManagementCenterServiceType()
+		service.Spec.Ports = util.EnrichServiceNodePorts(ports(), service.Spec.Ports)
 		return nil
 	})
 	if opResult != controllerutil.OperationResultNone {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -287,4 +288,18 @@ func NodeDiscoveryEnabled() bool {
 		return true
 	}
 	return watching == "true"
+}
+
+func EnrichServiceNodePorts(newPorts []v1.ServicePort, existing []v1.ServicePort) []v1.ServicePort {
+	existingMap := map[string]v1.ServicePort{}
+	for _, port := range existing {
+		existingMap[port.Name] = port
+	}
+
+	for i := range newPorts {
+		if val, ok := existingMap[newPorts[i].Name]; ok {
+			newPorts[i].NodePort = val.NodePort
+		}
+	}
+	return newPorts
 }


### PR DESCRIPTION
## Description

Changes:
-  Removed service-per-pod and node-name labels from force config. 
    
    Service Per Pod labels forced a restart when unisocket
    Load Balancer service was changed to ClusterIP. However,
    this should not force a restart since it does not change
    anything on Hazelcast side. Made the service per pod label
    config into a permanent one.
    
    Removed node name as externall address config from force restart
    config since its configuration on Hazelcast side already changes the pod
    annotation which forces a restart. Putting it in force restart config
    is redundant
- Make Hazelcast container ports dynamically updatable
- Removed infinite triggers caused by service update
    
    Dynamically updating the ports of the services caused
    indefinite updates on the services since at each update
    operator overwrote the NodePorts as 0. We now don't
    overwrite NodePorts

## User Impact

Operator is now able to update the Hazelcast container ports as well as all service ports correctly. 
