### PR TITLE
[CN-1082] Expose path fields for MC Ingress configuration

### DIFF
--- a/api/v1alpha1/managementcenter_types.go
+++ b/api/v1alpha1/managementcenter_types.go
@@ -227,6 +227,11 @@ type ExternalConnectivityIngress struct {
 	// Annotations added to the ingress object.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Path of the ingress rule.
+	// +kubebuilder:default:="/"
+	// +optional
+	Path string `json:"path,omitempty"`
 }
 
 // ExternalConnectivityRoute defines OpenShift route configuration of Management Center
@@ -296,7 +301,7 @@ const (
 	McRunning MCPhase = "Running"
 	// McFailed phase is the state of error during the ManagementCenter startup
 	McFailed MCPhase = "Failed"
-	// McConfiguring phase is the state of cofiguring the ManagementCenter and might be restated
+	// McConfiguring phase is the state of configuring the ManagementCenter and might be restated
 	McConfiguring MCPhase = "Configuring"
 	// McPending phase is the state of starting the cluster when the ManagementCenter is not started yet
 	McPending MCPhase = "Pending"

--- a/api/v1alpha1/managementcenter_validation.go
+++ b/api/v1alpha1/managementcenter_validation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +43,9 @@ func (v *managementCenterValidator) validateSpecCurrent(mc *ManagementCenter) {
 	}
 	if mc.Spec.SecurityProviders != nil {
 		v.validateSecurityProviders(mc.Spec.SecurityProviders, mc.Namespace)
+	}
+	if mc.Spec.ExternalConnectivity.IsEnabled() {
+		v.validateExternalConnectivity(mc.Spec.ExternalConnectivity)
 	}
 }
 
@@ -131,5 +135,13 @@ func (v *managementCenterValidator) validateSecurityProviders(config *SecurityPr
 		// we care only about not found error
 		v.NotFound(p, "Management Center LDAP credentials Secret not found")
 		return
+	}
+}
+
+func (v *managementCenterValidator) validateExternalConnectivity(config *ExternalConnectivityConfiguration) {
+	if config.Ingress != nil {
+		if !path.IsAbs(config.Ingress.Path) {
+			v.Invalid(Path("spec", "externalConnectivity", "ingress", "path"), config.Ingress.Path, "must be an absolute path")
+		}
 	}
 }

--- a/config/crd/bases/hazelcast.com_managementcenters.yaml
+++ b/config/crd/bases/hazelcast.com_managementcenters.yaml
@@ -79,6 +79,10 @@ spec:
                       ingressClassName:
                         description: IngressClassName of the ingress object.
                         type: string
+                      path:
+                        default: /
+                        description: Path of the ingress rule.
+                        type: string
                     required:
                     - hostname
                     type: object

--- a/controllers/managementcenter/managementcenter_resource_test.go
+++ b/controllers/managementcenter/managementcenter_resource_test.go
@@ -154,6 +154,69 @@ func Test_mcInitCmd(t *testing.T) {
 	}
 }
 
+func Test_getContextPath(t *testing.T) {
+	tests := []struct {
+		name string
+		mc   *hazelcastv1alpha1.ManagementCenter
+		want string
+	}{
+		{
+			name: "No external connectivity",
+			mc: &hazelcastv1alpha1.ManagementCenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: hazelcastv1alpha1.ManagementCenterSpec{
+					HazelcastClusters: []hazelcastv1alpha1.HazelcastClusterConfig{},
+				},
+			},
+			want: "/",
+		},
+		{
+			name: "External connectivity with Ingress using default path",
+			mc: &hazelcastv1alpha1.ManagementCenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: hazelcastv1alpha1.ManagementCenterSpec{
+					HazelcastClusters: []hazelcastv1alpha1.HazelcastClusterConfig{},
+					ExternalConnectivity: &hazelcastv1alpha1.ExternalConnectivityConfiguration{
+						Ingress: &hazelcastv1alpha1.ExternalConnectivityIngress{
+							Path: "/",
+						},
+					},
+				},
+			},
+			want: "/",
+		},
+		{
+			name: "External connectivity with Ingress using custom path",
+			mc: &hazelcastv1alpha1.ManagementCenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: hazelcastv1alpha1.ManagementCenterSpec{
+					HazelcastClusters: []hazelcastv1alpha1.HazelcastClusterConfig{},
+					ExternalConnectivity: &hazelcastv1alpha1.ExternalConnectivityConfiguration{
+						Ingress: &hazelcastv1alpha1.ExternalConnectivityIngress{
+							Path: "/mc",
+						},
+					},
+				},
+			},
+			want: "/mc",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if contextPath := getContextPath(test.mc); contextPath != test.want {
+				t.Errorf("getContextPath() = %v, want %v", contextPath, test.want)
+			}
+		})
+	}
+}
+
 func fakeK8sClient(initObjs ...client.Object) client.Client {
 	coreScheme, _ := (&scheme.Builder{GroupVersion: corev1.SchemeGroupVersion}).
 		Register(&v1.ClusterRole{}, &v1.ClusterRoleBinding{}, &corev1.Secret{}).

--- a/controllers/managementcenter/managementcenter_resource_test.go
+++ b/controllers/managementcenter/managementcenter_resource_test.go
@@ -154,7 +154,7 @@ func Test_mcInitCmd(t *testing.T) {
 	}
 }
 
-func Test_getContextPath(t *testing.T) {
+func Test_getRootPath(t *testing.T) {
 	tests := []struct {
 		name string
 		mc   *hazelcastv1alpha1.ManagementCenter
@@ -210,7 +210,7 @@ func Test_getContextPath(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if contextPath := getContextPath(test.mc); contextPath != test.want {
+			if contextPath := getRootPath(test.mc); contextPath != test.want {
 				t.Errorf("getContextPath() = %v, want %v", contextPath, test.want)
 			}
 		})

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -257,7 +257,6 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 						LivenessProbe: &v1.Probe{
 							ProbeHandler: v1.ProbeHandler{
 								HTTPGet: &v1.HTTPGetAction{
-									Path:   path.Join(getRootPath(mc), "health"),
 									Port:   intstr.FromInt(8081),
 									Scheme: corev1.URISchemeHTTP,
 								},
@@ -317,6 +316,7 @@ func (r *ManagementCenterReconciler) reconcileStatefulset(ctx context.Context, m
 		sts.Spec.Template.Spec.Containers[0].Image = mc.DockerImage()
 		sts.Spec.Template.Spec.Containers[0].Env = env(ctx, mc, r.Client, logger)
 		sts.Spec.Template.Spec.Containers[0].ImagePullPolicy = mc.Spec.ImagePullPolicy
+		sts.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path = path.Join(getRootPath(mc), "health")
 		if mc.Spec.Resources != nil {
 			sts.Spec.Template.Spec.Containers[0].Resources = *mc.Spec.Resources
 		}

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -509,6 +509,15 @@ func env(ctx context.Context, mc *hazelcastv1alpha1.ManagementCenter, c client.C
 		)
 	}
 
+	if mc.Spec.ExternalConnectivity.IsEnabled() {
+		if mc.Spec.ExternalConnectivity.Ingress.Path != "/" {
+			envs = append(envs, v1.EnvVar{
+				Name:  "MC_CONTEXT_PATH",
+				Value: mc.Spec.ExternalConnectivity.Ingress.Path,
+			})
+		}
+	}
+
 	// This env must be set after MC_LICENSE_KEY env var since it might have a reference
 	// to MC_LICENSE_KEY (e.g. -Dhazelcast.mc.license=$(MC_LICENSE_KEY)).
 	envs = append(envs,

--- a/controllers/managementcenter/managementcenter_resources.go
+++ b/controllers/managementcenter/managementcenter_resources.go
@@ -574,8 +574,7 @@ func javaOPTS(mc *hazelcastv1alpha1.ManagementCenter) string {
 	}
 
 	if mc.Spec.GetLicenseKeySecretName() != "" {
-		licenseKeyEnvVarReference := fmt.Sprintf("$(%s)", mcLicenseKey)
-		args = append(args, fmt.Sprintf("-Dhazelcast.mc.license=%s", licenseKeyEnvVarReference))
+		args = append(args, fmt.Sprintf("-Dhazelcast.mc.license=$(%s)", mcLicenseKey))
 	}
 
 	if mc.Spec.ExternalConnectivity.IsEnabled() && mc.Spec.ExternalConnectivity.Ingress != nil {

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -2878,6 +2878,10 @@ spec:
                       ingressClassName:
                         description: IngressClassName of the ingress object.
                         type: string
+                      path:
+                        default: /
+                        description: Path of the ingress rule.
+                        type: string
                     required:
                     - hostname
                     type: object

--- a/test/integration/hazelcast_config_test.go
+++ b/test/integration/hazelcast_config_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Hazelcast Config Secret", func() {
 			}
 			hz.Spec.CustomConfigCmName = cm.Name
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			hzConfig := GetHzConfig(hz)
 			Expect(hzConfig).Should(And(
@@ -104,7 +104,7 @@ var _ = Describe("Hazelcast Config Secret", func() {
 			}
 			hz.Spec.CustomConfigCmName = cm.Name
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			hzConfig := GetHzConfig(hz)
 			Expect(hzConfig).Should(HaveKey("user-code-deployment"))
@@ -132,7 +132,7 @@ var _ = Describe("Hazelcast Config Secret", func() {
 			}
 			hz.Spec.CustomConfigCmName = cm.Name
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			hzConfig := GetHzConfig(hz)
 			Expect(hzConfig).Should(HaveKey("advanced-network"))

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Hazelcast Properties", func() {
 			}
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			Eventually(func() map[string]string {
 				cfg := getSecret(hz)
@@ -70,7 +70,7 @@ var _ = Describe("Hazelcast Properties", func() {
 			}
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			Eventually(func() map[string]string {
 				cfg := getSecret(hz)

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("ensuring the finalizer added successfully")
@@ -216,7 +216,7 @@ var _ = Describe("Hazelcast CR", func() {
 					ObjectMeta: randomObjectMeta(namespace),
 				}
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 				ensureSpecEquals(fetchedCR, emptyHzSpecValues)
 			})
 
@@ -236,9 +236,9 @@ var _ = Describe("Hazelcast CR", func() {
 				assertExists(lookupKey(licenseSecret), licenseSecret)
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 				update(fetchedCR, removeSpec)
-				fetchedCR = ensureHzStatusIsPending(fetchedCR)
+				fetchedCR = assertHzStatusIsPending(fetchedCR)
 				ensureSpecEquals(fetchedCR, emptyHzSpecValues)
 			})
 		})
@@ -283,7 +283,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			Expect(fetchedCR.Spec.ExposeExternally.Type).Should(Equal(hazelcastv1alpha1.ExposeExternallyTypeUnisocket))
 			Expect(fetchedCR.Spec.ExposeExternally.DiscoveryServiceType).Should(Equal(corev1.ServiceTypeNodePort))
 
@@ -308,7 +308,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			Expect(fetchedCR.Spec.ExposeExternally.Type).Should(Equal(hazelcastv1alpha1.ExposeExternallyTypeSmart))
 			Expect(fetchedCR.Spec.ExposeExternally.DiscoveryServiceType).Should(Equal(corev1.ServiceTypeNodePort))
 			Expect(fetchedCR.Spec.ExposeExternally.MemberAccess).Should(Equal(hazelcastv1alpha1.MemberAccessNodePortExternalIP))
@@ -343,21 +343,21 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			fetchServices(fetchedCR, 4)
 
 			By("scaling the cluster to 6 members")
-			fetchedCR = ensureHzStatusIsPending(hz)
+			fetchedCR = assertHzStatusIsPending(hz)
 			update(fetchedCR, setClusterSize(6))
 			fetchedCR = fetchHz(fetchedCR)
-			ensureHzStatusIsPending(fetchedCR)
+			assertHzStatusIsPending(fetchedCR)
 			fetchServices(fetchedCR, 7)
 
 			By("scaling the cluster to 1 member")
-			fetchedCR = ensureHzStatusIsPending(hz)
+			fetchedCR = assertHzStatusIsPending(hz)
 			update(fetchedCR, setClusterSize(1))
 			fetchedCR = fetchHz(fetchedCR)
-			ensureHzStatusIsPending(fetchedCR)
+			assertHzStatusIsPending(fetchedCR)
 			fetchServices(fetchedCR, 2)
 		})
 
@@ -376,23 +376,23 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			fetchServices(fetchedCR, 4)
 
 			By("updating type to unisocket")
-			fetchedCR = ensureHzStatusIsPending(fetchedCR)
+			fetchedCR = assertHzStatusIsPending(fetchedCR)
 			update(fetchedCR, enableUnisocket, disableMemberAccess)
 
 			fetchedCR = fetchHz(fetchedCR)
-			ensureHzStatusIsPending(fetchedCR)
+			assertHzStatusIsPending(fetchedCR)
 			fetchServices(fetchedCR, 1)
 
 			By("updating discovery service to LoadBalancer")
-			fetchedCR = ensureHzStatusIsPending(fetchedCR)
+			fetchedCR = assertHzStatusIsPending(fetchedCR)
 			update(fetchedCR, setDiscoveryViaLoadBalancer)
 
 			fetchedCR = fetchHz(fetchedCR)
-			ensureHzStatusIsPending(fetchedCR)
+			assertHzStatusIsPending(fetchedCR)
 
 			Eventually(func() corev1.ServiceType {
 				serviceList := fetchServices(fetchedCR, 1)
@@ -400,17 +400,17 @@ var _ = Describe("Hazelcast CR", func() {
 			}).Should(Equal(corev1.ServiceTypeLoadBalancer))
 
 			By("updating type to smart")
-			fetchedCR = ensureHzStatusIsPending(fetchedCR)
+			fetchedCR = assertHzStatusIsPending(fetchedCR)
 			update(fetchedCR, enableSmart)
 
 			fetchedCR = fetchHz(fetchedCR)
-			ensureHzStatusIsPending(fetchedCR)
+			assertHzStatusIsPending(fetchedCR)
 			fetchServices(fetchedCR, 4)
 
 			By("deleting expose externally configuration")
 			update(fetchedCR, disableExposeExternally)
 			fetchedCR = fetchHz(fetchedCR)
-			ensureHzStatusIsPending(fetchedCR)
+			assertHzStatusIsPending(fetchedCR)
 			serviceList := fetchServices(fetchedCR, 1)
 			Expect(serviceList.Items[0].Spec.Type).Should(Equal(corev1.ServiceTypeClusterIP))
 		})
@@ -453,7 +453,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			_ = ensureHzStatusIsPending(hz)
+			_ = assertHzStatusIsPending(hz)
 
 			Eventually(func() map[string]string {
 				cfg := getSecret(hz)
@@ -580,7 +580,7 @@ var _ = Describe("Hazelcast CR", func() {
 					},
 				}
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 				fetchedSts := &v1.StatefulSet{}
 				assertExists(lookupKey(hz), fetchedSts)
 				Expect(fetchedSts.Spec.Template.Spec.ImagePullSecrets).Should(Equal(pullSecrets))
@@ -600,7 +600,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 				test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 				Eventually(func() []corev1.TopologySpreadConstraint {
@@ -628,7 +628,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 				test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 				Eventually(func() []corev1.TopologySpreadConstraint {
@@ -670,7 +670,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 				test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 				Eventually(func() []corev1.TopologySpreadConstraint {
@@ -777,7 +777,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("checking the Persistence CR configuration", func() {
@@ -806,7 +806,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			fetchedCR := ensureHzStatusIsPending(hz)
+			fetchedCR := assertHzStatusIsPending(hz)
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("checking the Persistence CR configuration", func() {
@@ -856,7 +856,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			By("checking Role", func() {
 				rbac := &rbacv1.Role{}
@@ -944,7 +944,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 
 				Expect(*fetchedCR.Spec.JVM.Memory.InitialRAMPercentage).Should(Equal(*p))
 				Expect(*fetchedCR.Spec.JVM.Memory.MinRAMPercentage).Should(Equal(*p))
@@ -966,7 +966,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 
 				Expect(*fetchedCR.Spec.JVM.GC.Logging).Should(Equal(true))
 				Expect(*fetchedCR.Spec.JVM.GC.Collector).Should(Equal(s))
@@ -1178,7 +1178,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				fetchedCR := ensureHzStatusIsPending(hz)
+				fetchedCR := assertHzStatusIsPending(hz)
 				test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 				Eventually(func() int {
@@ -1247,7 +1247,7 @@ var _ = Describe("Hazelcast CR", func() {
 				assertExists(lookupKey(licenseSecret), licenseSecret)
 
 				create(hz)
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 				hz.Spec = secondSpec
 				update(hz)
 				ss := getStatefulSet(hz)
@@ -1317,7 +1317,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 				ss := getStatefulSet(hz)
 
 				By("checking if StatefulSet has the ConfigMap Volumes")
@@ -1381,7 +1381,7 @@ var _ = Describe("Hazelcast CR", func() {
 
 				create(hz)
 
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 				Expect(hz.Spec.Repository).Should(Equal(n.HazelcastEERepo))
 			})
 		})
@@ -1494,7 +1494,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 
 				Eventually(func() config.AdvancedNetwork {
 					cfg := getSecret(hz)
@@ -1578,7 +1578,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 
 				Eventually(func() config.AdvancedNetwork {
 					cfg := getSecret(hz)
@@ -1678,7 +1678,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 
 				Eventually(func() bool {
 					cfg := getSecret(hz)
@@ -1744,7 +1744,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 
 				Eventually(func() bool {
 					cfg := getSecret(hz)
@@ -1770,7 +1770,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 
 				rbac := &rbacv1.Role{}
 				Expect(k8sClient.Get(
@@ -1818,7 +1818,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				ensureHzStatusIsPending(hz)
+				assertHzStatusIsPending(hz)
 
 				Eventually(func() bool {
 					configMap := getSecret(hz)
@@ -1978,7 +1978,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				_ = ensureHzStatusIsPending(hz)
+				_ = assertHzStatusIsPending(hz)
 
 				Eventually(func() config.Jet {
 					cfg := getSecret(hz)
@@ -2002,7 +2002,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				_ = ensureHzStatusIsPending(hz)
+				_ = assertHzStatusIsPending(hz)
 
 				Eventually(func() bool {
 					cfg := getSecret(hz)
@@ -2075,7 +2075,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 
 				Expect(hz.Spec.JetEngineConfiguration.Instance.LosslessRestartEnabled).Should(BeTrue())
 			})
@@ -2143,7 +2143,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 				ss := getStatefulSet(hz)
 
 				By("Checking if StatefulSet has the ConfigMap Volumes")
@@ -2210,7 +2210,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 
 				Expect(hz.Spec.SQL.CatalogPersistenceEnabled).Should(BeTrue())
 			})
@@ -2237,7 +2237,7 @@ var _ = Describe("Hazelcast CR", func() {
 				}
 
 				create(hz)
-				hz = ensureHzStatusIsPending(hz)
+				hz = assertHzStatusIsPending(hz)
 				Expect(hz.Spec.SQL.CatalogPersistenceEnabled).Should(BeTrue())
 
 				hz.Spec.SQL.CatalogPersistenceEnabled = false
@@ -2270,7 +2270,7 @@ var _ = Describe("Hazelcast CR", func() {
 			}
 
 			create(hz)
-			ensureHzStatusIsPending(hz)
+			assertHzStatusIsPending(hz)
 
 			resources := map[string]client.Object{
 				"Secret":         &corev1.Secret{},

--- a/test/integration/managementcenter_test.go
+++ b/test/integration/managementcenter_test.go
@@ -279,9 +279,8 @@ var _ = Describe("ManagementCenter CR", func() {
 			fetchedSts := &appsv1.StatefulSet{}
 			assertExists(lookupKey(fetchedMc), fetchedSts)
 			Expect(fetchedSts.Spec.Template.Spec.Containers).To(HaveLen(1))
-			assertEnvVar(fetchedSts.Spec.Template.Spec.Containers[0], "JAVA_OPTS", func(envvar corev1.EnvVar) bool {
-				return strings.Contains(envvar.Value, "-Dhazelcast.mc.contextPath=/mc")
-			})
+			Expect(fetchedSts.Spec.Template.Spec.Containers[0].Env).
+				Should(ContainElements(ContainSubstring("-Dhazelcast.mc.contextPath=/mc")))
 
 			By("checking liveness probe path")
 			Expect(fetchedSts.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path).Should(Equal("/mc/health"))

--- a/test/integration/managementcenter_test.go
+++ b/test/integration/managementcenter_test.go
@@ -214,7 +214,10 @@ var _ = Describe("ManagementCenter CR", func() {
 
 			Update(fetchedMc)
 			fetchedMc = EnsureStatusIsPending(mc)
-			Expect(fetchedMc.Spec.ExternalConnectivity.Ingress).Should(Equal(externalConnectivityIngress))
+
+			expectedExternalConnectivityIngress := externalConnectivityIngress.DeepCopy()
+			expectedExternalConnectivityIngress.Path = "/"
+			Expect(fetchedMc.Spec.ExternalConnectivity.Ingress).Should(Equal(expectedExternalConnectivityIngress))
 			assertExists(lookupKey(mc), ing)
 			Expect(*ing.Spec.IngressClassName).Should(Equal(externalConnectivityIngress.IngressClassName))
 			Expect(ing.Annotations).Should(Equal(externalConnectivityIngress.Annotations))
@@ -253,7 +256,7 @@ var _ = Describe("ManagementCenter CR", func() {
 			assertDoesNotExist(lookupKey(mc), ing)
 		})
 
-		It("should configure contextPath when custom path is set in Ingress", func() {
+		It("should configure contextPath when custom path is set in Ingress", Label("fast"), func() {
 			mc := &hazelcastv1alpha1.ManagementCenter{
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.ManagementCenterSpec(defaultMcSpecValues(), ee),

--- a/test/integration/managementcenter_test.go
+++ b/test/integration/managementcenter_test.go
@@ -256,7 +256,7 @@ var _ = Describe("ManagementCenter CR", func() {
 			assertDoesNotExist(lookupKey(mc), ing)
 		})
 
-		FIt("should configure contextPath in MC pod when custom path is set in Ingress", Label("fast"), func() {
+		It("should configure contextPath in MC pod when custom path is set in Ingress", Label("fast"), func() {
 			mc := &hazelcastv1alpha1.ManagementCenter{
 				ObjectMeta: randomObjectMeta(namespace),
 				Spec:       test.ManagementCenterSpec(defaultMcSpecValues(), ee),

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -150,16 +150,6 @@ func assertHzStatusIsPending(hz *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1
 	return hz
 }
 
-func assertEnvVar(cnt corev1.Container, name string, f func(corev1.EnvVar) bool) {
-	for _, envvar := range cnt.Env {
-		if envvar.Name == name {
-			Expect(f(envvar)).To(BeTrue())
-			return
-		}
-	}
-	Fail(fmt.Sprintf("env var %q not found", name))
-}
-
 func fetchHz(hz *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1.Hazelcast {
 	By("fetching Hazelcast CR")
 	fetchedCR := &hazelcastv1alpha1.Hazelcast{}

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -141,13 +141,23 @@ func randomObjectMeta(ns string, annotations ...string) metav1.ObjectMeta {
 	}
 }
 
-func ensureHzStatusIsPending(hz *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1.Hazelcast {
+func assertHzStatusIsPending(hz *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1.Hazelcast {
 	By("ensuring that the status is correct")
 	Eventually(func() hazelcastv1alpha1.Phase {
 		hz = fetchHz(hz)
 		return hz.Status.Phase
 	}, timeout, interval).Should(Equal(hazelcastv1alpha1.Pending))
 	return hz
+}
+
+func assertEnvVar(cnt corev1.Container, name string, f func(corev1.EnvVar) bool) {
+	for _, envvar := range cnt.Env {
+		if envvar.Name == name {
+			Expect(f(envvar)).To(BeTrue())
+			return
+		}
+	}
+	Fail(fmt.Sprintf("env var %q not found", name))
 }
 
 func fetchHz(hz *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1.Hazelcast {


### PR DESCRIPTION
## Description

Ingress `path` section in external connectivity is exposed in MC.

## User Impact

The ingress path for external connectivity in the Management Center CR is configurable.