### PR TITLE
[CN-1071] Set a max length limit to the WanConfig name field

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -1018,7 +1018,8 @@ type WANConfig struct {
 	Port        uint               `json:"port,omitempty"`
 	PortCount   uint               `json:"portCount,omitempty"`
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
-	Name        string             `json:"name,omitempty"`
+	// +kubebuilder:validation:MaxLength:=8
+	Name string `json:"name,omitempty"`
 }
 
 type ServerSocketEndpointConfig struct {

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -74,6 +74,7 @@ spec:
                     items:
                       properties:
                         name:
+                          maxLength: 8
                           type: string
                         port:
                           type: integer

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -452,6 +452,7 @@ spec:
                     items:
                       properties:
                         name:
+                          maxLength: 8
                           type: string
                         port:
                           type: integer


### PR DESCRIPTION
## Description

There is a k8s limitation that port names can be at most 15 character. We are adding 6-7 characters to given WANConfig name field to generate port name. We need to set a length limit to the WanConfig name field.

## User Impact

```
advancedNetwork:
  wan:
    - name: istanbul (Length limit is introduced. Max length is 8) 
      port: 5710
      portCount: 5
      serviceType: LoadBalancer
```