### PR TITLE
Refactor HotBackup persistence validation

### DIFF
--- a/api/v1alpha1/hotbackup_validation.go
+++ b/api/v1alpha1/hotbackup_validation.go
@@ -17,8 +17,8 @@ func NewHotBackupValidator(o client.Object) hotbackupValidator {
 	return hotbackupValidator{NewFieldValidator(o)}
 }
 
-func ValidateHotBackupPersistence(h *Hazelcast) error {
-	v := NewHotBackupValidator(h)
+func ValidateHotBackupPersistence(hb *HotBackup,h *Hazelcast) error {
+	v := NewHotBackupValidator(hb)
 	v.validateHotBackupPersistence(h)
 	return v.Err()
 }

--- a/api/v1alpha1/hotbackup_validation.go
+++ b/api/v1alpha1/hotbackup_validation.go
@@ -17,7 +17,7 @@ func NewHotBackupValidator(o client.Object) hotbackupValidator {
 	return hotbackupValidator{NewFieldValidator(o)}
 }
 
-func ValidateHotBackupPersistence(hb *HotBackup,h *Hazelcast) error {
+func ValidateHotBackupPersistence(hb *HotBackup, h *Hazelcast) error {
 	v := NewHotBackupValidator(hb)
 	v.validateHotBackupPersistence(h)
 	return v.Err()
@@ -38,7 +38,7 @@ func (v *hotbackupValidator) validateHotBackupPersistence(h *Hazelcast) {
 	}
 
 	if !lastSpec.Persistence.IsEnabled() {
-		v.Invalid(Path("spec", "persistenceEnabled"), lastSpec.Persistence.IsEnabled(), "Persistence must be enabled at Hazelcast")
+		v.Invalid(Path("spec", "persistenceEnabled"), lastSpec.Persistence.IsEnabled(), fmt.Sprintf("Hazelcast '%s' must enable persistence", h.Name))
 		return
 	}
 }

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -127,7 +127,7 @@ func (r *HotBackupReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 			withHotBackupState(hazelcastv1alpha1.HotBackupPending))
 	}
 
-	if err := hazelcastv1alpha1.ValidateHotBackupPersistence(h); err != nil {
+	if err := hazelcastv1alpha1.ValidateHotBackupPersistence(hb, h); err != nil {
 		return r.updateStatus(ctx, req.NamespacedName, recoptions.Error(err),
 			withHotBackupFailedState(err.Error()))
 	}

--- a/controllers/hazelcast/hot_backup_controller_test.go
+++ b/controllers/hazelcast/hot_backup_controller_test.go
@@ -230,7 +230,7 @@ func TestHotBackupReconciler_shouldFailIfPersistenceNotEnabledAtHazelcast(t *tes
 		_ = r.Client.Get(context.TODO(), nn, hb)
 		return hb.Status.State
 	}, 2*time.Second, 100*time.Millisecond).Should(Equal(hazelcastv1alpha1.HotBackupFailure))
-	Expect(hb.Status.Message).Should(ContainSubstring("Persistence must be enabled at Hazelcast"))
+	Expect(hb.Status.Message).Should(ContainSubstring(fmt.Sprintf("Hazelcast '%s' must enable persistence", h.Name)))
 }
 
 func fail(t *testing.T) func(message string, callerSkip ...int) {


### PR DESCRIPTION
Use the `HotBackup` object as the source object of the error instead of the `Hazelcast` object.

https://github.com/hazelcast/hazelcast-platform-operator/pull/981#discussion_r1475710007