### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @hazelcast/cloud-native


### PR DESCRIPTION
## Description

Need to remove codeowner file to have the possibility to assign the reviewers automatically only after all checks are passed.
