### PR TITLE
[CN-1070] Remove watching of resources in operator's own namespace when watchedNamespaces is specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -376,8 +376,6 @@ func setManagerWatchedNamespaces(mgrOptions *ctrl.Options, operatorNamespace str
 		mgrOptions.Namespace = watchedNamespaces[0]
 	case util.WatchedNsTypeSingle, util.WatchedNsTypeMulti:
 		setupLog.Info("Watching namespaces", "watched_namespaces", watchedNamespaces, "operator_namespace", operatorNamespace)
-		// Operator should be able to watch resources in its own namespace
-		watchedNamespaces = append(watchedNamespaces, operatorNamespace)
 		mgrOptions.NewCache = cache.MultiNamespacedCacheBuilder(watchedNamespaces)
 	default:
 		setupLog.Info("Watching all namespaces by default")


### PR DESCRIPTION
## Description

Previously the operator was trying to watch the resources in the operator's own namespace when **WatchedNsTypeSingle** and  **WatchedNsTypeMulti** but necessary permission was not given to the according service account. Also this scenario was not intended to be supported.

## User Impact

When **watchedNamespaces** is specified, the operator will no longer watch its own namespace by default. If you want it to watch, you need to specify the namespace explicitly with the **watchedNamespaces**.
