### PR TITLE
[CN-924] Fix flaky External API errors should be reflected to Hazelcast CR status test

### DIFF
--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 				err := k8sClient.Get(context.Background(), hzLookupKey, hz)
 				Expect(err).ToNot(HaveOccurred())
 				return hz.Status.Phase
-			}, 30*Second, interval).Should(Equal(phase))
+			}, 10*Minute, interval).Should(Equal(phase))
 			Expect(hz.Status.Message).Should(Not(BeEmpty()))
 		}
 

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 				err := k8sClient.Get(context.Background(), hzLookupKey, hz)
 				Expect(err).ToNot(HaveOccurred())
 				return hz.Status.Phase
-			}, 10*Minute, interval).Should(Equal(phase))
+			}, 3*Minute, interval).Should(Equal(phase))
 			Expect(hz.Status.Message).Should(Not(BeEmpty()))
 		}
 


### PR DESCRIPTION
## Description

Increases the timeout duration to 10 mins.  

As the Hz cluster is created without checking (waiting) status of the Hazelcast CR in the test case, then 30 secs might not be enough timeout duration in the next operation. Increasing the timeout may fix the flakiness.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
