### PR TITLE
[CN-845] Add persistence validation for hotbackup

### DIFF
--- a/api/v1alpha1/common_validation.go
+++ b/api/v1alpha1/common_validation.go
@@ -52,7 +52,7 @@ func ValidateAppliedPersistence(persistenceEnabled bool, h *Hazelcast) *field.Er
 
 	if !lastSpec.Persistence.IsEnabled() {
 		return field.Invalid(field.NewPath("spec").Child("persistenceEnabled"), lastSpec.Persistence.IsEnabled(),
-			"data structure persistence must match with Hazelcast persistence")
+			"Persistence must be enabled at Hazelcast")
 	}
 
 	return nil

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -127,10 +127,9 @@ func (r *HotBackupReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 			withHotBackupState(hazelcastv1alpha1.HotBackupPending))
 	}
 
-	fieldErr := hazelcastv1alpha1.ValidateAppliedPersistence(true, h)
-	if fieldErr != nil {
-		return r.updateStatus(ctx, req.NamespacedName, recoptions.Error(fieldErr),
-			withHotBackupFailedState(fieldErr.Error()))
+	if err := hazelcastv1alpha1.ValidateAppliedPersistence(true, h); err != nil {
+		return r.updateStatus(ctx, req.NamespacedName, recoptions.Error(err),
+			withHotBackupFailedState(err.Error()))
 	}
 
 	err = r.updateLastSuccessfulConfiguration(ctx, req.NamespacedName)

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -127,6 +127,12 @@ func (r *HotBackupReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 			withHotBackupState(hazelcastv1alpha1.HotBackupPending))
 	}
 
+	fieldErr := hazelcastv1alpha1.ValidateAppliedPersistence(true, h)
+	if fieldErr != nil {
+		return r.updateStatus(ctx, req.NamespacedName, recoptions.Error(fieldErr),
+			withHotBackupFailedState(fieldErr.Error()))
+	}
+
 	err = r.updateLastSuccessfulConfiguration(ctx, req.NamespacedName)
 	if err != nil {
 		logger.Info("Could not save the current successful spec as annotation to the custom resource")

--- a/test/e2e/hazelcast_cache_persistence_test.go
+++ b/test/e2e/hazelcast_cache_persistence_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Hazelcast Cache Config with Persistence", Label("cache_persist
 		Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
 		assertDataStructureStatus(chLookupKey, hazelcastv1alpha1.DataStructureFailed, m)
 
-		Expect(m.Status.Message).To(ContainSubstring("data structure persistence must match with Hazelcast persistence"))
+		Expect(m.Status.Message).To(ContainSubstring("Persistence must be enabled at Hazelcast"))
 	})
 
 	It("should keep the entries after a Hot Backup", Label("slow"), func() {

--- a/test/e2e/hazelcast_map_persistence_test.go
+++ b/test/e2e/hazelcast_map_persistence_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Hazelcast Map Config with Persistence", Label("map_persistence
 
 		Expect(k8sClient.Create(context.Background(), m)).Should(Succeed())
 		m = assertMapStatus(m, hazelcastv1alpha1.MapFailed)
-		Expect(m.Status.Message).To(ContainSubstring("data structure persistence must match with Hazelcast persistence"))
+		Expect(m.Status.Message).To(ContainSubstring("Persistence must be enabled at Hazelcast"))
 	})
 
 	It("should keep the entries after a Hot Backup", Label("slow"), func() {


### PR DESCRIPTION
## Description

If Persistence is not enabled on Hazelcast, Hotbackup CR will have failed status and corresponding error message.
