### PR TITLE
[CN-871] Added integration tests for hz clusters' tls configuration on mc

### DIFF
--- a/test/integration/managementcenter_test.go
+++ b/test/integration/managementcenter_test.go
@@ -476,7 +476,8 @@ var _ = Describe("ManagementCenter CR", func() {
 					},
 				}}
 
-				Expect(k8sClient.Create(context.Background(), mc)).Should(HaveOccurred())
+				Expect(k8sClient.Create(context.Background(), mc)).
+					Should(MatchError(ContainSubstring("Management Center Cluster config TLS Secret name is empty")))
 			})
 
 			It("should error when secretName does not exist", Label("fast"), func() {
@@ -492,7 +493,8 @@ var _ = Describe("ManagementCenter CR", func() {
 					},
 				}}
 
-				Expect(k8sClient.Create(context.Background(), mc)).Should(HaveOccurred())
+				Expect(k8sClient.Create(context.Background(), mc)).
+					Should(MatchError(ContainSubstring("Management Center Cluster config TLS Secret not found")))
 			})
 		})
 

--- a/test/integration/managementcenter_test.go
+++ b/test/integration/managementcenter_test.go
@@ -462,6 +462,38 @@ var _ = Describe("ManagementCenter CR", func() {
 				Create(mc)
 				EnsureStatus(mc)
 			})
+
+			It("should error when secretName is empty", Label("fast"), func() {
+				mc := &hazelcastv1alpha1.ManagementCenter{
+					ObjectMeta: randomObjectMeta(namespace),
+					Spec:       test.ManagementCenterSpec(defaultMcSpecValues(), ee),
+				}
+				mc.Spec.HazelcastClusters = []hazelcastv1alpha1.HazelcastClusterConfig{{
+					Name:    "dev",
+					Address: "dummy",
+					TLS: &hazelcastv1alpha1.TLS{
+						SecretName: "",
+					},
+				}}
+
+				Expect(k8sClient.Create(context.Background(), mc)).Should(HaveOccurred())
+			})
+
+			It("should error when secretName does not exist", Label("fast"), func() {
+				mc := &hazelcastv1alpha1.ManagementCenter{
+					ObjectMeta: randomObjectMeta(namespace),
+					Spec:       test.ManagementCenterSpec(defaultMcSpecValues(), ee),
+				}
+				mc.Spec.HazelcastClusters = []hazelcastv1alpha1.HazelcastClusterConfig{{
+					Name:    "dev",
+					Address: "dummy",
+					TLS: &hazelcastv1alpha1.TLS{
+						SecretName: "notfound",
+					},
+				}}
+
+				Expect(k8sClient.Create(context.Background(), mc)).Should(HaveOccurred())
+			})
 		})
 
 		When("MutualAuthentication is configured", func() {


### PR DESCRIPTION
## Description

Added integration test for the tls configuration validation on MC. Validation is added in [another PR](https://github.com/hazelcast/hazelcast-platform-operator/pull/755).
