### PR TITLE
[CN-812] Rename secret to secretName for ManagementCenter and HotBackup

### DIFF
--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -104,7 +104,7 @@ func validateExposeExternally(h *Hazelcast) *field.Error {
 
 func validateLicense(h *Hazelcast) *field.Error {
 	if checkEnterprise(h.Spec.Repository) && len(h.Spec.GetLicenseKeySecretName()) == 0 {
-		return field.Required(field.NewPath("spec").Child("licenseKeySecret"),
+		return field.Required(field.NewPath("spec").Child("licenseKeySecretName"),
 			"must be set when Hazelcast Enterprise is deployed")
 	}
 
@@ -119,7 +119,7 @@ func validateLicense(h *Hazelcast) *field.Error {
 		err := kubeclient.Get(context.Background(), secretName, &secret)
 		if kerrors.IsNotFound(err) {
 			// we care only about not found error
-			return field.NotFound(field.NewPath("spec").Child("licenseKeySecret"),
+			return field.NotFound(field.NewPath("spec").Child("licenseKeySecretName"),
 				"Hazelcast Enterprise licenseKeySecret is not found")
 		}
 	}

--- a/api/v1alpha1/hotbackup_types.go
+++ b/api/v1alpha1/hotbackup_types.go
@@ -88,13 +88,24 @@ type HotBackupSpec struct {
 	// +optional
 	BucketURI string `json:"bucketURI,omitempty"`
 
+	// secret is a deprecated alias for secretName.
+	// +optional
+	DeprecatedSecret string `json:"secret,omitempty"`
+
 	// Name of the secret with credentials for cloud providers.
 	// +optional
-	Secret string `json:"secret,omitempty"`
+	SecretName string `json:"secretName,omitempty"`
+}
+
+func (hbs *HotBackupSpec) GetSecretName() string {
+	if hbs.SecretName == "" {
+		return hbs.DeprecatedSecret
+	}
+	return hbs.SecretName
 }
 
 func (hbs *HotBackupSpec) IsExternal() bool {
-	return hbs.BucketURI != "" && hbs.Secret != ""
+	return hbs.BucketURI != "" && hbs.GetSecretName() != ""
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/managementcenter_types.go
+++ b/api/v1alpha1/managementcenter_types.go
@@ -29,9 +29,13 @@ type ManagementCenterSpec struct {
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
+	// licenseKeySecret is a deprecated alias for licenseKeySecretName.
+	// +optional
+	DeprecatedLicenseKeySecret string `json:"licenseKeySecret,omitempty"`
+
 	// Name of the secret with Hazelcast Enterprise License Key.
 	// +optional
-	LicenseKeySecret string `json:"licenseKeySecret,omitempty"`
+	LicenseKeySecretName string `json:"licenseKeySecretName,omitempty"`
 
 	// Connection configuration for the Hazelcast clusters that Management Center will monitor.
 	// +optional
@@ -56,6 +60,13 @@ type ManagementCenterSpec struct {
 	// +kubebuilder:default:={}
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+func (s *ManagementCenterSpec) GetLicenseKeySecretName() string {
+	if s.LicenseKeySecretName == "" {
+		return s.DeprecatedLicenseKeySecret
+	}
+	return s.LicenseKeySecretName
 }
 
 type HazelcastClusterConfig struct {

--- a/config/crd/bases/hazelcast.com_cronhotbackups.yaml
+++ b/config/crd/bases/hazelcast.com_cronhotbackups.yaml
@@ -73,6 +73,9 @@ spec:
                           Hazelcast resource
                         type: string
                       secret:
+                        description: secret is a deprecated alias for secretName.
+                        type: string
+                      secretName:
                         description: Name of the secret with credentials for cloud
                           providers.
                         type: string

--- a/config/crd/bases/hazelcast.com_hotbackups.yaml
+++ b/config/crd/bases/hazelcast.com_hotbackups.yaml
@@ -58,6 +58,9 @@ spec:
                   resource
                 type: string
               secret:
+                description: secret is a deprecated alias for secretName.
+                type: string
+              secretName:
                 description: Name of the secret with credentials for cloud providers.
                 type: string
             required:

--- a/config/crd/bases/hazelcast.com_managementcenters.yaml
+++ b/config/crd/bases/hazelcast.com_managementcenters.yaml
@@ -143,6 +143,9 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
               licenseKeySecret:
+                description: licenseKeySecret is a deprecated alias for licenseKeySecretName.
+                type: string
+              licenseKeySecretName:
                 description: Name of the secret with Hazelcast Enterprise License
                   Key.
                 type: string

--- a/config/samples/_v1alpha1_hazelcast.yaml
+++ b/config/samples/_v1alpha1_hazelcast.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key

--- a/config/samples/_v1alpha1_hazelcast_executor_service.yaml
+++ b/config/samples/_v1alpha1_hazelcast_executor_service.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   userCodeDeployment:
     bucketConfig:
-      secret: br-secret-gcp
+      secretName: br-secret-gcp
       bucketURI: "gs://operator-custom-class/executorService"
   executorServices:
     - name: service1

--- a/config/samples/_v1alpha1_hazelcast_expose_externally.yaml
+++ b/config/samples/_v1alpha1_hazelcast_expose_externally.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   exposeExternally:
     type: Smart
     discoveryServiceType: LoadBalancer

--- a/config/samples/_v1alpha1_hazelcast_high_availability.yaml
+++ b/config/samples/_v1alpha1_hazelcast_high_availability.yaml
@@ -6,4 +6,4 @@ spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
   highAvailabilityMode: ZONE
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key

--- a/config/samples/_v1alpha1_hazelcast_jet.yaml
+++ b/config/samples/_v1alpha1_hazelcast_jet.yaml
@@ -6,7 +6,7 @@ spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
   version: '5.3.0-BETA-2'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   jet:
     enabled: true
     resourceUploadEnabled: true

--- a/config/samples/_v1alpha1_hazelcast_jet_job_upload.yaml
+++ b/config/samples/_v1alpha1_hazelcast_jet_job_upload.yaml
@@ -12,4 +12,4 @@ spec:
     resourceUploadEnabled: true
     bucketConfig:
       bucketURI: "gs://operator-user-code/jetJobs"
-      secret: br-secret-gcp
+      secretName: br-secret-gcp

--- a/config/samples/_v1alpha1_hazelcast_jvm_gc.yaml
+++ b/config/samples/_v1alpha1_hazelcast_jvm_gc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   jvm:
     args:
       - "-XX:MaxGCPauseMillis=200"

--- a/config/samples/_v1alpha1_hazelcast_mc_monitoring_config.yaml
+++ b/config/samples/_v1alpha1_hazelcast_mc_monitoring_config.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   managementCenter:
     scriptingEnabled: true
     consoleEnabled: true

--- a/config/samples/_v1alpha1_hazelcast_persistence.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   persistence:
     baseDir: "/data/hot-restart/"
     clusterDataRecoveryPolicy: "FullRecoveryOnly"

--- a/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_agent.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent
   persistence:

--- a/config/samples/_v1alpha1_hazelcast_persistence_force_start.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_force_start.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   persistence:
     baseDir: "/data/hot-restart/"
     clusterDataRecoveryPolicy: "FullRecoveryOnly"

--- a/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
+++ b/config/samples/_v1alpha1_hazelcast_persistence_restore.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: "docker.io/hazelcast/hazelcast-enterprise"
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   agent:
     repository: hazelcast/platform-operator-agent
   persistence:
@@ -16,5 +16,5 @@ spec:
       requestStorage: 8Gi
     restore:
       bucketConfig:
-        secret: br-secret-az
+        secretName: br-secret-az
         bucketURI: "azblob://backup?prefix=hazelcast/2022-06-02-21-57-49/"

--- a/config/samples/_v1alpha1_hazelcast_tls.yaml
+++ b/config/samples/_v1alpha1_hazelcast_tls.yaml
@@ -4,6 +4,6 @@ metadata:
   name: hazelcast
 spec:
   clusterSize: 3
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   tls:
     secretName: example

--- a/config/samples/_v1alpha1_hazelcast_user_code_bucket.yaml
+++ b/config/samples/_v1alpha1_hazelcast_user_code_bucket.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   userCodeDeployment:
     bucketConfig:
-      secret: br-secret-gcp
+      secretName: br-secret-gcp
       bucketURI: "gs://operator-user-code/entryListener"

--- a/config/samples/_v1alpha1_hotbackup_agent.yaml
+++ b/config/samples/_v1alpha1_hotbackup_agent.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   hazelcastResourceName: hazelcast
   bucketURI: "s3://operator-e2e-external-backup"
-  secret: "br-secret-s3"
+  secretName: "br-secret-s3"
 
 #  bucketURI: "gs://operator-agent-backup"
-#  secret: "br-secret-gcp"
+#  secretName: "br-secret-gcp"
 
 #  bucketURI: "azblob://backup"
-#  secret: "br-secret-az"
+#  secretName: "br-secret-az"

--- a/config/samples/_v1alpha1_jetjob.yaml
+++ b/config/samples/_v1alpha1_jetjob.yaml
@@ -10,9 +10,9 @@ spec:
     resourceUploadEnabled: true
     bucketConfig:
       bucketURI: "gs://operator-user-code/jetJobs"
-      secret: br-secret-gcp
+      secretName: br-secret-gcp
   version: '5.3.0-BETA-2'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
 ---
 apiVersion: hazelcast.com/v1alpha1
 kind: JetJob

--- a/config/samples/_v1alpha1_jetjob_dynamic.yaml
+++ b/config/samples/_v1alpha1_jetjob_dynamic.yaml
@@ -15,5 +15,5 @@ spec:
   jarName: jet-pipeline-1.0.2.jar
   bucketConfig:
     bucketURI: "gs://operator-user-code/jetJobs"
-    secret: br-secret-gcp
+    secretName: br-secret-gcp
 

--- a/config/samples/_v1alpha1_managementcenter.yaml
+++ b/config/samples/_v1alpha1_managementcenter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   externalConnectivity:
     type: LoadBalancer
   hazelcastClusters:

--- a/config/samples/_v1alpha1_managementcenter_ingress.yaml
+++ b/config/samples/_v1alpha1_managementcenter_ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   externalConnectivity:
     type: ClusterIP
     ingress:

--- a/config/samples/_v1alpha1_managementcenter_no_pvc.yaml
+++ b/config/samples/_v1alpha1_managementcenter_no_pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   externalConnectivity:
     type: LoadBalancer
   hazelcastClusters:

--- a/config/samples/_v1alpha1_managementcenter_route.yaml
+++ b/config/samples/_v1alpha1_managementcenter_route.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   externalConnectivity:
     type: ClusterIP
     route:

--- a/config/samples/_v1alpha1_managementcenter_tls.yaml
+++ b/config/samples/_v1alpha1_managementcenter_tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: managementcenter
 spec:
   repository: 'hazelcast/management-center'
-  licenseKeySecret: hazelcast-license-key
+  licenseKeySecretName: hazelcast-license-key
   externalConnectivity:
     type: LoadBalancer
   hazelcastClusters:

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1696,7 +1696,7 @@ func getRestoreContainerFromHotBackupResource(ctx context.Context, cl client.Cli
 	var cont corev1.Container
 	if hb.Spec.IsExternal() {
 		bucketURI := hb.Status.GetBucketURI()
-		cont = restoreAgentContainer(h, hb.Spec.Secret, bucketURI)
+		cont = restoreAgentContainer(h, hb.Spec.GetSecretName(), bucketURI)
 	} else {
 		backupFolder := hb.Status.GetBackupFolder()
 		cont = restoreLocalAgentContainer(h, backupFolder)

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -322,7 +322,7 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 				BucketURI:     hb.Spec.BucketURI,
 				BackupBaseDir: hz.Spec.Persistence.BaseDir,
 				HazelcastName: hb.Spec.HazelcastResourceName,
-				SecretName:    hb.Spec.Secret,
+				SecretName:    hb.Spec.GetSecretName(),
 				MemberID:      i,
 			})
 			if err != nil {

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -461,14 +461,14 @@ func configMount() corev1.VolumeMount {
 func env(mc *hazelcastv1alpha1.ManagementCenter) []v1.EnvVar {
 	envs := []v1.EnvVar{{Name: mcInitCmd, Value: clusterAddCommand(mc)}}
 
-	if mc.Spec.LicenseKeySecret != "" {
+	if mc.Spec.GetLicenseKeySecretName() != "" {
 		envs = append(envs,
 			v1.EnvVar{
 				Name: mcLicenseKey,
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
-							Name: mc.Spec.LicenseKeySecret,
+							Name: mc.Spec.GetLicenseKeySecretName(),
 						},
 						Key: n.LicenseDataKey,
 					},

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -201,6 +201,9 @@ spec:
                           Hazelcast resource
                         type: string
                       secret:
+                        description: secret is a deprecated alias for secretName.
+                        type: string
+                      secretName:
                         description: Name of the secret with credentials for cloud
                           providers.
                         type: string
@@ -2161,6 +2164,9 @@ spec:
                   resource
                 type: string
               secret:
+                description: secret is a deprecated alias for secretName.
+                type: string
+              secretName:
                 description: Name of the secret with credentials for cloud providers.
                 type: string
             required:

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -2484,6 +2484,9 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
               licenseKeySecret:
+                description: licenseKeySecret is a deprecated alias for licenseKeySecretName.
+                type: string
+              licenseKeySecretName:
                 description: Name of the secret with Hazelcast Enterprise License
                   Key.
                 type: string

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -365,7 +365,7 @@ var (
 			Spec: hazelcastv1alpha1.HotBackupSpec{
 				HazelcastResourceName: hzName,
 				BucketURI:             bucketURI,
-				Secret:                secretName,
+				SecretName:            secretName,
 			},
 		}
 	}

--- a/test/e2e/config/managementcenter/config.go
+++ b/test/e2e/config/managementcenter/config.go
@@ -127,7 +127,7 @@ var (
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
 				Repository:                 *mcRepo,
 				Version:                    "not-exists",
-				DeprecatedLicenseKeySecret: licenseKey(ee),
+				LicenseKeySecretName: licenseKey(ee),
 			},
 		}
 	}

--- a/test/e2e/config/managementcenter/config.go
+++ b/test/e2e/config/managementcenter/config.go
@@ -125,8 +125,8 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:                 *mcRepo,
-				Version:                    "not-exists",
+				Repository:           *mcRepo,
+				Version:              "not-exists",
 				LicenseKeySecretName: licenseKey(ee),
 			},
 		}

--- a/test/e2e/config/managementcenter/config.go
+++ b/test/e2e/config/managementcenter/config.go
@@ -26,9 +26,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:       *mcRepo,
-				Version:          *mcVersion,
-				LicenseKeySecret: licenseKey(ee),
+				Repository:                 *mcRepo,
+				Version:                    *mcVersion,
+				DeprecatedLicenseKeySecret: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeLoadBalancer,
 				},
@@ -48,9 +48,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:       *mcRepo,
-				Version:          *mcVersion,
-				LicenseKeySecret: licenseKey(ee),
+				Repository:                 *mcRepo,
+				Version:                    *mcVersion,
+				DeprecatedLicenseKeySecret: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeLoadBalancer,
 				},
@@ -75,9 +75,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:       *mcRepo,
-				Version:          *mcVersion,
-				LicenseKeySecret: licenseKey(ee),
+				Repository:                 *mcRepo,
+				Version:                    *mcVersion,
+				DeprecatedLicenseKeySecret: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeLoadBalancer,
 				},
@@ -94,9 +94,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:       *mcRepo,
-				Version:          *mcVersion,
-				LicenseKeySecret: licenseKey(ee),
+				Repository:                 *mcRepo,
+				Version:                    *mcVersion,
+				DeprecatedLicenseKeySecret: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeClusterIP,
@@ -125,9 +125,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:       *mcRepo,
-				Version:          "not-exists",
-				LicenseKeySecret: licenseKey(ee),
+				Repository:                 *mcRepo,
+				Version:                    "not-exists",
+				DeprecatedLicenseKeySecret: licenseKey(ee),
 			},
 		}
 	}

--- a/test/e2e/config/managementcenter/config.go
+++ b/test/e2e/config/managementcenter/config.go
@@ -26,9 +26,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:                 *mcRepo,
-				Version:                    *mcVersion,
-				DeprecatedLicenseKeySecret: licenseKey(ee),
+				Repository:           *mcRepo,
+				Version:              *mcVersion,
+				LicenseKeySecretName: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeLoadBalancer,
 				},
@@ -48,9 +48,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:                 *mcRepo,
-				Version:                    *mcVersion,
-				DeprecatedLicenseKeySecret: licenseKey(ee),
+				Repository:           *mcRepo,
+				Version:              *mcVersion,
+				LicenseKeySecretName: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeLoadBalancer,
 				},
@@ -75,9 +75,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:                 *mcRepo,
-				Version:                    *mcVersion,
-				DeprecatedLicenseKeySecret: licenseKey(ee),
+				Repository:           *mcRepo,
+				Version:              *mcVersion,
+				LicenseKeySecretName: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeLoadBalancer,
 				},
@@ -94,9 +94,9 @@ var (
 				Labels:    lbls,
 			},
 			Spec: hazelcastv1alpha1.ManagementCenterSpec{
-				Repository:                 *mcRepo,
-				Version:                    *mcVersion,
-				DeprecatedLicenseKeySecret: licenseKey(ee),
+				Repository:           *mcRepo,
+				Version:              *mcVersion,
+				LicenseKeySecretName: licenseKey(ee),
 				ExternalConnectivity: hazelcastv1alpha1.ExternalConnectivityConfiguration{
 
 					Type: hazelcastv1alpha1.ExternalConnectivityTypeClusterIP,

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -905,7 +905,7 @@ func restoreConfig(hotBackup *hazelcastcomv1alpha1.HotBackup, useBucketConfig bo
 		return hazelcastcomv1alpha1.RestoreConfiguration{
 			BucketConfiguration: &hazelcastcomv1alpha1.BucketConfiguration{
 				BucketURI:  hotBackup.Status.GetBucketURI(),
-				SecretName: hotBackup.Spec.SecretName,
+				SecretName: hotBackup.Spec.GetSecretName(),
 			},
 		}
 	}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -905,7 +905,7 @@ func restoreConfig(hotBackup *hazelcastcomv1alpha1.HotBackup, useBucketConfig bo
 		return hazelcastcomv1alpha1.RestoreConfiguration{
 			BucketConfiguration: &hazelcastcomv1alpha1.BucketConfiguration{
 				BucketURI:  hotBackup.Status.GetBucketURI(),
-				SecretName: hotBackup.Spec.Secret,
+				SecretName: hotBackup.Spec.SecretName,
 			},
 		}
 	}

--- a/test/integration/hazelcast_webhook_test.go
+++ b/test/integration/hazelcast_webhook_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Hazelcast webhook", func() {
 				Spec:       spec,
 			}
 			Expect(k8sClient.Create(context.Background(), hz)).
-				Should(MatchError(ContainSubstring("spec.licenseKeySecret: Required value: must be set when Hazelcast Enterprise is deployed")))
+				Should(MatchError(ContainSubstring("spec.licenseKeySecretName: Required value: must be set when Hazelcast Enterprise is deployed")))
 		})
 	})
 

--- a/test/integration/managementcenter_controller_test.go
+++ b/test/integration/managementcenter_controller_test.go
@@ -530,12 +530,12 @@ var _ = Describe("ManagementCenter controller", func() {
 
 	Context("Statefulset Updates", func() {
 		firstSpec := hazelcastv1alpha1.ManagementCenterSpec{
-			Repository:        "hazelcast/management-center-1",
-			Version:           "5.2",
-			ImagePullPolicy:   corev1.PullAlways,
-			ImagePullSecrets:  nil,
-			LicenseKeySecret:  "key-secret",
-			HazelcastClusters: nil,
+			Repository:           "hazelcast/management-center-1",
+			Version:              "5.2",
+			ImagePullPolicy:      corev1.PullAlways,
+			ImagePullSecrets:     nil,
+			LicenseKeySecretName: "key-secret",
+			HazelcastClusters:    nil,
 		}
 		secondSpec := hazelcastv1alpha1.ManagementCenterSpec{
 			Repository:      "hazelcast/management-center",
@@ -546,7 +546,7 @@ var _ = Describe("ManagementCenter controller", func() {
 				{Name: "secret2"},
 			},
 
-			LicenseKeySecret: "",
+			LicenseKeySecretName: "",
 			HazelcastClusters: []hazelcastv1alpha1.HazelcastClusterConfig{
 				{Name: "dev", Address: "cluster-address"},
 			},
@@ -613,7 +613,7 @@ var _ = Describe("ManagementCenter controller", func() {
 				By("checking if StatefulSet LicenseKeySecretName is updated")
 				for _, env := range el {
 					if env.Name == "MC_LICENSEKEY" {
-						Expect(env.ValueFrom.SecretKeyRef.Key).To(Equal(secondSpec.LicenseKeySecret))
+						Expect(env.ValueFrom.SecretKeyRef.Key).To(Equal(secondSpec.GetLicenseKeySecretName()))
 					}
 				}
 

--- a/test/spec.go
+++ b/test/spec.go
@@ -52,7 +52,7 @@ func ManagementCenterSpec(values *MCSpecValues, ee bool) hazelcastv1alpha1.Manag
 		ImagePullPolicy: values.ImagePullPolicy,
 	}
 	if ee {
-		spec.LicenseKeySecret = values.LicenseKey
+		spec.LicenseKeySecretName = values.LicenseKey
 	}
 	return spec
 }
@@ -63,6 +63,6 @@ func CheckManagementCenterCR(mc *hazelcastv1alpha1.ManagementCenter, expected *M
 	Expect(mc.Spec.ImagePullPolicy).Should(Equal(expected.ImagePullPolicy))
 
 	if ee {
-		Expect(mc.Spec.LicenseKeySecret).Should(Equal(expected.LicenseKey))
+		Expect(mc.Spec.GetLicenseKeySecretName()).Should(Equal(expected.LicenseKey))
 	}
 }


### PR DESCRIPTION
## User Impact

The field licenseKeySecret in ManagementCenterSpec was renamed to licenseKeySecretName.
The field secret in HotBackupSpec was renamed to secretName.
