### PR TITLE
Added HZ, MC versions as input params to workflow and skip jet job tests for 5.1.X version 

### DIFF
--- a/.github/workflows/multi-version-tests.yaml
+++ b/.github/workflows/multi-version-tests.yaml
@@ -2,6 +2,19 @@ name: Multi Version Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      HZ_5_0_X:
+        description: "5.0.X Hazelcast version"
+        required: false
+      HZ_5_1_X:
+        description: "5.1.X Hazelcast version"
+        required: false
+      MC_5_0_X:
+        description: "5.0.X Management Center version"
+        required: false
+      MC_5_1_X:
+        description: "5.1.X Management Center version"
+        required: false
 
 env:
   GO_VERSION: '1.19.0'
@@ -17,6 +30,11 @@ jobs:
   matrix_preparation:
     name: Test Matrix Preparation
     runs-on: ubuntu-latest
+    env:
+      HZ_5_0_X: ${{ github.event.inputs.HZ_5_0_X }}
+      HZ_5_1_X: ${{ github.event.inputs.HZ_5_1_X }}
+      MC_5_0_X: ${{ github.event.inputs.MC_5_0_X }}
+      MC_5_1_X: ${{ github.event.inputs.MC_5_1_X }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -24,10 +42,22 @@ jobs:
         id: set-matrix
         run: |
           echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
-          HZ_5_0_X=$(gh api $HZ_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.0.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
-          HZ_5_1_X=$(gh api $HZ_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.1.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
-          MC_5_0_X=$(gh api $MC_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.0.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
-          MC_5_1_X=$(gh api $MC_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.1.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+          if [[ ${HZ_5_0_X} == '' ]]; then
+             HZ_5_0_X=$(gh api $HZ_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.0.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+             echo "HZ_5_0_X=${HZ_5_0_X}" >> $GITHUB_ENV
+          fi
+          if [[ ${HZ_5_1_X} == '' ]]; then
+             HZ_5_1_X=$(gh api $HZ_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.1.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+             echo "HZ_5_1_X=${HZ_5_1_X}" >> $GITHUB_ENV
+          fi
+          if [[ ${MC_5_0_X} == '' ]]; then
+             MC_5_0_X=$(gh api $MC_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.0.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+             echo "MC_5_0_X=${MC_5_0_X}" >> $GITHUB_ENV
+          fi
+          if [[ ${MC_5_1_X} == '' ]]; then
+             MC_5_1_X=$(gh api $MC_TAGS --jq '.[].ref | select(startswith("refs/tags/v5.1.")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+             echo "MC_5_1_X=${MC_5_1_X}" >> $GITHUB_ENV
+          fi
           matrixJson=$(jq -n --argjson NR_OF_SUITES "$NR_OF_SUITES" --argjson editions '["ee", "os"]' '[
                     range($NR_OF_SUITES) as $i |
                     $editions[] as $edition |

--- a/test/e2e/hazelcast_jetjob_test.go
+++ b/test/e2e/hazelcast_jetjob_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	. "time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,8 +27,9 @@ var _ = Describe("Hazelcast JetJob", Label("JetJob"), func() {
 		if !useExistingCluster() {
 			Skip("End to end tests require k8s cluster. Set USE_EXISTING_CLUSTER=true")
 		}
-		if os.Getenv("HZ_VERSION") == "5.1.6" {
-			Skip("We don't support Jet for 5.1.6 version")
+		version := os.Getenv("HZ_VERSION")
+		if strings.Contains(version, "5.1.6") || strings.Contains(version, "5.0.5") {
+			Skip("We don't support Jet for 5.1.6 or 5.0.5 version")
 		}
 		if runningLocally() {
 			return

--- a/test/e2e/hazelcast_jetjob_test.go
+++ b/test/e2e/hazelcast_jetjob_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	. "time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,6 +25,9 @@ var _ = Describe("Hazelcast JetJob", Label("JetJob"), func() {
 	BeforeEach(func() {
 		if !useExistingCluster() {
 			Skip("End to end tests require k8s cluster. Set USE_EXISTING_CLUSTER=true")
+		}
+		if os.Getenv("HZ_VERSION") == "5.1.6" {
+			Skip("We don't support Jet for 5.1.6 version")
 		}
 		if runningLocally() {
 			return


### PR DESCRIPTION
## Description

Since we do not support JetJobs for 5.1.X it should be disabled in the MultiVersion workflow.
