### PR TITLE
Fix flakiness by increasing timeout duration on the HotBackup bucket test

### DIFF
--- a/test/e2e/hazelcast_backup_test.go
+++ b/test/e2e/hazelcast_backup_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Hazelcast Backup", Label("backup"), func() {
 				return nil
 			}
 			return err
-		}, 20*Second, interval).Should(Succeed())
+		}, Minute, interval).Should(Succeed())
 		assertExists(types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, &secret)
 
 		By("triggering the backup")


### PR DESCRIPTION
## Description

Insufficient timeout (20 sec) lead the test case to flakiness:
https://github.com/hazelcast/hazelcast-platform-operator/actions/runs/5891942299/job/15980442661#step:12:1820

It increases from 20 sec to 1 min.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
