### PR TITLE
Fix decision step commit message error

### DIFF
--- a/.github/workflows/k8s-dist-tests.yaml
+++ b/.github/workflows/k8s-dist-tests.yaml
@@ -55,14 +55,15 @@ jobs:
     steps:
       - name: Decide to run tests
         id: should-run-tests
+        env:
+          COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
         run: |
           if [[ '${{ github.event_name }}' != 'push' ]]; then
             echo "RUN_TESTS=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          COMMIT_MESSAGE='${{ github.event.commits[0].message }}'
-          PR_NUMBER=$(echo $COMMIT_MESSAGE | grep -oP '\(#\K[0-9]*(?=\))')
+          PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oP '\(#\K[0-9]*(?=\))')
           PR_LABELS=$( (gh pr view https://github.com/${{github.repository}}/pull/${PR_NUMBER} --json labels  | jq .labels[].name) || echo "Could not get PR labels")
           for label in $PR_LABELS; do
             # if full suite is ran before 


### PR DESCRIPTION

## Description

Commit messages can have characters that can cause bash to have syntax error since the github context is evaluated before the script is run.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
