### PR TITLE
Check Hazelcast members' container restart count

### DIFF
--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Hazelcast", Label("hz"), func() {
 			hazelcast := hazelcastconfig.Default(hzLookupKey, ee, labels)
 			CreateHazelcastCR(hazelcast)
 			evaluateReadyMembers(hzLookupKey)
+			assertMembersNotRestarted(hzLookupKey)
 			assertMemberLogs(hazelcast, "Members {size:3, ver:3}")
 
 			By("removing pods so that cluster gets recreated", func() {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -468,7 +468,9 @@ func assertMembersNotRestarted(lookupKey types.NamespacedName) {
 			Namespace: lookupKey.Namespace,
 		}
 		pod := corev1.Pod{}
-		k8sClient.Get(context.Background(), podLookupKey, &pod)
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), podLookupKey, &pod)
+		}, Minute, interval).ShouldNot(HaveOccurred())
 		Expect(pod.Status.ContainerStatuses[0].RestartCount).To(BeZero())
 	}
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -456,6 +456,23 @@ func assertMemberLogs(h *hazelcastcomv1alpha1.Hazelcast, expected string) {
 	Fail(fmt.Sprintf("Failed to find \"%s\" in member logs", expected))
 }
 
+func assertMembersNotRestarted(lookupKey types.NamespacedName) {
+	hz := &hazelcastcomv1alpha1.Hazelcast{}
+	Eventually(func() error {
+		return k8sClient.Get(context.Background(), lookupKey, hz)
+	}, Minute, interval).ShouldNot(HaveOccurred())
+	membersCount := int(*hz.Spec.ClusterSize)
+	for i := 0; i < membersCount; i++ {
+		podLookupKey := types.NamespacedName{
+			Name:      fmt.Sprintf("%s-%d", lookupKey.Name, i),
+			Namespace: lookupKey.Namespace,
+		}
+		pod := corev1.Pod{}
+		k8sClient.Get(context.Background(), podLookupKey, &pod)
+		Expect(pod.Status.ContainerStatuses[0].RestartCount).To(BeZero())
+	}
+}
+
 func evaluateReadyMembers(lookupKey types.NamespacedName) {
 	By(fmt.Sprintf("evaluate number of ready members for lookup name '%s' and '%s' namespace", lookupKey.Name, lookupKey.Namespace), func() {
 		hz := &hazelcastcomv1alpha1.Hazelcast{}


### PR DESCRIPTION
## Description

Check restartCount of Hazelcast containers. It let us detect potential bugs in some specific cases e.g. expose-externally. 