### PR TITLE
increase the timeout of integration tests

### DIFF
--- a/.github/workflows/k8s-dist-tests.yaml
+++ b/.github/workflows/k8s-dist-tests.yaml
@@ -175,19 +175,19 @@ jobs:
       - name: Run integration tests
         run: |
           case ${{ matrix.edition }} in
-            os) GO_TEST_FLAGS=-ee=false;;
-            ee) GO_TEST_FLAGS=-ee=true;;
+            os) COVER_OUT='cover-it-os.out';GO_TEST_FLAGS='-ee=false -eventually-timeout=30s';;
+            ee) COVER_OUT='cover-it-ee.out';GO_TEST_FLAGS='-ee=true -eventually-timeout=30s';;
             *)  echo Unexpected edition: ${{ matrix.edition }} && exit 1;;
           esac
-          echo "GO_TEST_FLAGS=${GO_TEST_FLAGS}" >> $GITHUB_ENV
-          make GO_TEST_FLAGS=${GO_TEST_FLAGS} test-it
+          echo "COVER_OUT=${COVER_OUT}" >> $GITHUB_ENV
+          make GO_TEST_FLAGS=${GO_TEST_FLAGS} COVER_OUT=${COVER_OUT} test-it
 
       - name: Upload Integration Coverage Report
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-coverage
-          path: cover_it${{ env.GO_TEST_FLAGS }}.out
+          path: ${{ env.COVER_OUT }}
           retention-days: 1
 
   upload-coverage:
@@ -208,7 +208,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: cover_it-ee=true.out,cover_it-ee=false.out
+          files: cover-it-ee.out,cover-it-os.out
           flags: integration
           name: Integration Tests Report
           fail_ci_if_error: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -104,10 +104,10 @@ jobs:
         run: make test-unit
 
       - name: Run integration tests (OS)
-        run: make GO_TEST_FLAGS="-ee=false" test-it
+        run: make GO_TEST_FLAGS="-ee=false -eventually-timeout=30s" test-it
 
       - name: Run integration tests (EE)
-        run: make GO_TEST_FLAGS="-ee=true" test-it
+        run: make GO_TEST_FLAGS="-ee=true -eventually-timeout=30s" test-it
 
   generate-test-suites:
     name: Generate Test Suites

--- a/Makefile
+++ b/Makefile
@@ -192,14 +192,15 @@ tilt-remote-ttl:
 
 ENVTEST_ASSETS_DIR=$(TOOLBIN)/envtest
 GO_TEST_FLAGS ?= "-ee=true"
+COVER_OUT ?= "cover.out"
 
 test-it: manifests generate fmt vet envtest ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -ginkgo.label-filter="slow || fast" -coverprofile=cover_it$(GO_TEST_FLAGS).out -coverpkg $(COV_PKG) $(GO_TEST_FLAGS) -timeout 5m
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -ginkgo.label-filter="slow || fast" -coverprofile $(COVER_OUT) -coverpkg $(COV_PKG) $(GO_TEST_FLAGS) -timeout 5m
 
 test-it-focus: manifests generate fmt vet envtest ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -coverprofile cover.out $(GO_TEST_FLAGS) -timeout 5m
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go test -tags $(GO_BUILD_TAGS) -v ./test/integration/... -coverprofile $(COVER_OUT) $(GO_TEST_FLAGS) -timeout 5m
 
 E2E_TEST_SUITE ?= hz || mc || hz_persistence || hz_expose_externally || map || map_persistence || cache_persistence || hz_wan || custom_class || multimap || topic || replicatedmap || queue || cache || resilience
 ifeq (,$(E2E_TEST_SUITE))


### PR DESCRIPTION
## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

Add new variable for coverage output file name in Makefile
Increase timeout duration of integration test up to 30 sec.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
