### PR TITLE
[CN-1113]: Add property to enable auto upgrade by default

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -792,6 +792,7 @@ func hazelcastConfig(ctx context.Context, c client.Client, h *hazelcastv1alpha1.
 	if h.Spec.Properties != nil {
 		h.Spec.Properties = mergeProperties(logger, h.Spec.Properties)
 	} else {
+		h.Spec.Properties = make(map[string]string)
 		for k, v := range defaultProperties {
 			h.Spec.Properties[k] = v
 		}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -54,6 +54,10 @@ const (
 
 var DefaultProperties = map[string]string{
 	"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+	// https://docs.hazelcast.com/hazelcast/5.3/kubernetes/kubernetes-auto-discovery#configuration
+	// We added the following properties to here with their default values, because DefaultProperties cannot be overridden
+	"hazelcast.persistence.auto.cluster.state":          "true",
+	"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
 }
 
 func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -789,6 +789,12 @@ func (r *HazelcastReconciler) reconcileMTLSSecret(ctx context.Context, h *hazelc
 func hazelcastConfig(ctx context.Context, c client.Client, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) ([]byte, error) {
 	cfg := hazelcastBasicConfig(h)
 
+	if h.Spec.Properties != nil {
+		h.Spec.Properties = mergeProperties(logger, defaultProperties, h.Spec.Properties)
+	} else {
+		h.Spec.Properties = defaultProperties
+	}
+
 	fillHazelcastConfigWithProperties(&cfg, h)
 	fillHazelcastConfigWithExecutorServices(&cfg, h)
 	fillHazelcastConfigWithSerialization(&cfg, h)
@@ -834,12 +840,6 @@ func hazelcastConfig(ctx context.Context, c client.Client, h *hazelcastv1alpha1.
 		case "Cache":
 			fillHazelcastConfigWithCaches(&cfg, filteredDSList)
 		}
-	}
-
-	if h.Spec.Properties != nil {
-		h.Spec.Properties = mergeProperties(logger, defaultProperties, h.Spec.Properties)
-	} else {
-		h.Spec.Properties = defaultProperties
 	}
 
 	if h.Spec.CustomConfigCmName != "" {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -838,6 +838,8 @@ func hazelcastConfig(ctx context.Context, c client.Client, h *hazelcastv1alpha1.
 
 	if h.Spec.Properties != nil {
 		h.Spec.Properties = mergeProperties(logger, defaultProperties, h.Spec.Properties)
+	} else {
+		h.Spec.Properties = defaultProperties
 	}
 
 	if h.Spec.CustomConfigCmName != "" {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -52,7 +52,7 @@ const (
 	javaOpts = "JAVA_OPTS"
 )
 
-var defaultProperties = map[string]string{
+var DefaultProperties = map[string]string{
 	"hazelcast.cluster.version.auto.upgrade.enabled": "true",
 }
 
@@ -793,7 +793,7 @@ func hazelcastConfig(ctx context.Context, c client.Client, h *hazelcastv1alpha1.
 		h.Spec.Properties = mergeProperties(logger, h.Spec.Properties)
 	} else {
 		h.Spec.Properties = make(map[string]string)
-		for k, v := range defaultProperties {
+		for k, v := range DefaultProperties {
 			h.Spec.Properties[k] = v
 		}
 	}
@@ -873,7 +873,7 @@ func hazelcastConfig(ctx context.Context, c client.Client, h *hazelcastv1alpha1.
 
 func mergeProperties(logger logr.Logger, inputProps map[string]string) map[string]string {
 	m := make(map[string]string)
-	for k, v := range defaultProperties {
+	for k, v := range DefaultProperties {
 		m[k] = v
 	}
 	for k, v := range inputProps {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -917,6 +917,11 @@ func hazelcastBasicConfig(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 			},
 		},
 	}
+
+	cfg.Properties = map[string]string{
+		"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+	}
+
 	if h.Spec.UserCodeDeployment != nil {
 		cfg.UserCodeDeployment = config.UserCodeDeployment{
 			Enabled: h.Spec.UserCodeDeployment.ClientEnabled,

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -36,9 +36,8 @@ var _ = Describe("Hazelcast Properties", func() {
 			hz.Spec.Properties["hazelcast.graceful.shutdown.max.wait"] = "300"
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			fetchedCR := ensureHzStatusIsPending(hz)
 
-			fetchedCR := fetchHz(hz)
 			Expect("true").Should(Equal(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]))
 			Expect("300").Should(Equal(fetchedCR.Spec.Properties["hazelcast.graceful.shutdown.max.wait"]))
 		})
@@ -52,9 +51,8 @@ var _ = Describe("Hazelcast Properties", func() {
 			hz.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"] = "false"
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			fetchedCR := ensureHzStatusIsPending(hz)
 
-			fetchedCR := fetchHz(hz)
 			Expect("true").Should(Equal(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]))
 		})
 	})

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Hazelcast Properties", func() {
 	})
 
 	Context("with custom properties", func() {
-		It("should add new property", Label("fast"), func() {
+		FIt("should add new property", Label("fast"), func() {
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
@@ -51,18 +51,22 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
-				"hazelcast.graceful.shutdown.max.wait":           "300",
+				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
+				"hazelcast.graceful.shutdown.max.wait":              "300",
+				"hazelcast.persistence.auto.cluster.state":          "true",
+				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
 			}))
 		})
 
-		It("should not override default property", Label("fast"), func() {
+		FIt("should not override default property", Label("fast"), func() {
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
 			}
 			hz.Spec.Properties = map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled": "false",
+				"hazelcast.cluster.version.auto.upgrade.enabled":    "false",
+				"hazelcast.persistence.auto.cluster.state":          "false",
+				"hazelcast.persistence.auto.cluster.state.strategy": "FROZEN",
 			}
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
@@ -78,7 +82,9 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
+				"hazelcast.persistence.auto.cluster.state":          "true",
+				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
 			}))
 		})
 	})

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Hazelcast Properties", func() {
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
 			}
+			hz.Spec.Properties = make(map[string]string)
 			hz.Spec.Properties["hazelcast.graceful.shutdown.max.wait"] = "300"
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
@@ -47,6 +48,7 @@ var _ = Describe("Hazelcast Properties", func() {
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
 			}
+			hz.Spec.Properties = make(map[string]string)
 			hz.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"] = "false"
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Hazelcast Properties", func() {
 			ensureHzStatusIsPending(hz)
 
 			fetchedCR := fetchHz(hz)
-			Expect(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]).Should(Equal("true"))
-			Expect(fetchedCR.Spec.Properties["hazelcast.graceful.shutdown.max.wait"]).Should(Equal("300"))
+			Expect("true").Should(Equal(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]))
+			Expect("300").Should(Equal(fetchedCR.Spec.Properties["hazelcast.graceful.shutdown.max.wait"]))
 		})
 
 		It("should not override default property", Label("fast"), func() {
@@ -55,7 +55,7 @@ var _ = Describe("Hazelcast Properties", func() {
 			ensureHzStatusIsPending(hz)
 
 			fetchedCR := fetchHz(hz)
-			Expect(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]).Should(Equal("true"))
+			Expect("true").Should(Equal(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]))
 		})
 	})
 })

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
+	"github.com/hazelcast/hazelcast-platform-operator/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Hazelcast Properties", func() {
+	const namespace = "default"
+
+	BeforeEach(func() {
+		if ee {
+			By(fmt.Sprintf("creating license key secret '%s'", n.LicenseDataKey))
+			licenseKeySecret := CreateLicenseKeySecret(n.LicenseKeySecret, namespace)
+			assertExists(lookupKey(licenseKeySecret), licenseKeySecret)
+		}
+	})
+
+	AfterEach(func() {
+		DeleteAllOf(&hazelcastv1alpha1.Hazelcast{}, nil, namespace, map[string]string{})
+	})
+
+	Context("with custom properties", func() {
+		It("should add new property", Label("fast"), func() {
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
+			}
+			hz.Spec.Properties["hazelcast.graceful.shutdown.max.wait"] = "300"
+
+			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
+			ensureHzStatusIsPending(hz)
+
+			fetchedCR := fetchHz(hz)
+			Expect(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]).Should(Equal("true"))
+			Expect(fetchedCR.Spec.Properties["hazelcast.graceful.shutdown.max.wait"]).Should(Equal("300"))
+		})
+
+		It("should not override default property", Label("fast"), func() {
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
+			}
+			hz.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"] = "false"
+
+			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
+			ensureHzStatusIsPending(hz)
+
+			fetchedCR := fetchHz(hz)
+			Expect(fetchedCR.Spec.Properties["hazelcast.cluster.version.auto.upgrade.enabled"]).Should(Equal("true"))
+		})
+	})
+})

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Hazelcast Properties", func() {
 	})
 
 	Context("with custom properties", func() {
-		FIt("should add new property", Label("fast"), func() {
+		It("should add new property", Label("fast"), func() {
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
@@ -58,7 +58,7 @@ var _ = Describe("Hazelcast Properties", func() {
 			}))
 		})
 
-		FIt("should not override default property", Label("fast"), func() {
+		It("should not override default property", Label("fast"), func() {
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/smithy-go/ptr"
+	"github.com/hazelcast/hazelcast-platform-operator/controllers/hazelcast"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
@@ -438,6 +439,13 @@ var _ = Describe("Hazelcast CR", func() {
 				"hazelcast.slow.operation.detector.stacktrace.logging.enabled": "true",
 				"hazelcast.query.optimizer.type":                               "NONE",
 			}
+			samplePropsWithDefaults := make(map[string]string)
+			for k, v := range hazelcast.DefaultProperties {
+				samplePropsWithDefaults[k] = v
+			}
+			for k, v := range sampleProperties {
+				samplePropsWithDefaults[k] = v
+			}
 			spec.Properties = sampleProperties
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
@@ -456,7 +464,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				return a.Hazelcast.Properties
-			}, timeout, interval).Should(Equal(sampleProperties))
+			}, timeout, interval).Should(Equal(samplePropsWithDefaults))
 		})
 	})
 


### PR DESCRIPTION
## Description

This change sets `hazelcast.cluster.version.auto.upgrade.enabled` by default.

## User Impact

As mentioned in the [Hazelcast Rolling Upgrade Document](https://docs.hazelcast.com/hazelcast/5.3/maintain-cluster/rolling-upgrades#rolling-upgrade-procedure), last step of the upgrade procedure is to trigger a rolling upgrade on the cluster. With this change, Hazelcast Platform Operator triggers it automatically by setting `hazelcast.cluster.version.auto.upgrade.enabled` to `true` by default.