### PR TITLE
[CN-901] Fixing error in Map reconciler when nearCache is configured

### DIFF
--- a/api/v1alpha1/map_types.go
+++ b/api/v1alpha1/map_types.go
@@ -91,8 +91,7 @@ type NearCache struct {
 
 	// NearCacheEviction specifies the eviction behavior in Near Cache
 	// +kubebuilder:default:={evictionPolicy: NONE, maxSizePolicy: ENTRY_COUNT}
-	// +optional
-	NearCacheEviction NearCacheEviction `json:"eviction,omitempty"`
+	NearCacheEviction NearCacheEviction `json:"eviction"`
 
 	// CacheLocalEntries specifies whether the local entries are cached
 	// +kubebuilder:default:=true

--- a/api/v1alpha1/map_types.go
+++ b/api/v1alpha1/map_types.go
@@ -90,8 +90,9 @@ type NearCache struct {
 	MaxIdleSeconds uint `json:"maxIdleSeconds,omitempty"`
 
 	// NearCacheEviction specifies the eviction behavior in Near Cache
+	// +kubebuilder:default:={evictionPolicy: NONE, maxSizePolicy: ENTRY_COUNT}
 	// +optional
-	NearCacheEviction *NearCacheEviction `json:"eviction,omitempty"`
+	NearCacheEviction NearCacheEviction `json:"eviction,omitempty"`
 
 	// CacheLocalEntries specifies whether the local entries are cached
 	// +kubebuilder:default:=true
@@ -111,8 +112,9 @@ type NearCacheEviction struct {
 	MaxSizePolicy MaxSizePolicyType `json:"maxSizePolicy,omitempty"`
 
 	// Size is maximum size of the Near Cache used for max-size-policy
+	// +kubebuilder:default:=0
 	// +optional
-	Size uint32 `json:"size,omitempty"`
+	Size uint32 `json:"size"`
 }
 
 type EntryListenerConfiguration struct {

--- a/api/v1alpha1/map_validation.go
+++ b/api/v1alpha1/map_validation.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -98,7 +99,7 @@ func ValidateNotUpdatableMapFields(current *MapSpec, last *MapSpec) field.ErrorL
 			field.Forbidden(field.NewPath("spec").Child("inMemoryFormat"), "field cannot be updated"))
 	}
 
-	if isNearCacheUpdated(current, last) {
+	if !reflect.DeepEqual(current.NearCache, last.NearCache) {
 		allErrs = append(allErrs,
 			field.Forbidden(field.NewPath("spec").Child("nearCache"), "field cannot be updated"))
 	}
@@ -107,37 +108,6 @@ func ValidateNotUpdatableMapFields(current *MapSpec, last *MapSpec) field.ErrorL
 		return nil
 	}
 	return allErrs
-}
-
-func isNearCacheUpdated(current *MapSpec, last *MapSpec) bool {
-	if current.NearCache != nil && last.NearCache != nil {
-		if *current.NearCache.InvalidateOnChange != *last.NearCache.InvalidateOnChange ||
-			current.NearCache.Name != last.NearCache.Name ||
-			*current.NearCache.CacheLocalEntries != *last.NearCache.CacheLocalEntries ||
-			current.NearCache.TimeToLiveSeconds != last.NearCache.TimeToLiveSeconds ||
-			current.NearCache.MaxIdleSeconds != last.NearCache.MaxIdleSeconds ||
-			current.NearCache.InMemoryFormat != last.NearCache.InMemoryFormat {
-			return true
-		}
-
-		if current.NearCache.NearCacheEviction != nil && last.NearCache.NearCacheEviction != nil {
-			if current.NearCache.NearCacheEviction.EvictionPolicy != last.NearCache.NearCacheEviction.EvictionPolicy ||
-				current.NearCache.NearCacheEviction.Size != last.NearCache.NearCacheEviction.Size ||
-				current.NearCache.NearCacheEviction.MaxSizePolicy != last.NearCache.NearCacheEviction.MaxSizePolicy {
-				return true
-			}
-		}
-
-		if current.NearCache.NearCacheEviction == nil && last.NearCache.NearCacheEviction != nil {
-			return true
-		}
-	}
-
-	if current.NearCache == nil && last.NearCache != nil {
-		return true
-	}
-
-	return false
 }
 
 func indexConfigSliceEquals(a, b []IndexConfig) bool {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1695,11 +1695,7 @@ func (in *NearCache) DeepCopyInto(out *NearCache) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.NearCacheEviction != nil {
-		in, out := &in.NearCacheEviction, &out.NearCacheEviction
-		*out = new(NearCacheEviction)
-		**out = **in
-	}
+	out.NearCacheEviction = in.NearCacheEviction
 	if in.CacheLocalEntries != nil {
 		in, out := &in.CacheLocalEntries, &out.CacheLocalEntries
 		*out = new(bool)

--- a/config/crd/bases/hazelcast.com_maps.yaml
+++ b/config/crd/bases/hazelcast.com_maps.yaml
@@ -242,6 +242,9 @@ spec:
                       are cached
                     type: boolean
                   eviction:
+                    default:
+                      evictionPolicy: NONE
+                      maxSizePolicy: ENTRY_COUNT
                     description: NearCacheEviction specifies the eviction behavior
                       in Near Cache
                     properties:
@@ -273,6 +276,7 @@ spec:
                         - ENTRY_COUNT
                         type: string
                       size:
+                        default: 0
                         description: Size is maximum size of the Near Cache used for
                           max-size-policy
                         format: int32

--- a/config/crd/bases/hazelcast.com_maps.yaml
+++ b/config/crd/bases/hazelcast.com_maps.yaml
@@ -310,6 +310,8 @@ spec:
                     description: TimeToLiveSeconds maximum number of seconds for each
                       entry to stay in the Near Cache
                     type: integer
+                required:
+                - eviction
                 type: object
               persistenceEnabled:
                 default: false

--- a/controllers/hazelcast/map_controller.go
+++ b/controllers/hazelcast/map_controller.go
@@ -322,9 +322,13 @@ func fillAddMapConfigInput(ctx context.Context, c client.Client, mapInput *codec
 				StoreInitialDelaySeconds: 600,
 				StoreIntervalSeconds:     600,
 			}
-		mapInput.NearCacheConfig.EvictionConfigHolder.EvictionPolicy = string(ms.NearCache.NearCacheEviction.EvictionPolicy)
-		mapInput.NearCacheConfig.EvictionConfigHolder.MaxSizePolicy = string(ms.NearCache.NearCacheEviction.MaxSizePolicy)
-		mapInput.NearCacheConfig.EvictionConfigHolder.Size = int32(ms.NearCache.NearCacheEviction.Size)
+
+		mapInput.NearCacheConfig.EvictionConfigHolder = codecTypes.EvictionConfigHolder{
+			EvictionPolicy: string(ms.NearCache.NearCacheEviction.EvictionPolicy),
+			MaxSizePolicy:  string(ms.NearCache.NearCacheEviction.MaxSizePolicy),
+			Size:           int32(ms.NearCache.NearCacheEviction.Size),
+		}
+
 	}
 
 	return nil

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -4159,6 +4159,8 @@ spec:
                     description: TimeToLiveSeconds maximum number of seconds for each
                       entry to stay in the Near Cache
                     type: integer
+                required:
+                - eviction
                 type: object
               persistenceEnabled:
                 default: false

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -4091,6 +4091,9 @@ spec:
                       are cached
                     type: boolean
                   eviction:
+                    default:
+                      evictionPolicy: NONE
+                      maxSizePolicy: ENTRY_COUNT
                     description: NearCacheEviction specifies the eviction behavior
                       in Near Cache
                     properties:
@@ -4122,6 +4125,7 @@ spec:
                         - ENTRY_COUNT
                         type: string
                       size:
+                        default: 0
                         description: Size is maximum size of the Near Cache used for
                           max-size-policy
                         format: int32

--- a/test/integration/map_test.go
+++ b/test/integration/map_test.go
@@ -197,6 +197,20 @@ var _ = Describe("Map CR", func() {
 	})
 
 	Context("with NearCache configuration", func() {
+		It("should not fail with empty near cache configuration", Label("fast"), func() {
+			m := &hazelcastv1alpha1.Map{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec: hazelcastv1alpha1.MapSpec{
+					DataStructureSpec: hazelcastv1alpha1.DataStructureSpec{
+						HazelcastResourceName: "hazelcast",
+					},
+					NearCache: &hazelcastv1alpha1.NearCache{},
+				},
+			}
+			By("creating Map CR successfully")
+			Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
+		})
+
 		It("should create Map CR with near cache configuration", Label("fast"), func() {
 			m := &hazelcastv1alpha1.Map{
 				ObjectMeta: randomObjectMeta(namespace),
@@ -210,7 +224,7 @@ var _ = Describe("Map CR", func() {
 						InvalidateOnChange: pointer.Bool(false),
 						TimeToLiveSeconds:  300,
 						MaxIdleSeconds:     300,
-						NearCacheEviction: &hazelcastv1alpha1.NearCacheEviction{
+						NearCacheEviction: hazelcastv1alpha1.NearCacheEviction{
 							EvictionPolicy: "NONE",
 							MaxSizePolicy:  "ENTRY_COUNT",
 							Size:           10,


### PR DESCRIPTION
## Description

The error is caused by the nil pointer of `*NearCacheEviction` in `NearCache` struct.

The Fix basically includes:
- refer to `NearCacheEviction` instead of pointer
- adding defaults to `NearCacheEviction`

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
