### PR TITLE
[CN-914] Added auto upgrade HZ and MC version step

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_BRANCH: ${{ github.event.inputs.RELEASE_BRANCH }}
+      HZ_REPO: hazelcast/hazelcast
+      MC_REPO: hazelcast/management-center
     steps:
       - name: Validate version
         run: |
@@ -27,12 +29,46 @@ jobs:
         with:
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
-      - name: Create Release Branch
+      - name: Set the latest HZ and MC versions and Create Release Branch
+        id: update_version
         run: |
           git config user.email "devopshelm@hazelcast.com"
           git config user.name "devOpsHelm"
-          git checkout -b ${RELEASE_BRANCH}
-          git push -u origin ${RELEASE_BRANCH} 
+          
+          get_latest_tag() {
+            echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
+            local LATEST_TAG=$(gh api repos/$1/git/matching-refs/tags --jq '.[].ref | select(test("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+            echo $LATEST_TAG
+          }
+          
+          HZ_LATEST_TAG=$(get_latest_tag "$HZ_REPO")
+          MC_LATEST_TAG=$(get_latest_tag "$MC_REPO")
+          sed -i '/Version of Hazelcast Platform\./{n; /^\s*$/! {s#// +kubebuilder:default:="\([0-9][^"]*\)"#// +kubebuilder:default:="'"$HZ_LATEST_TAG"'"#;};}' api/v1alpha1/hazelcast_types.go
+          sed -i '/Version of Management Center\./{n; /^\s*$/! {s#// +kubebuilder:default:="\([0-9][^"]*\)"#// +kubebuilder:default:="'"$MC_LATEST_TAG"'"#;};}' api/v1alpha1/managementcenter_types.go
+          sed -i 's/HazelcastVersion = \".*\"/HazelcastVersion = \"'$HZ_LATEST_TAG'\"/' internal/naming/constants.go
+          sed -i 's/MCVersion = \".*\"/MCVersion = \"'$MC_LATEST_TAG'\"/' internal/naming/constants.go
+          grep -rl 'kind: Hazelcast' config/samples | xargs sed -i -E -e 's/(version: ).*/\1'"'$HZ_LATEST_TAG'"'/'
+          
+          if git diff --quiet; then
+            #Create the release branch based on 'main' branch
+              git checkout -b ${RELEASE_BRANCH}
+              git push -u origin ${RELEASE_BRANCH} 
+          else
+            #Create PR against main branch
+             make sync-manifests
+             git checkout -b "update-hz-and-mc"
+             git add .
+             git commit --signoff -m "Update Hazelcast and MC version"
+             git push -u origin "update-hz-and-mc"
+             gh pr create --fill \
+              --reviewer "hazelcast/cloud-native" \
+              --label "non-release" \
+              --milestone "${RELEASE_BRANCH}"
+          
+            #Create the release branch based on 'update-hz-and-mc' branch         
+             git checkout -b ${RELEASE_BRANCH} "update-hz-and-mc"
+             git push -u origin ${RELEASE_BRANCH}
+          fi
 
       - name: Checkout 'Release' Branch
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Added step into a pre-release workflow that will get the latest HZ and MC version and update it in the files:

- api/v1alpha1/hazelcast_types.go 
- api/v1alpha1/managementcenter_types.go
- internal/naming/constants.go
- All samples files

If the changes are made, then:

1. run the 'make sync-manifests'
2. Create a branch (e.g. update-hz-and-mc) with these changes and then create a PR against 'main'
3. Create a release branch (e.g. 5.9) based on the branch ('update-hz-and-mc') from Step 2


