### PR TITLE
[CN-1004] Print HazelcastReference column in the wide output of CRDs referencing to Hazelcast CR

### DIFF
--- a/api/v1alpha1/cache_types.go
+++ b/api/v1alpha1/cache_types.go
@@ -44,6 +44,7 @@ type CacheStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the Cache Config"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current Cache Config"
 // +kubebuilder:resource:shortName=ch
 

--- a/api/v1alpha1/cronhotbackup_types.go
+++ b/api/v1alpha1/cronhotbackup_types.go
@@ -63,6 +63,7 @@ type CronHotBackupStatus struct{}
 // +kubebuilder:resource:shortName=chb
 // CronHotBackup is the Schema for the cronhotbackups API
 // +kubebuilder:printcolumn:name="SUSPENDED",type="boolean",JSONPath=".spec.suspend",description="Suspention status of the CronHotBackup"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hotBackupTemplate.spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 type CronHotBackup struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/api/v1alpha1/hazelcastendpoint_types.go
+++ b/api/v1alpha1/hazelcastendpoint_types.go
@@ -45,6 +45,7 @@ type HazelcastEndpointStatus struct {
 // HazelcastEndpoint is the Schema for the hazelcastendpoints API
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="Type of the HazelcastEndpoint"
 // +kubebuilder:printcolumn:name="Address",type="string",JSONPath=".status.address",description="Address of the HazelcastEndpoint"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current HazelcastEndpoint"
 // +kubebuilder:resource:shortName=hzep
 type HazelcastEndpoint struct {

--- a/api/v1alpha1/hotbackup_types.go
+++ b/api/v1alpha1/hotbackup_types.go
@@ -113,6 +113,7 @@ func (hbs *HotBackupSpec) IsExternal() bool {
 
 // HotBackup is the Schema for the hot backup API
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the HotBackup process"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current HotBackup Config"
 // +kubebuilder:resource:shortName=hb
 type HotBackup struct {

--- a/api/v1alpha1/jetjob_types.go
+++ b/api/v1alpha1/jetjob_types.go
@@ -120,6 +120,7 @@ func (jjs JetJobStatusPhase) IsSuspended() bool {
 //+kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Current state of the JetJob"
 // +kubebuilder:printcolumn:name="Id",type="string",JSONPath=".status.id",description="ID of the JetJob"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="SubmissionTime",type="string",JSONPath=".status.submissionTime",description="Time when the JetJob was submitted"
 // +kubebuilder:printcolumn:name="CompletionTime",type="string",JSONPath=".status.completionTime",description="Time when the JetJob was completed"
 // +kubebuilder:resource:shortName=jj

--- a/api/v1alpha1/map_types.go
+++ b/api/v1alpha1/map_types.go
@@ -366,6 +366,7 @@ type EventJournal struct {
 
 // Map is the Schema for the maps API
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the Map Config"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current Map Config"
 type Map struct {
 	metav1.TypeMeta `json:",inline"`

--- a/api/v1alpha1/multimap_types.go
+++ b/api/v1alpha1/multimap_types.go
@@ -44,6 +44,7 @@ type MultiMapStatus struct {
 
 // MultiMap is the Schema for the multimaps API
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the MultiMap Config"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current MultiMap Config"
 // +kubebuilder:resource:shortName=mmap
 type MultiMap struct {

--- a/api/v1alpha1/queue_types.go
+++ b/api/v1alpha1/queue_types.go
@@ -40,6 +40,7 @@ type QueueStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the Queue Config"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current Queue Config"
 // +kubebuilder:resource:shortName=q
 

--- a/api/v1alpha1/replicatedmap_types.go
+++ b/api/v1alpha1/replicatedmap_types.go
@@ -52,6 +52,7 @@ const (
 
 // ReplicatedMap is the Schema for the replicatedmaps API
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the ReplicatedMap Config"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current ReplicatedMap Config"
 // +kubebuilder:resource:shortName=rmap
 type ReplicatedMap struct {

--- a/api/v1alpha1/topic_types.go
+++ b/api/v1alpha1/topic_types.go
@@ -41,6 +41,7 @@ type TopicStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="Current state of the Topic Config"
+// +kubebuilder:printcolumn:name="Hazelcast-Resource",type="string",priority=1,JSONPath=".spec.hazelcastResourceName",description="Name of the Hazelcast resource that this resource is created for"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=1,JSONPath=".status.message",description="Message for the current Topic Config"
 
 // Topic is the Schema for the topics API

--- a/config/crd/bases/hazelcast.com_caches.yaml
+++ b/config/crd/bases/hazelcast.com_caches.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current Cache Config
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_cronhotbackups.yaml
+++ b/config/crd/bases/hazelcast.com_cronhotbackups.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .spec.suspend
       name: SUSPENDED
       type: boolean
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hotBackupTemplate.spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/hazelcast.com_hazelcastendpoints.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcastendpoints.yaml
@@ -26,6 +26,11 @@ spec:
       jsonPath: .status.address
       name: Address
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current HazelcastEndpoint
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_hotbackups.yaml
+++ b/config/crd/bases/hazelcast.com_hotbackups.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current HotBackup Config
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_jetjobs.yaml
+++ b/config/crd/bases/hazelcast.com_jetjobs.yaml
@@ -26,6 +26,11 @@ spec:
       jsonPath: .status.id
       name: Id
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Time when the JetJob was submitted
       jsonPath: .status.submissionTime
       name: SubmissionTime

--- a/config/crd/bases/hazelcast.com_maps.yaml
+++ b/config/crd/bases/hazelcast.com_maps.yaml
@@ -20,6 +20,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current Map Config
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_multimaps.yaml
+++ b/config/crd/bases/hazelcast.com_multimaps.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current MultiMap Config
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_queues.yaml
+++ b/config/crd/bases/hazelcast.com_queues.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current Queue Config
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_replicatedmaps.yaml
+++ b/config/crd/bases/hazelcast.com_replicatedmaps.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current ReplicatedMap Config
       jsonPath: .status.message
       name: Message

--- a/config/crd/bases/hazelcast.com_topics.yaml
+++ b/config/crd/bases/hazelcast.com_topics.yaml
@@ -20,6 +20,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current Topic Config
       jsonPath: .status.message
       name: Message

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -22,6 +22,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current Cache Config
       jsonPath: .status.message
       name: Message
@@ -169,6 +174,11 @@ spec:
       jsonPath: .spec.suspend
       name: SUSPENDED
       type: boolean
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hotBackupTemplate.spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -300,6 +310,11 @@ spec:
     - description: Address of the HazelcastEndpoint
       jsonPath: .status.address
       name: Address
+      type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
       type: string
     - description: Message for the current HazelcastEndpoint
       jsonPath: .status.message
@@ -2406,6 +2421,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current HotBackup Config
       jsonPath: .status.message
       name: Message
@@ -2503,6 +2523,11 @@ spec:
     - description: ID of the JetJob
       jsonPath: .status.id
       name: Id
+      type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
       type: string
     - description: Time when the JetJob was submitted
       jsonPath: .status.submissionTime
@@ -4095,6 +4120,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current Map Config
       jsonPath: .status.message
       name: Message
@@ -4475,6 +4505,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current MultiMap Config
       jsonPath: .status.message
       name: Message
@@ -4596,6 +4631,11 @@ spec:
     - description: Current state of the Queue Config
       jsonPath: .status.state
       name: Status
+      type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
       type: string
     - description: Message for the current Queue Config
       jsonPath: .status.message
@@ -4726,6 +4766,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
+      type: string
     - description: Message for the current ReplicatedMap Config
       jsonPath: .status.message
       name: Message
@@ -4831,6 +4876,11 @@ spec:
     - description: Current state of the Topic Config
       jsonPath: .status.state
       name: Status
+      type: string
+    - description: Name of the Hazelcast resource that this resource is created for
+      jsonPath: .spec.hazelcastResourceName
+      name: Hazelcast-Resource
+      priority: 1
       type: string
     - description: Message for the current Topic Config
       jsonPath: .status.message


### PR DESCRIPTION
## Description

`hazelcast-resource` column has been added to the `additionalPrinterColumns`

## User Impact

`HAZELCAST-RESOURCE` column is added in the wide output of CRDs which have reference to Hazelcast CR.

```
$ kubectl get map -o wide
NAME    STATUS    HAZELCAST-RESOURCE   MESSAGE
users   Success   hz-sample

$ kubectl get hotbackup -o wide
NAME                         STATUS    HAZELCAST-RESOURCE   MESSAGE
cron-hot-backup-1697037000   Success   hazelcast
hot-backup                   Success   hazelcast
```