### PR TITLE
Update docs-release.yaml workflow

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -6,7 +6,7 @@ on:
         description: "Version in the form of X.Y"
         required: true
       UPCOMING_RELEASE_VERSION:
-        description: "Version in the form of X.Y"
+        description: "Upcoming version in the form of X.Y"
         required: true
       LATEST_SUPPORTED_HAZELCAST:
         description: "Latest supported Hazelcast Version in the form of X.Y[.Z]"
@@ -110,8 +110,12 @@ jobs:
           git config user.name "devOpsHelm"
           BRANCH_NAME=v/${MAJOR_MINOR_VERSION}
           if [[ ${MAJOR_MINOR_VERSION} == ${RELEASE_VERSION} ]] ;then
-            git checkout -b $BRANCH_NAME
-            git pull origin main
+            if git fetch origin $BRANCH_NAME; then
+              git checkout $BRANCH_NAME
+              git pull origin $BRANCH_NAME
+            else
+              git checkout -b $BRANCH_NAME origin/main
+            fi
           fi
 
           # Commit and push changes


### PR DESCRIPTION
## Description
FIxed the issue when documentation release failed:
`Already up to date.
[v/5.9 508b36f] Update docs to 5.9
 2 files changed, 10 insertions(+), 9 deletions(-)
To https://github.com/hazelcast/hazelcast-platform-operator-docs
 ! [rejected]        v/5.9 -> v/5.9 (fetch first)
error: failed to push some refs to 'https://github.com/hazelcast/hazelcast-platform-operator-docs'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.`