### PR TITLE
[CN-1039] Create Hazelcast Endpoint CR for the default WAN port

### DIFF
--- a/test/integration/hazelcastendpoint_test.go
+++ b/test/integration/hazelcastendpoint_test.go
@@ -162,7 +162,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 1)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 1)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 2)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -184,7 +184,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 1)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 1)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 2)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -206,7 +206,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 4)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -274,7 +274,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 			services := expectLenOfHazelcastEndpointServices(ctx, hz, 1)
-			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 1)
+			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 2)
 
 			setLoadBalancerIngressAddress(ctx, services)
 			expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)


### PR DESCRIPTION
## Description

When the WANConfig under the AdvancedNetwork **is not configured**;
```
Hazelcast Endpoint CRs:
NAME            TYPE        ADDRESS
hazelcast       Discovery   127.0.0.1:5701
hazelcast-0     Member      127.0.0.1:5701
hazelcast-1     Member      127.0.0.1:5701
hazelcast-2     Member      127.0.0.1:5701
hazelcast-wan   WAN         127.0.0.1:5710 // Default WAN port in the discovery service
```

When the WANConfig under the AdvancedNetwork **is configured**;
```
Hazelcast Endpoint CRs:
NAME                   TYPE        ADDRESS
hazelcast              Discovery   127.0.0.1:5701
hazelcast-0            Member      127.0.0.1:5701
hazelcast-1            Member      127.0.0.1:5701
hazelcast-2            Member      127.0.0.1:5701
hazelcast-istanbul-0   WAN         127.0.0.1:5710
hazelcast-istanbul-1   WAN         127.0.0.1:5711
hazelcast-istanbul-2   WAN         127.0.0.1:5712
hazelcast-istanbul-3   WAN         127.0.0.1:5713
hazelcast-istanbul-4   WAN         127.0.0.1:5714
```
