### PR TITLE
[CN-1049] Skip validations on MC and HZ deletion

### DIFF
--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -35,12 +35,12 @@ type hazelcastValidator struct {
 	fieldValidator
 }
 
-func NewHazlecastValidator(o client.Object) hazelcastValidator {
+func NewHazelcastValidator(o client.Object) hazelcastValidator {
 	return hazelcastValidator{NewFieldValidator(o)}
 }
 
 func ValidateHazelcastSpec(h *Hazelcast) error {
-	v := NewHazlecastValidator(h)
+	v := NewHazelcastValidator(h)
 	v.validateSpecCurrent(h)
 	v.validateSpecUpdate(h)
 	return v.Err()

--- a/api/v1alpha1/hazelcast_webhook.go
+++ b/api/v1alpha1/hazelcast_webhook.go
@@ -34,6 +34,9 @@ func (r *Hazelcast) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Hazelcast) ValidateUpdate(old runtime.Object) error {
 	hazelcastlog.Info("validate update", "name", r.Name)
+	if r.GetDeletionTimestamp() != nil {
+		return nil
+	}
 	return ValidateHazelcastSpec(r)
 }
 

--- a/api/v1alpha1/jetjob_validation.go
+++ b/api/v1alpha1/jetjob_validation.go
@@ -67,7 +67,7 @@ func ValidateExistingJobName(jj *JetJob, jjList *JetJobList) error {
 }
 
 func ValidateJetConfiguration(h *Hazelcast) error {
-	v := NewHazlecastValidator(h)
+	v := NewHazelcastValidator(h)
 	if !h.Spec.JetEngineConfiguration.IsEnabled() {
 		v.Required(Path("spec", "jet", "enabled"), "jet engine must be enabled")
 	}

--- a/api/v1alpha1/jetjobsnapshot_validation.go
+++ b/api/v1alpha1/jetjobsnapshot_validation.go
@@ -39,7 +39,7 @@ func (v *jetJobSnapshotValidator) validateJetJobSnapshotUpdateSpec(jjs *JetJobSn
 }
 
 func ValidateHazelcastLicenseKey(h *Hazelcast) error {
-	v := NewHazlecastValidator(h)
+	v := NewHazelcastValidator(h)
 	if h.Spec.GetLicenseKeySecretName() == "" {
 		v.Required(Path("spec", "licenseKeySecretName"), "license key must be set")
 	}

--- a/api/v1alpha1/managementcenter_webhook.go
+++ b/api/v1alpha1/managementcenter_webhook.go
@@ -27,19 +27,16 @@ var _ webhook.Defaulter = &ManagementCenter{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *ManagementCenter) ValidateCreate() error {
 	managementcenterlog.Info("validate create", "name", r.Name)
-	if err := ValidateManagementCenterSpec(r); err != nil {
-		return err
-	}
-	return nil
+	return ValidateManagementCenterSpec(r)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *ManagementCenter) ValidateUpdate(old runtime.Object) error {
 	managementcenterlog.Info("validate update", "name", r.Name)
-	if err := ValidateManagementCenterSpec(r); err != nil {
-		return err
+	if r.GetDeletionTimestamp() != nil {
+		return nil
 	}
-	return nil
+	return ValidateManagementCenterSpec(r)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type


### PR DESCRIPTION
## Description

Before HZ and MC deletion, we are removing finalizer and updating the CR. Thus, webhook's **ValidateUpdate** function is triggered for them. If there is a broken state for the CR, we were not able to remove finalizer and stuck at the ValidateUpdate function. In order to solve this issue, we add a check to the function. If the CR is marked as deleted(using DeletionTimestamp), we skip the validation.   

