### PR TITLE
[CN-860] Added e2e tests for map and cache 

### DIFF
--- a/test/e2e/hazelcast_cache_test.go
+++ b/test/e2e/hazelcast_cache_test.go
@@ -68,4 +68,21 @@ var _ = Describe("Hazelcast Cache Config", Label("cache"), func() {
 		Expect(string(cacheConfig.InMemoryFormat)).Should(Equal(string(c.Spec.InMemoryFormat)))
 	})
 
+	When("Native Memory is not enabled for Hazelcast CR", func() {
+		It("should fail with InMemoryFormat value is set to NativeMemory", Label("fast"), func() {
+			setLabelAndCRName("hch-3")
+			hazelcast := hazelcastconfig.Default(hzLookupKey, ee, labels)
+			CreateHazelcastCR(hazelcast)
+
+			By("creating the cache config with NativeMemory")
+			c := hazelcastconfig.DefaultCache(chLookupKey, hazelcast.Name, labels)
+			c.Spec.InMemoryFormat = hazelcastcomv1alpha1.InMemoryFormatNative
+
+			Expect(k8sClient.Create(context.Background(), c)).Should(Succeed())
+			c = assertDataStructureStatus(chLookupKey, hazelcastcomv1alpha1.DataStructureFailed, &hazelcastcomv1alpha1.Cache{}).(*hazelcastcomv1alpha1.Cache)
+
+			Expect(c.Status.Message).To(ContainSubstring("Native Memory must be enabled at Hazelcast"))
+		})
+	})
+
 })


### PR DESCRIPTION
## Description

Added e2e test for the map and cache configuration validation when native memory is not enabled on HZ. The validation is added in [another PR](https://github.com/hazelcast/hazelcast-platform-operator/pull/759).
