### PR TITLE
[CN-1106] Skip NodePort test case in OCP workflow

### DIFF
--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -252,8 +252,9 @@ jobs:
             ee) GO_TEST_FLAGS=-ee=true;;
             *)  echo Unexpected edition: ${{ matrix.edition }} && exit 1;;
           esac
+          # temporarily disabled NodePort test
           GO_TEST_FLAGS="${GO_TEST_FLAGS} --kind"
-          make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=$NAMESPACE RELEASE_NAME=$RELEASE_NAME REPORT_SUFFIX=${{ matrix.edition }}_01 WORKFLOW_ID=ocp
+          make test-e2e GO_TEST_FLAGS="${GO_TEST_FLAGS}" NAMESPACE=$NAMESPACE RELEASE_NAME=$RELEASE_NAME REPORT_SUFFIX=${{ matrix.edition }}_01 WORKFLOW_ID=ocp
           echo "RUNNING TESTS in $NAMESPACE"
 
       - name: Clean up after Tests

--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -252,6 +252,7 @@ jobs:
             ee) GO_TEST_FLAGS=-ee=true;;
             *)  echo Unexpected edition: ${{ matrix.edition }} && exit 1;;
           esac
+          GO_TEST_FLAGS="${GO_TEST_FLAGS} --kind"
           make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=$NAMESPACE RELEASE_NAME=$RELEASE_NAME REPORT_SUFFIX=${{ matrix.edition }}_01 WORKFLOW_ID=ocp
           echo "RUNNING TESTS in $NAMESPACE"
 


### PR DESCRIPTION
## Description

We've decided to temporarily skip the NodePort test case in the OCP workflow.

It will be reactivated after fixing the OCP network setup.
see: CN-1126