### PR TITLE
[CN-882] Delete JetJob CR when its Hazelcast CR is deleted

### DIFF
--- a/api/v1alpha1/jetjob_types.go
+++ b/api/v1alpha1/jetjob_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // +kubebuilder:validation:Enum=Failed;NotRunning;Starting;Running;Suspended;SuspendedExportingSnapshot;Completing;ExecutionFailed;Completed
@@ -141,6 +142,14 @@ type JetJobList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []JetJob `json:"items"`
+}
+
+func (jjl *JetJobList) GetItems() []client.Object {
+	l := make([]client.Object, 0, len(jjl.Items))
+	for _, item := range jjl.Items {
+		l = append(l, client.Object(&item))
+	}
+	return l
 }
 
 func init() {

--- a/controllers/hazelcast/hazelcast_controller.go
+++ b/controllers/hazelcast/hazelcast_controller.go
@@ -395,6 +395,12 @@ func (r *HazelcastReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}); err != nil {
 		return err
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &hazelcastv1alpha1.JetJob{}, "hazelcastResourceName", func(rawObj client.Object) []string {
+		m := rawObj.(*hazelcastv1alpha1.JetJob)
+		return []string{m.Spec.HazelcastResourceName}
+	}); err != nil {
+		return err
+	}
 
 	controller := ctrl.NewControllerManagedBy(mgr).
 		For(&hazelcastv1alpha1.Hazelcast{}).

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -91,7 +91,9 @@ func (r *HazelcastReconciler) deleteDependentCRs(ctx context.Context, h *hazelca
 		"ReplicatedMap": &hazelcastv1alpha1.ReplicatedMapList{},
 		"Queue":         &hazelcastv1alpha1.QueueList{},
 		"Cache":         &hazelcastv1alpha1.CacheList{},
+		"JetJob":        &hazelcastv1alpha1.JetJobList{},
 	}
+
 	for crKind, crList := range dependentCRs {
 		if err := r.deleteDependentCR(ctx, h, crKind, crList); err != nil {
 			return err

--- a/controllers/hazelcast/hazelcast_resources_test.go
+++ b/controllers/hazelcast/hazelcast_resources_test.go
@@ -31,7 +31,7 @@ func Test_hazelcastConfigMultipleCRs(t *testing.T) {
 	}
 
 	hzConfig := &config.HazelcastWrapper{}
-	err := yaml.Unmarshal([]byte(cm.Data["hazelcast.yaml"]), hzConfig)
+	err := yaml.Unmarshal(cm.Data["hazelcast.yaml"], hzConfig)
 	if err != nil {
 		t.Errorf("Error unmarshalling Hazelcast config")
 	}

--- a/controllers/hazelcast/jetjob_controller.go
+++ b/controllers/hazelcast/jetjob_controller.go
@@ -374,16 +374,18 @@ func (r *JetJobReconciler) executeFinalizer(ctx context.Context, jj *hazelcastv1
 		return nil
 	}
 
-	hzNn := types.NamespacedName{Name: jj.Spec.HazelcastResourceName, Namespace: jj.Namespace}
+	hzNn := types.NamespacedName{
+		Name:      jj.Spec.HazelcastResourceName,
+		Namespace: jj.Namespace,
+	}
 	hz := &hazelcastv1alpha1.Hazelcast{}
 	err := r.Client.Get(ctx, hzNn, hz)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			logger.Info("Hazelcast resource not found. Ignoring since object must be deleted")
-			return nil
-		} else {
-			return err
+			return r.removeCheckerAndFinalizer(ctx, jj)
 		}
+		return err
 	}
 
 	// If Hazelcast CR is getting deleted, the finalizer doesn't cancel the actual job
@@ -395,6 +397,10 @@ func (r *JetJobReconciler) executeFinalizer(ctx context.Context, jj *hazelcastv1
 		logger.Info("Hazelcast CR is being deleted, no need to cancel actual job", "hazelcast", hz.Name)
 	}
 
+	return r.removeCheckerAndFinalizer(ctx, jj)
+}
+
+func (r *JetJobReconciler) removeCheckerAndFinalizer(ctx context.Context, jj *hazelcastv1alpha1.JetJob) error {
 	r.removeJobFromChecker(jj)
 	controllerutil.RemoveFinalizer(jj, n.Finalizer)
 	if err := r.Update(ctx, jj); err != nil {

--- a/controllers/hazelcast/jetjob_controller.go
+++ b/controllers/hazelcast/jetjob_controller.go
@@ -388,7 +388,7 @@ func (r *JetJobReconciler) executeFinalizer(ctx context.Context, jj *hazelcastv1
 
 	// If Hazelcast CR is getting deleted, the finalizer doesn't cancel the actual job
 	if hz.DeletionTimestamp == nil {
-		if err := r.stopJetExecution(ctx, jj, hz, logger); err != nil {
+		if err := r.stopJetExecution(ctx, jj, hzNn, logger); err != nil {
 			return fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	} else {
@@ -403,14 +403,10 @@ func (r *JetJobReconciler) executeFinalizer(ctx context.Context, jj *hazelcastv1
 	return nil
 }
 
-func (r *JetJobReconciler) stopJetExecution(ctx context.Context, jj *hazelcastv1alpha1.JetJob, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {
+func (r *JetJobReconciler) stopJetExecution(ctx context.Context, jj *hazelcastv1alpha1.JetJob, hzNn types.NamespacedName, logger logr.Logger) error {
 	if jj.Status.Id == 0 {
 		logger.Info("Jet job ID is 0", "name", jj.Name, "namespace", jj.Namespace)
 		return nil
-	}
-	hzNn := types.NamespacedName{
-		Name:      h.Name,
-		Namespace: h.Namespace,
 	}
 	c, err := r.ClientRegistry.GetOrCreate(ctx, hzNn)
 	if err != nil {

--- a/test/e2e/hazelcast_jetjob_test.go
+++ b/test/e2e/hazelcast_jetjob_test.go
@@ -189,16 +189,15 @@ var _ = Describe("Hazelcast JetJob", Label("JetJob"), func() {
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 		assertHotBackupSuccess(hotBackup, 20*Minute)
 
+		By("deleting Hazelcast CR")
 		RemoveHazelcastCR(hazelcast)
 
-		By("creating new Hazelcast cluster from the existing backup")
+		By("creating new Hazelcast cluster from hot-backup")
 		hazelcast = hazelcastconfig.JetWithRestore(hzLookupKey, ee, hotBackup.Name, labels)
 		CreateHazelcastCR(hazelcast)
 		evaluateReadyMembers(hzLookupKey)
 
-		checkJetJobStatus(hazelcastv1alpha1.JetJobRunning)
-
-		By("Checking the JetJob jar is running in new Hazelcast cluster")
+		By("Checking the JetJob jar is running in the new Hazelcast cluster")
 		test.EventuallyInLogsUnordered(logReader, 15*Second, logInterval).
 			Should(ContainElements(
 				MatchRegexp(fmt.Sprintf(".*\\[%s\\/\\w+#\\d+\\]\\s+SimpleEvent\\(timestamp=.*,\\s+sequence=\\d+\\).*", jj.Name))))


### PR DESCRIPTION
## Description

Finalizer of Hazelcast CR deletes its dependent JetJob CRs. 
When the JetJob CR is deleted, if its Hazelcast CR has marked to be deleted, (we assume that the deletion operation of JetJob CR is triggered by Hazelcast CR finalizer), then the JetJob finalizer does't cancel the actual job. In this way, the jet jobs in the cluster can be recovered by `losslesRestart` in the backup of HotRestart.

## User Impact

When Hazelcast CR object is getting deleted, its dependent JetJob CR objects are deleted as well without canceling the actual jobs. In case of restoring the cluster from a backup, the jobs were in the cluster can be recovered by `losslesRestart`.
