### PR TITLE
[CN-1067] Add 'delete' Webhook to Hotbackup CRD for checking restore references

### DIFF
--- a/api/v1alpha1/hotbackup_validation.go
+++ b/api/v1alpha1/hotbackup_validation.go
@@ -1,11 +1,14 @@
 package v1alpha1
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/hazelcast/hazelcast-platform-operator/internal/kubeclient"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
 )
 
@@ -41,4 +44,51 @@ func (v *hotbackupValidator) validateHotBackupPersistence(h *Hazelcast) {
 		v.Invalid(Path("spec", "persistenceEnabled"), lastSpec.Persistence.IsEnabled(), "Persistence must be enabled at Hazelcast")
 		return
 	}
+}
+
+func ValidateHotBackupIsNotReferencedByHazelcast(hb *HotBackup) error {
+	hzList := HazelcastList{}
+
+	err := kubeclient.List(context.Background(), &hzList, &client.ListOptions{Namespace: hb.Namespace})
+	if err != nil {
+		hotbackuplog.Error(err, "error on listing Hazelcast resources")
+	}
+
+	var errs []error
+	for _, hz := range hzList.Items {
+		hzCopy := hz
+		errs = append(errs, ValidateHotBackupRestoreReference(&hzCopy, hb))
+	}
+
+	return joinErrors(errs)
+}
+
+func ValidateHotBackupRestoreReference(h *Hazelcast, hb *HotBackup) error {
+	v := NewHotBackupValidator(h)
+	v.validateHotBackupRestoreReference(h, hb)
+	return v.Err()
+}
+
+func (v *hotbackupValidator) validateHotBackupRestoreReference(h *Hazelcast, hb *HotBackup) {
+	if h.Spec.Persistence.IsEnabled() {
+		if h.Spec.Persistence.Restore.HotBackupResourceName == hb.Name {
+			v.Forbidden(Path("spec", "persistence", "restore", "hotBackupResourceName"), fmt.Sprintf("HotBackup '%s' is referenced by Hazelcast restore", hb.Name))
+		}
+	}
+}
+
+// It can be removed after we update Go to 1.20 or forward
+func joinErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	var b []byte
+	for i, err := range errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return errors.New(string(b))
 }

--- a/api/v1alpha1/hotbackup_webhook.go
+++ b/api/v1alpha1/hotbackup_webhook.go
@@ -19,7 +19,7 @@ func (r *HotBackup) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-hazelcast-com-v1alpha1-hotbackup,mutating=false,failurePolicy=ignore,sideEffects=None,groups=hazelcast.com,resources=hotbackups,verbs=create;update,versions=v1alpha1,name=vhotbackup.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-hazelcast-com-v1alpha1-hotbackup,mutating=false,failurePolicy=ignore,sideEffects=None,groups=hazelcast.com,resources=hotbackups,verbs=create;update;delete,versions=v1alpha1,name=vhotbackup.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &HotBackup{}
 

--- a/api/v1alpha1/hotbackup_webhook.go
+++ b/api/v1alpha1/hotbackup_webhook.go
@@ -43,6 +43,5 @@ func (r *HotBackup) ValidateUpdate(old runtime.Object) error {
 func (r *HotBackup) ValidateDelete() error {
 	hotbackuplog.Info("validate delete", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object deletion.
-	return nil
+	return ValidateHotBackupIsNotReferencedByHazelcast(r)
 }

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -102,6 +102,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - hotbackups
   sideEffects: None

--- a/helm-charts/hazelcast-platform-operator/templates/webhook.yaml
+++ b/helm-charts/hazelcast-platform-operator/templates/webhook.yaml
@@ -73,6 +73,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
         resources:
           - hotbackups
     sideEffects: None

--- a/test/integration/hotbackup_test.go
+++ b/test/integration/hotbackup_test.go
@@ -6,9 +6,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
 	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
+	"github.com/hazelcast/hazelcast-platform-operator/test"
 )
 
 var _ = Describe("HotBackup CR", func() {
@@ -40,6 +42,48 @@ var _ = Describe("HotBackup CR", func() {
 
 			By("checking the CR values with default ones")
 			Expect(hb.Spec.HazelcastResourceName).To(Equal("hazelcast"))
+		})
+	})
+
+	Context("HotBackup is deleted", func() {
+		It("should not be allowed when it is referenced by Hazelcast restore", Label("fast"), func() {
+			hb := &hazelcastv1alpha1.HotBackup{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec: hazelcastv1alpha1.HotBackupSpec{
+					HazelcastResourceName: "hazelcast",
+				},
+			}
+			By("creating HotBackup CR successfully")
+			Expect(k8sClient.Create(context.Background(), hb)).Should(Succeed())
+
+			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
+			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
+				BaseDir: "/baseDir/",
+				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+				Restore: hazelcastv1alpha1.RestoreConfiguration{
+					HotBackupResourceName: hb.Name,
+				},
+			}
+			hz := &hazelcastv1alpha1.Hazelcast{
+				ObjectMeta: randomObjectMeta(namespace),
+				Spec:       spec,
+			}
+			By("creating the Hazelcast CR with specs successfully")
+			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
+
+			By("trying to delete the HotBackup resource which is referenced by Hazelcast restore")
+			err := k8sClient.Delete(context.Background(), hb)
+			Expect(err).Should(MatchError(ContainSubstring(fmt.Sprintf("HotBackup '%s' is referenced by Hazelcast restore", hb.Name))))
+
+			By("deleting the Hazelcast CR")
+			hz.Finalizers = make([]string, 0) // It is required to be able to delete the Hazelcast resource
+			Expect(k8sClient.Delete(context.Background(), hz)).Should(Succeed())
+			assertDoesNotExist(lookupKey(hz), hz)
+
+			By("deleting the HotBackup CR which is not referenced by Hazelcast restore")
+			Expect(k8sClient.Delete(context.Background(), hb)).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Description

We can fix it via using delete webhook at validation level to prevent Hotbackup CR deletion while it’s referenced in HZ CR.
Add the corresponding integration test if the delete webhook is working as expected.

## User Impact

Validation Webhook for deletion is added to Hotbackup CRD to verify whether it is referenced by any Hazelcast resource.