### PR TITLE
[CN-935] Depreciate `imagePullSecrets` and add `image.pullSecrets` in values.yaml

### DIFF
--- a/helm-charts/hazelcast-platform-operator/templates/NOTES.txt
+++ b/helm-charts/hazelcast-platform-operator/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{- if .Values.imagePullSecrets }}
+#################################################################################
+######   WARNING: `imagePullSecrets` has been deprecated!                   #####
+######            It has been moved and renamed to `image.pullSecrets`.     #####
+#################################################################################
+{{- end }}

--- a/helm-charts/hazelcast-platform-operator/templates/NOTES.txt
+++ b/helm-charts/hazelcast-platform-operator/templates/NOTES.txt
@@ -1,6 +1,0 @@
-{{- if .Values.imagePullSecrets }}
-#################################################################################
-######   WARNING: `imagePullSecrets` has been deprecated!                   #####
-######            It has been moved and renamed to `image.pullSecrets`.     #####
-#################################################################################
-{{- end }}

--- a/helm-charts/hazelcast-platform-operator/templates/_helpers.tpl
+++ b/helm-charts/hazelcast-platform-operator/templates/_helpers.tpl
@@ -51,6 +51,21 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Return the proper Image Pull Secret Names
+*/}}
+{{- define "hazelcast-platform-operator.imagePullSecrets" -}}
+{{ if .Values.image.pullSecrets }}
+{{- range .Values.image.pullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- else }}
+{{- range .Values.imagePullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "hazelcast-platform-operator.serviceAccountName" -}}

--- a/helm-charts/hazelcast-platform-operator/templates/deployment.yaml
+++ b/helm-charts/hazelcast-platform-operator/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
     spec:
       serviceAccountName: {{ include "hazelcast-platform-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
-      {{- with .Values.imagePullSecrets }}
+      {{- if include "hazelcast-platform-operator.imagePullSecrets" . }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- include "hazelcast-platform-operator.imagePullSecrets" . | indent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-charts/hazelcast-platform-operator/values.yaml
+++ b/helm-charts/hazelcast-platform-operator/values.yaml
@@ -10,6 +10,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest-snapshot
+  pullSecrets: []
 
 developerModeEnabled: false
 phoneHomeEnabled: true
@@ -30,7 +31,8 @@ debug:
   enabled: false
   port: 40000
 
-imagePullSecrets: []
+## DEPRECATED: Use 'image.pullSecrets' instead of imagePullSecrets.
+# imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Description

The `imagePullSecrets` field is depreciated and new field, `image.pullSecrets` is exposed.
Users can still set `imagePullSecrets`. 
In `helpers.tpl`, we first check if  `image.pullSecrets` is set then use that field. If not use `imagePullSecrets`. 
