### PR TITLE
[CN-859] Add validation for NativeMemory.AllocatorType when persistence is enabled

### DIFF
--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -1621,7 +1621,11 @@ var _ = Describe("Hazelcast CR", func() {
 
 				Expect(k8sClient.Create(context.Background(), hz)).Should(HaveOccurred())
 			})
+
 			It("should fail if NativeMemory.AllocatorType is not POOLED when persistence is enabled", Label("fast"), func() {
+				if !ee {
+					Skip("This test will only run in EE configuration")
+				}
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
 					AllocatorType: hazelcastv1alpha1.NativeMemoryStandard,
@@ -1785,6 +1789,9 @@ var _ = Describe("Hazelcast CR", func() {
 			})
 
 			It("should error when not using enterprise version", Label("fast"), func() {
+				if ee {
+					Skip("This test will only run in OS configuration")
+				}
 
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.TLS = &hazelcastv1alpha1.TLS{

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -1621,6 +1621,21 @@ var _ = Describe("Hazelcast CR", func() {
 
 				Expect(k8sClient.Create(context.Background(), hz)).Should(HaveOccurred())
 			})
+			It("should fail if NativeMemory.AllocatorType is not POOLED when persistence is enabled", Label("fast"), func() {
+				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
+				spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
+					AllocatorType: hazelcastv1alpha1.NativeMemoryStandard,
+				}
+				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+					BaseDir: "/data/hot-restart/",
+				}
+				hz := &hazelcastv1alpha1.Hazelcast{
+					ObjectMeta: randomObjectMeta(namespace),
+					Spec:       spec,
+				}
+
+				Expect(k8sClient.Create(context.Background(), hz)).Should(HaveOccurred())
+			})
 		})
 	})
 
@@ -1770,9 +1785,6 @@ var _ = Describe("Hazelcast CR", func() {
 			})
 
 			It("should error when not using enterprise version", Label("fast"), func() {
-				if ee {
-					Skip("This test will only run in OS configuration")
-				}
 
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.TLS = &hazelcastv1alpha1.TLS{


### PR DESCRIPTION
## Description

We realized that there is a restriction for the `NativeMemory.AllocatorType` field when we enabled `Persistence`.
When `Persistence` is enabled, `NativeMemory.AllocatorType` must be `POOLED`. It cannot be `STANDARD`.

So the necessary validation is added for this case.