### PR TITLE
Explicitly set 'go build arch' to amd64 in Tilt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,10 +231,10 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager -tags "$(GO_BUILD_TAGS)" main.go
 
 build-tilt: generate fmt vet # This is not going to work if client and server cpu architectures are different
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell go env GOARCH) go build -tags "$(GO_BUILD_TAGS)" -ldflags "-s -w" -o bin/tilt/manager main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags "$(GO_BUILD_TAGS)" -ldflags "-s -w" -o bin/tilt/manager main.go
 
 build-tilt-debug: generate fmt vet # This is not going to work if client and server cpu architectures are different
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell go env GOARCH) go build -tags "$(GO_BUILD_TAGS)" -gcflags "-N -l" -o bin/tilt/manager-debug main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags "$(GO_BUILD_TAGS)" -gcflags "-N -l" -o bin/tilt/manager-debug main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	PHONE_HOME_ENABLED=$(PHONE_HOME_ENABLED) DEVELOPER_MODE_ENABLED=$(DEVELOPER_MODE_ENABLED) go run -tags "$(GO_BUILD_TAGS)" ./main.go


### PR DESCRIPTION
## Description

Arch should always be `amd64` when deploying the operator in a k8s cluster. It shouldn't be taken from the OS where the build process is running on.

## User Impact
