### PR TITLE
Update credentials and steps name

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -224,4 +224,4 @@ jobs:
           status: failure
           channel: "#github-actions-log"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -52,7 +52,7 @@ jobs:
           git config user.name "devOpsHelm"
           
           get_latest_tag() {
-            echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
+            echo ${{ env.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
             local LATEST_TAG=$(gh api repos/$1/git/matching-refs/tags --jq '.[].ref | select(test("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
             echo $LATEST_TAG
           }

--- a/test/e2e/hazelcast_backup_slow_test.go
+++ b/test/e2e/hazelcast_backup_slow_test.go
@@ -309,13 +309,13 @@ var _ = Describe("Hazelcast Backup", Label("backup_slow"), func() {
 		assertMapStatus(m, hazelcastv1alpha1.MapSuccess)
 		fillTheMapDataPortForward(context.Background(), hazelcast, localPort, m.MapName(), 10)
 
-		By("triggering first backup as external")
+		By("triggering first backup as local")
 		hotBackup := hazelcastconfig.HotBackupBucket(hbLookupKey, hazelcast.Name, labels, "", "")
 		Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 		hotBackup = assertHotBackupSuccess(hotBackup, 1*Minute)
 		fillTheMapDataPortForward(context.Background(), hazelcast, localPort, m.MapName(), 10)
 
-		By("triggering second backup as local")
+		By("triggering second backup as external")
 		hbLookupKey2 := types.NamespacedName{Name: hbLookupKey.Name + "2", Namespace: hbLookupKey.Namespace}
 		hotBackup2 := hazelcastconfig.HotBackupBucket(hbLookupKey2, hazelcast.Name, labels, "gs://operator-e2e-external-backup", "br-secret-gcp")
 		Expect(k8sClient.Create(context.Background(), hotBackup2)).Should(Succeed())


### PR DESCRIPTION
## Description

Update leftover credentials to AWS secrets manager and rename wrong test step 
