### PR TITLE
Downgrade the action upload,download and delete actions from @v4 to @v3

### DIFF
--- a/.github/workflows/backup-e2e-gke.yaml
+++ b/.github/workflows/backup-e2e-gke.yaml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-backup
           path: allure-results/backup/

--- a/.github/workflows/community-operator-tests.yaml
+++ b/.github/workflows/community-operator-tests.yaml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p operators/${{ env.HZ_OPERATOR_NAME }}/${{ inputs.BUNDLE_VERSION }}
 
       - name: Download Bundle Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: bundle-artifacts
           path: community-operators/operators/${{ env.HZ_OPERATOR_NAME }}/${{ inputs.BUNDLE_VERSION }}

--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-aks
           path: allure-results/aks/

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-eks
           path: allure-results/eks/

--- a/.github/workflows/e2e-gke.yaml
+++ b/.github/workflows/e2e-gke.yaml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-gke
           path: allure-results/gke/

--- a/.github/workflows/e2e-high-load.yaml
+++ b/.github/workflows/e2e-high-load.yaml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-high-load
           path: allure-results/high-load/

--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-ocp
           path: allure-results/ocp/

--- a/.github/workflows/generate-test-report.yaml
+++ b/.github/workflows/generate-test-report.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Download test-report.xml
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: test-report-${{ inputs.WORKFLOW_ID }}
           path: allure-results/${{ inputs.WORKFLOW_ID }}

--- a/.github/workflows/high-availability-e2e-gke.yaml
+++ b/.github/workflows/high-availability-e2e-gke.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-high-availability
           path: allure-results/high-availability/

--- a/.github/workflows/istio-e2e-gke.yaml
+++ b/.github/workflows/istio-e2e-gke.yaml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-istio
           path: allure-results/istio/

--- a/.github/workflows/k8s-cluster-scope-tests.yml
+++ b/.github/workflows/k8s-cluster-scope-tests.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-cluster_scope
           path: allure-results/cluster_scope/

--- a/.github/workflows/k8s-dist-tests.yaml
+++ b/.github/workflows/k8s-dist-tests.yaml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload Unit Test Coverage Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-coverage
           path: |
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload Integration Coverage Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-coverage
           path: ${{ env.COVER_OUT }}
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Test Coverage Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: test-coverage
 

--- a/.github/workflows/multi-version-tests.yaml
+++ b/.github/workflows/multi-version-tests.yaml
@@ -77,7 +77,7 @@ jobs:
           generate_test_suites $NR_OF_SUITES
 
       - name: Upload Test Suites
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-suites
           path: suite_files/
@@ -284,7 +284,7 @@ jobs:
           kubectl rollout status deployment $DEPLOY_NAME
 
       - name: Download test-suites Files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: test-suites
           path: suite_files/
@@ -301,7 +301,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-multi
           path: allure-results/multi/

--- a/.github/workflows/nightly-ph-gke.yaml
+++ b/.github/workflows/nightly-ph-gke.yaml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-ph
           path: allure-results/ph/

--- a/.github/workflows/nightly-wan-e2e-gke.yaml
+++ b/.github/workflows/nightly-wan-e2e-gke.yaml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-wan
           path: allure-results/wan/

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -342,7 +342,7 @@ jobs:
           helm repo index --url=https://hazelcast-charts.s3.amazonaws.com --merge ./index.yaml .
 
       - name: Upload Backup of the Helm Chart Index
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: index.yaml
           path: ${{ runner.temp }}/index.yaml
@@ -566,7 +566,7 @@ jobs:
           set -e
 
       - name: Download a Backup of the Helm Chart Index
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: index.yaml
           path: ./index.yaml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -122,7 +122,7 @@ jobs:
            generate_test_suites $NR_OF_SUITES
 
       - name: Upload Test Suites
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-suites
           path: suite_files/
@@ -360,7 +360,7 @@ jobs:
           kubectl rollout status deployment $DEPLOY_NAME
 
       - name: Download test-suites Files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: test-suites
           path: suite_files/
@@ -377,7 +377,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-report-pr
           path: allure-results/pr/

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -313,7 +313,7 @@ jobs:
           target: vulnerability_report.html
 
       - name: Save Scan Report As Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: failure() && steps.vulnerabilityScan.outcome == 'failure'
         with:
           name: vulnerability-report
@@ -397,7 +397,7 @@ jobs:
           EOF
 
       - name: Upload Bundle Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: bundle-artifacts
           path: ./bundle/
@@ -532,7 +532,7 @@ jobs:
     name: Clean The Bundle Artifact and Test Image
     steps:
       - name: Delete Bundle Artifact
-        uses: geekyeggo/delete-artifact@v4
+        uses: geekyeggo/delete-artifact@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: |


### PR DESCRIPTION
Downgrade the 3 actions because of the breaking changes like these. Also @v4 is not compatible with @v3

- Uploading to the same named Artifact multiple times.
- Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.