### PR TITLE
[CN-834] Hazelcast CR name validation

### DIFF
--- a/test/integration/hazelcast_controller_test.go
+++ b/test/integration/hazelcast_controller_test.go
@@ -272,6 +272,18 @@ var _ = Describe("Hazelcast controller", func() {
 			assertDoesNotExist(clusterScopedLookupKey(hz), &rbacv1.ClusterRole{})
 			assertDoesNotExist(clusterScopedLookupKey(hz), &rbacv1.ClusterRoleBinding{})
 		})
+
+		It("should fail if CR name is invalid", Label("fast"), func() {
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "1hz",
+					Namespace: namespace,
+				},
+				Spec: test.HazelcastSpec(defaultSpecValues, ee),
+			}
+
+			Expect(k8sClient.Create(context.Background(), hz)).Should(HaveOccurred())
+		})
 	})
 
 	Context("Hazelcast CR with expose externally", func() {


### PR DESCRIPTION
## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

Adding constraint to Hazelcast CR to conform DNS-1035.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->

Hazelcast CR name has the same constraints as DNS-1035 label.
