### PR TITLE
Fix compact serialization config generation

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1287,9 +1287,17 @@ func fillHazelcastConfigWithSerialization(cfg *config.Hazelcast, h *hazelcastv1a
 		}
 	}
 	if s.CompactSerialization != nil {
+		classes := make([]string, 0, len(s.CompactSerialization.Classes))
+		for _, class := range s.CompactSerialization.Classes {
+			classes = append(classes, fmt.Sprintf("class: %s", class))
+		}
+		serializers := make([]string, 0, len(s.CompactSerialization.Serializers))
+		for _, serializer := range s.CompactSerialization.Serializers {
+			serializers = append(serializers, fmt.Sprintf("serializer: %s", serializer))
+		}
 		cfg.Serialization.CompactSerialization = &config.CompactSerialization{
-			Serializers: s.CompactSerialization.Serializers,
-			Classes:     s.CompactSerialization.Classes,
+			Serializers: serializers,
+			Classes:     classes,
 		}
 	}
 }


### PR DESCRIPTION
## Description
Config generation is fixed.
Corresponding unit tests are added.

The issue is described in [this slack message](https://hazelcast.slack.com/archives/C01KZ897X7G/p1693541996363869).
The proper config is taken from the following doc page:
https://docs.hazelcast.com/hazelcast/5.3/serialization/compact-serialization#configuration

Nothing change on the kubernetes api. Thus no impact for user.