### PR TITLE
[CN-1106] Define kind flag in e2e tests to skip external address checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ GINKGO_PARALLEL_PROCESSES ?= 4
 GINKGO_KIND_PARALLEL_PROCESSES ?= 2
 
 test-e2e-split-kind: generate fmt vet ginkgo ## Run end-to-end tests on Kind
-	DEPLOYMENT_NAME=$(DEPLOYMENT_NAME) $(GINKGO) -r --compilers=2 --keep-going --junit-report=test_report_$(REPORT_SUFFIX).xml --output-dir=allure-results/$(WORKFLOW_ID) --procs $(GINKGO_KIND_PARALLEL_PROCESSES) --flake-attempts 2 --trace --slow-spec-threshold=100s --tags $(GO_BUILD_TAGS) $(FOCUSED_TESTS) --vv --progress --timeout 70m --coverprofile cover.out ./test/e2e -- -namespace "$(NAMESPACE)" -hazelcast-version "$(HZ_VERSION)" -mc-version "$(MC_VERSION)" $(GO_TEST_FLAGS)
+	DEPLOYMENT_NAME=$(DEPLOYMENT_NAME) $(GINKGO) -r --compilers=2 --keep-going --junit-report=test_report_$(REPORT_SUFFIX).xml --output-dir=allure-results/$(WORKFLOW_ID) --procs $(GINKGO_KIND_PARALLEL_PROCESSES) --flake-attempts 2 --trace --slow-spec-threshold=100s --tags $(GO_BUILD_TAGS) $(FOCUSED_TESTS) --vv --progress --timeout 70m --coverprofile cover.out ./test/e2e -- -namespace "$(NAMESPACE)" -hazelcast-version "$(HZ_VERSION)" -mc-version "$(MC_VERSION)" $(GO_TEST_FLAGS) --kind
 
 test-e2e: generate fmt vet ginkgo ## Run end-to-end tests
 	DEPLOYMENT_NAME=$(DEPLOYMENT_NAME) $(GINKGO) -r --keep-going --junit-report=test_report_$(REPORT_SUFFIX).xml --output-dir=allure-results/$(WORKFLOW_ID) --procs $(GINKGO_PARALLEL_PROCESSES) --trace --label-filter="(slow || fast) $(E2E_TEST_LABELS)" --slow-spec-threshold=100s --tags $(GO_BUILD_TAGS) --vv --progress --timeout 70m --flake-attempts 2 --output-interceptor-mode=none --coverprofile cover.out ./test/e2e -- -namespace "$(NAMESPACE)" -deployNamespace "$(WATCHED_NAMESPACES)" -hazelcast-version "$(HZ_VERSION)" -mc-version "$(MC_VERSION)" $(GO_TEST_FLAGS)

--- a/test/e2e/hazelcast_expose_externally_test.go
+++ b/test/e2e/hazelcast_expose_externally_test.go
@@ -78,13 +78,14 @@ var _ = Describe("Hazelcast CR with expose externally feature", Label("hz_expose
 				service := getServiceOfMember(ctx, hzLookupKey.Namespace, member)
 				Expect(service.Spec.Type).Should(Equal(corev1.ServiceTypeNodePort))
 				Expect(service.Spec.Ports).Should(HaveLen(1))
+				// skip the following check if the cluster is Kind
+				if kind {
+					GinkgoWriter.Printf("Skip the external address check on Kind cluster")
+					break
+				}
 				nodePort := service.Spec.Ports[0].NodePort
 				node := getNodeOfMember(ctx, hzLookupKey.Namespace, member)
 				externalAddresses := filterNodeAddressesByExternalIP(node.Status.Addresses)
-				// skip member IP check if the node has no external IP
-				if len(externalAddresses) == 0 {
-					break
-				}
 				Expect(externalAddresses).Should(HaveLen(1))
 				externalAddress := fmt.Sprintf("%s:%d", externalAddresses[0], nodePort)
 				clientPublicAddresses := filterClientMemberAddressesByPublicIdentifier(clientMember)

--- a/test/e2e/options_test.go
+++ b/test/e2e/options_test.go
@@ -16,6 +16,7 @@ var (
 	context2        string
 	interval        time.Duration
 	ee              bool
+	kind            bool
 )
 
 func init() {
@@ -27,5 +28,6 @@ func init() {
 	flag.StringVar(&context2, "SECOND_CONTEXT_NAME", os.Getenv("SECOND_CONTEXT_NAME"), "Second context name")
 	flag.DurationVar(&interval, "interval", 100*time.Millisecond, "The length of time between checks")
 	flag.BoolVar(&ee, "ee", true, "Flag to define whether Enterprise edition of Hazelcast will be used")
+	flag.BoolVar(&kind, "kind", false, "specify if the test cluster is Kind")
 	rand.Seed(time.Now().UnixNano())
 }


### PR DESCRIPTION
## Description

Defines `kind` flag in e2e tests to skip external address checks.