### PR TITLE
[cn-843] [cn-842] Using basedir for backup without "/" causes error during HZ cluster creation and empty basedir

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -647,7 +647,7 @@ func (p *HazelcastPersistenceConfiguration) AutoRemoveStaleData() bool {
 
 // Returns true if Persistence configuration is specified.
 func (p *HazelcastPersistenceConfiguration) IsEnabled() bool {
-	return p != nil && p.BaseDir != ""
+	return p != nil
 }
 
 // IsRestoreEnabled returns true if Restore configuration is specified

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -223,7 +223,7 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 	}
 
 	if !strings.HasPrefix(p.BaseDir, "/") && p.BaseDir != "" {
-		p.BaseDir = "/" + p.BaseDir
+		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"), p.BaseDir, " must include `/` "))
 	}
 
 }

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -222,7 +222,7 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 		v.addErr(field.Required(field.NewPath("spec").Child("persistence").Child("baseDir"), "must be set when persistence is enabled"))
 	}
 
-	if !strings.HasPrefix(p.BaseDir, "/") {
+	if !strings.HasPrefix(p.BaseDir, "/") && p.BaseDir != "" {
 		p.BaseDir = "/" + p.BaseDir
 	}
 

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"reflect"
 	"regexp"
 	"sort"
@@ -218,14 +219,9 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 			"PartialStart can be used only with Partial clusterDataRecoveryPolicy"))
 	}
 
-	if p.BaseDir == "" {
-		v.addErr(field.Required(field.NewPath("spec").Child("persistence").Child("baseDir"), "must be set when persistence is enabled"))
+	if !path.IsAbs(p.BaseDir) {
+		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"), p.BaseDir, " must be absolute path "))
 	}
-
-	if !strings.HasPrefix(p.BaseDir, "/") && p.BaseDir != "" {
-		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"), p.BaseDir, " must include `/` "))
-	}
-
 }
 
 func (v *hazelcastValidator) validateClusterSize(h *Hazelcast) {

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -218,9 +218,12 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 			"PartialStart can be used only with Partial clusterDataRecoveryPolicy"))
 	}
 
+	if p.BaseDir == "" {
+		v.addErr(field.Required(field.NewPath("spec").Child("persistence").Child("baseDir"), "must be set when persistence is enabled"))
+	}
+
 	if !strings.HasPrefix(p.BaseDir, "/") {
-		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"),
-			p.BaseDir, "must start with /"))
+		p.BaseDir = "/" + p.BaseDir
 	}
 
 }

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -217,6 +217,12 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 		v.addErr(field.Forbidden(field.NewPath("spec").Child("persistence").Child("startupAction"),
 			"PartialStart can be used only with Partial clusterDataRecoveryPolicy"))
 	}
+
+	if !strings.HasPrefix(p.BaseDir, "/") {
+		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"),
+			p.BaseDir, "must start with /"))
+	}
+
 }
 
 func (v *hazelcastValidator) validateClusterSize(h *Hazelcast) {

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -220,7 +220,7 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 	}
 
 	if !path.IsAbs(p.BaseDir) {
-		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"), p.BaseDir, " must be absolute path "))
+		v.addErr(field.Invalid(field.NewPath("spec").Child("persistence").Child("baseDir"), p.BaseDir, "must be absolute path"))
 	}
 }
 

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -716,6 +716,25 @@ var _ = Describe("Hazelcast CR", func() {
 	})
 
 	Context("with Persistence configuration", func() {
+		It("should fail to create with empty baseDir", Label("fast"), func() {
+			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
+			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "",
+				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}
+
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec:       spec,
+			}
+
+			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
+		})
+	})
+
+	Context("with Persistence configuration", func() {
 		It("should fail to create with invalid baseDir", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
@@ -730,7 +749,7 @@ var _ = Describe("Hazelcast CR", func() {
 				Spec:       spec,
 			}
 
-			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
+			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 		})
 	})
 

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -716,6 +716,25 @@ var _ = Describe("Hazelcast CR", func() {
 	})
 
 	Context("with Persistence configuration", func() {
+		It("should fail to create with invalid baseDir", Label("fast"), func() {
+			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
+			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "baseDir/",
+				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}
+
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec:       spec,
+			}
+
+			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
+		})
+	})
+
+	Context("with Persistence configuration", func() {
 		It("should create with default values", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -749,7 +749,7 @@ var _ = Describe("Hazelcast CR", func() {
 				Spec:       spec,
 			}
 
-			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Description
- Fixing the baseDir field's path bugs
- Introducing  new tests related to that task
- If the baseDir does not start with `/`  we append `/` into prefix.
