### PR TITLE
Remove incorrect logs in external address function

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -253,10 +253,6 @@ func GetExternalAddresses(ctx context.Context, cli client.Client, cr ExternalAdd
 				externalAddrs = append(externalAddrs, fmt.Sprintf("%s:%d", addr, port.Port))
 			}
 		}
-
-		if len(externalAddrs) == 0 {
-			logger.Info("Load Balancer external IP is not ready.")
-		}
 	}
 
 	return externalAddrs, wanAddrs


### PR DESCRIPTION
It removes the incorrect logs in external address function. This function will possibly be removed soon though.

The deleted statement prints the misleading logs when the WAN in advanced network is enabled.