### PR TITLE
DO NOT MERGE - set publishNotReadyAddresses to true

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -335,7 +335,8 @@ func (r *HazelcastReconciler) reconcileService(ctx context.Context, h *hazelcast
 	service := &corev1.Service{
 		ObjectMeta: metadata(h),
 		Spec: corev1.ServiceSpec{
-			Selector: util.Labels(h),
+			Selector:                 util.Labels(h),
+			PublishNotReadyAddresses: true,
 		},
 	}
 


### PR DESCRIPTION
We can set `publishNotReadyAddresses` to true in the discovery service. This ensures that all Hazelcast member pods are considered ready by the service. Consequently, Istio can correctly route both inbound and outbound traffic as expected, similar to the behavior observed when the `PodManagementPolicy` is set to `OrderedReady` in a `StatefulSet`.

This change is intended to resolve the issue we are encountering in the Istio setup, specifically issue #904.