### PR TITLE
Include additional fields of JetJob CR to wide output

### DIFF
--- a/api/v1alpha1/jetjob_types.go
+++ b/api/v1alpha1/jetjob_types.go
@@ -116,6 +116,8 @@ func (jjs JetJobStatusPhase) IsSuspended() bool {
 // +kubebuilder:printcolumn:name="Id",type="string",JSONPath=".status.id",description="ID of the JetJob"
 // +kubebuilder:printcolumn:name="SubmissionTime",type="string",JSONPath=".status.submissionTime",description="Time when the JetJob was submitted"
 // +kubebuilder:printcolumn:name="CompletionTime",type="string",JSONPath=".status.completionTime",description="Time when the JetJob was completed"
+// +kubebuilder:printcolumn:name="FailureText",type="string",priority=1,JSONPath=".status.failureText",description="The text about failure of the JetJob"
+// +kubebuilder:printcolumn:name="SuspensionCause",type="string",priority=1,JSONPath=".status.suspensionCause",description="The reason why the JetJob is suspended"
 // +kubebuilder:resource:shortName=jj
 
 // JetJob is the Schema for the jetjobs API

--- a/config/crd/bases/hazelcast.com_jetjobs.yaml
+++ b/config/crd/bases/hazelcast.com_jetjobs.yaml
@@ -34,6 +34,16 @@ spec:
       jsonPath: .status.completionTime
       name: CompletionTime
       type: string
+    - description: The text about failure of the JetJob
+      jsonPath: .status.failureText
+      name: FailureText
+      priority: 1
+      type: string
+    - description: The reason why the JetJob is suspended
+      jsonPath: .status.suspensionCause
+      name: SuspensionCause
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -2393,6 +2393,16 @@ spec:
       jsonPath: .status.completionTime
       name: CompletionTime
       type: string
+    - description: The text about failure of the JetJob
+      jsonPath: .status.failureText
+      name: FailureText
+      priority: 1
+      type: string
+    - description: The reason why the JetJob is suspended
+      jsonPath: .status.suspensionCause
+      name: SuspensionCause
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
## Description

kubectl output with `-o wide` flag displays `FAILURETEXT` and `SUSPENSIONCAUSE` fields

## User Impact

