### PR TITLE
Remove explicit skip checks

### DIFF
--- a/.github/workflows/e2e-platform-misc.yaml
+++ b/.github/workflows/e2e-platform-misc.yaml
@@ -107,7 +107,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             GKE_SA_KEY,CN/GKE_SA_KEY
@@ -169,7 +169,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             GKE_SA_KEY,CN/GKE_SA_KEY
@@ -296,7 +296,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             SLACK_WEBHOOK_URL,CN/SLACK_WEBHOOK_URL

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,11 +60,11 @@ jobs:
       - name: Check if tests are unfocused
         if: ${{ !cancelled() }}
         run: |
-           make ginkgo
-           if [[ $($(make ginkgo PRINT_TOOL_NAME=true) unfocus | wc -l) -gt 1 ]]; then
-             echo "Some tests have 'F' before the test name. Run the 'ginkgo unfocus' command against your branch '${{ github.event.pull_request.head.ref }}' and push the changes."
-             exit 1
-           fi
+          make ginkgo
+          if [[ $($(make ginkgo PRINT_TOOL_NAME=true) unfocus | wc -l) -gt 1 ]]; then
+            echo "Some tests have 'F' before the test name. Run the 'ginkgo unfocus' command against your branch '${{ github.event.pull_request.head.ref }}' and push the changes."
+            exit 1
+          fi
 
       - name: Check if all manifests are synced
         run: |
@@ -81,12 +81,12 @@ jobs:
       - name: Check formating
         if: ${{ !cancelled() }}
         run: |
-           make fmt
+          make fmt
 
       - name: Run vet tool
         if: ${{ !cancelled() }}
         run: |
-           make vet
+          make vet
 
   unit-tests:
     name: Run unit and integration tests
@@ -273,33 +273,33 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
-              kubectl create namespace ${NAMESPACE}
-              kubectl config set-context --current --namespace=$NAMESPACE
-              kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
-              kubectl wait --for=condition=ready --timeout=60s -n metallb-system pod -l app=metallb
-              HOST_MIN=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.200/p')
-              HOST_MAX=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.250/p')
-              IP_RANGE=$HOST_MIN-$HOST_MAX
+            kubectl create namespace ${NAMESPACE}
+            kubectl config set-context --current --namespace=$NAMESPACE
+            kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
+            kubectl wait --for=condition=ready --timeout=60s -n metallb-system pod -l app=metallb
+            HOST_MIN=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.200/p')
+            HOST_MAX=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.250/p')
+            IP_RANGE=$HOST_MIN-$HOST_MAX
 
-              cat <<EOF | kubectl apply -f -
-              apiVersion: metallb.io/v1beta1
-              kind: IPAddressPool
-              metadata:
-                name: kind-pool
-                namespace: metallb-system
-              spec:
-                addresses:
-                - $IP_RANGE
-              ---
-              apiVersion: metallb.io/v1beta1
-              kind: L2Advertisement
-              metadata:
-                name: l2
-                namespace: metallb-system
-              spec:
-                ipAddressPools:
-                - kind-pool
-              EOF
+            cat <<EOF | kubectl apply -f -
+            apiVersion: metallb.io/v1beta1
+            kind: IPAddressPool
+            metadata:
+              name: kind-pool
+              namespace: metallb-system
+            spec:
+              addresses:
+              - $IP_RANGE
+            ---
+            apiVersion: metallb.io/v1beta1
+            kind: L2Advertisement
+            metadata:
+              name: l2
+              namespace: metallb-system
+            spec:
+              ipAddressPools:
+              - kind-pool
+            EOF
 
       - name: Create Secrets
         if: matrix.edition == 'ee'

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -74,9 +74,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 
 	Context("The hot backup process", func() {
 		It("triggers successfully", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 
 			setLabelAndCRName("br-1")
 			clusterSize := int32(3)
@@ -107,9 +104,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("starts after the cluster becomes ready", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-2")
 			clusterSize := int32(1)
 			hazelcast := hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
@@ -130,9 +124,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 
 		It("is interrupted when the HotBackup CR is deleted", Tag(Fast|EE|AnyCloud), func() {
 			setLabelAndCRName("br-3")
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			ctx := context.Background()
 			bucketURI := "gs://operator-e2e-external-backup"
 			secretName := "br-secret-gcp"
@@ -200,9 +191,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("fails when external backup credentials are incorrect", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-4")
 			ctx := context.Background()
 			clusterSize := int32(1)
@@ -258,9 +246,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("triggers multiple times using CronHotBackup", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-5")
 			By("creating cron hot backup")
 			hbSpec := &hazelcastcomv1alpha1.HotBackupSpec{}
@@ -287,9 +272,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should backup, restore and backup data again successfully", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-6")
 			var mapSizeInMb = 1072
 			var additionalEntries = 111
@@ -363,9 +345,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 
 	Context("Restoring and verifying data", func() {
 		It("should restore from LocalBackup using PVC and HotBackupResourceName", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-7")
 			clusterSize := int32(3)
 
@@ -375,9 +354,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should restore 3 GB from an external backup using a GCP bucket", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-8")
 			ctx := context.Background()
 			var mapSizeInMb = 3072
@@ -446,9 +422,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should restore multiple times from HotBackupResourceName", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-8")
 			clusterSize := int32(3)
 
@@ -509,9 +482,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should check cache entry persistence after HotBackup", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-9")
 			clusterSize := int32(3)
 
@@ -555,9 +525,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		DescribeTable("when restoring from ExternalBackup", func(bucketURI, secretName string, useBucketConfig bool) {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-10")
 			By("creating cluster with backup enabled")
 			clusterSize := int32(3)
@@ -576,9 +543,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 	Context("Startup actions configuration", func() {
 		DescribeTable("should start the cluster successfully triggering",
 			func(action hazelcastcomv1alpha1.PersistenceStartupAction, dataPolicy hazelcastcomv1alpha1.DataRecoveryPolicyType) {
-				if !ee {
-					Skip("This test will only run in EE configuration")
-				}
 				setLabelAndCRName("br-11")
 				clusterSize := int32(3)
 

--- a/test/e2e/cache_test.go
+++ b/test/e2e/cache_test.go
@@ -54,9 +54,6 @@ var _ = Describe("Hazelcast Cache Config", Group("cache"), func() {
 		})
 
 		It("should persist and remove cache config in/from Hazelcast config", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hch-2")
 			caches := []string{"cache1", "cache2", "cache3", "cachefail"}
 			hazelcast := hazelcastconfig.Default(hzLookupKey, ee, labels)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,9 +1,10 @@
 package e2e
 
 import (
-	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"fmt"
 	"testing"
 
+	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
@@ -30,7 +31,12 @@ var controllerManagerName = types.NamespacedName{
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, GetSuiteName())
+	suiteConfig, _ := GinkgoConfiguration()
+	if ee {
+		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[EE])
+	}
+
+	RunSpecs(t, GetSuiteName(), suiteConfig)
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
+	ginkgoTypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,11 +33,17 @@ var controllerManagerName = types.NamespacedName{
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	suiteConfig, _ := GinkgoConfiguration()
-	if ee {
-		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[EE])
-	}
+	SetLicenseLabelFilters(&suiteConfig)
 
 	RunSpecs(t, GetSuiteName(), suiteConfig)
+}
+
+func SetLicenseLabelFilters(suiteConfig *ginkgoTypes.SuiteConfig) {
+	if ee {
+		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[EE])
+	} else {
+		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[OS])
+	}
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -121,9 +121,6 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 
 	Context("Cluster deletion", func() {
 		It("should delete dependent data structures and backups on Hazelcast CR deletion", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("h-6")
 			clusterSize := int32(3)
 
@@ -159,9 +156,6 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 
 	Context("TLS Configuration", func() {
 		It("should form a cluster with TLS configuration enabled", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("h-7")
 			hz := hazelcastconfig.HazelcastTLS(hzLookupKey, ee, labels)
 
@@ -182,9 +176,6 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 		})
 
 		It("should support mutual TLS authentication in Hazelcast cluster", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("h-8")
 			hz := hazelcastconfig.HazelcastMTLS(hzLookupKey, ee, labels)
 

--- a/test/e2e/jetjob_test.go
+++ b/test/e2e/jetjob_test.go
@@ -173,9 +173,6 @@ var _ = Describe("Hazelcast JetJob", Group("jetjob"), func() {
 		})
 
 		It("persists JetJob on a new cluster when LosslessRestartEnabled", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			longRunJar := "jet-pipeline-longrun-2.0.0.jar"
 			setLabelAndCRName("jj-5")
 

--- a/test/e2e/jetjobsnapshot_test.go
+++ b/test/e2e/jetjobsnapshot_test.go
@@ -37,10 +37,6 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 
 	Context("JetJob snapshot utilization", func() {
 		It("should export snapshot and initialize new job from that snapshot", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-
 			setLabelAndCRName("jjs-1")
 
 			hazelcast := hazelcastconfig.JetConfigured(hzLookupKey, ee, labels)
@@ -155,10 +151,6 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 
 	Context("Operational behavior", func() {
 		It("cancel the JetJob after successful snapshot export", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-
 			setLabelAndCRName("jjs-2")
 
 			hazelcast := hazelcastconfig.JetConfigured(hzLookupKey, ee, labels)
@@ -187,10 +179,6 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 		})
 
 		It("fails when export snapshot from a suspended JetJob", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-
 			setLabelAndCRName("jjs-3")
 
 			hazelcast := hazelcastconfig.JetConfigured(hzLookupKey, ee, labels)

--- a/test/e2e/management_center_test.go
+++ b/test/e2e/management_center_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
-	"github.com/hazelcast/hazelcast-platform-operator/internal/platform"
 	mcconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/managementcenter"
 )
 

--- a/test/e2e/management_center_test.go
+++ b/test/e2e/management_center_test.go
@@ -124,9 +124,6 @@ var _ = Describe("Management-Center", Group("mc"), func() {
 
 	Context("ManagementCenter CR with Route", func() {
 		It("should be able to access route in Openshift env.", Tag(Fast|AnyLicense|OCP), func() {
-			if platform.GetType() != platform.OpenShift {
-				Skip("This test will only run in OpenShift environments")
-			}
 			setLabelAndCRName("mc-4")
 			mc := mcconfig.RouteEnabled(mcLookupKey, ee, labels)
 			create(mc)

--- a/test/e2e/map_test.go
+++ b/test/e2e/map_test.go
@@ -154,9 +154,6 @@ var _ = Describe("Hazelcast Map - ", Group("map"), func() {
 		})
 
 		It("persist and removed map config in/from Hazelcast config", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hm-4")
 			maps := []string{"map1", "map2", "map3", "mapfail"}
 

--- a/test/e2e/multi_ns_test.go
+++ b/test/e2e/multi_ns_test.go
@@ -61,9 +61,6 @@ var _ = Describe("Hazelcast Multi-Namespace", Group("multi_namespace"), func() {
 					setCRNamespace(deployNamespace)
 				}
 
-				if !ee {
-					Skip("This test will only run in EE configuration")
-				}
 				setLabelAndCRName("mns-2")
 				clusterSize := int32(3)
 

--- a/test/e2e/paltform_wan_test.go
+++ b/test/e2e/paltform_wan_test.go
@@ -39,9 +39,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 3 GB data by each cluster in active-passive mode in the different namespaces", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		SwitchContext(context1)
 		setupEnv()
 		setLabelAndCRName("hpwan-1")
@@ -103,9 +100,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 6 GB data by each cluster in active-active mode in the different namespaces", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		SwitchContext(context1)
 		setupEnv()
 		var mapSizeInMb = 1024
@@ -238,9 +232,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 3 GB data by each cluster in active-passive mode in the different GKE clusters", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hpwan-3")
 		var mapSizeInMb = 1024
 		/**
@@ -311,9 +302,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 6 GB data by each cluster in active-active mode in the different GKE clusters", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		var mapSizeInMb = 1024
 		/**
 		2 (entries per single goroutine) = 1048576  (Bytes per 1Mb)  / 8192 (Bytes per entry) / 64 (goroutines)

--- a/test/e2e/platform_persistence_test.go
+++ b/test/e2e/platform_persistence_test.go
@@ -36,9 +36,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should successfully start after one member restart", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-1")
 		ctx := context.Background()
 		clusterSize := int32(3)
@@ -75,9 +72,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should restore 3 GB data after planned shutdown", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-2")
 		var mapSizeInMb = 3072
 		var pvcSizeInMb = mapSizeInMb * 2 // Taking backup duplicates the used storage
@@ -142,9 +136,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should not start repartitioning after one member restart", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-3")
 		ctx := context.Background()
 		clusterSize := int32(3)
@@ -187,9 +178,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should not start repartitioning after planned shutdown", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-4")
 		ctx := context.Background()
 		clusterSize := int32(3)
@@ -248,9 +236,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should persist SQL mappings", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-5")
 
 		hazelcast := hazelcastconfig.HazelcastSQLPersistence(hzLookupKey, 1, labels)
@@ -275,9 +260,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	DescribeTable("Hazelcast", func(policyType hazelcastcomv1alpha1.DataRecoveryPolicyType, mapNameSuffix string) {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-6")
 		var mapSizeInMb = 500
 		var pvcSizeInMb = 14500

--- a/test/e2e/platform_resilience_test.go
+++ b/test/e2e/platform_resilience_test.go
@@ -84,9 +84,6 @@ var _ = Describe("Platform Resilience Tests", Group("resilience"), func() {
 	})
 
 	It("should kill the pod randomly and preserve the data after restore", Tag(Slow|Any), Serial, func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hr-3")
 		duration := "30s"
 		mapSizeInMb := 500

--- a/test/e2e/platform_rolling_upgrade_test.go
+++ b/test/e2e/platform_rolling_upgrade_test.go
@@ -33,9 +33,6 @@ var _ = Describe("Platform Rolling UpgradeTests", Group("rolling_upgrade"), func
 	})
 
 	It("should upgrade HZ version after pause/resume with 7999 partition count", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hra-1")
 		var mapSizeInMb = 500
 		var pvcSizeInMb = 14500

--- a/test/e2e/platform_rollout_restart_test.go
+++ b/test/e2e/platform_rollout_restart_test.go
@@ -32,9 +32,6 @@ var _ = Describe("Platform Rollout Restart Tests", Group("rollout_restart"), fun
 	})
 
 	It("should perform rollout restart with 14Gb data", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hrr-1")
 		var mapSizeInMb = 500
 		var pvcSizeInMb = 14500

--- a/test/e2e/platform_soak_test.go
+++ b/test/e2e/platform_soak_test.go
@@ -33,10 +33,6 @@ var _ = Describe("Platform Soak Tests", Group("soak"), func() {
 	})
 
 	It("should upgrade HZ version after pause/resume with default partition count during 4 hours and keep 45 GB data", Serial, Tag(Slow|EE|AnyCloud), func() {
-
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("soak-1")
 		var pvcSizeInMb = 14500
 		var pauseBetweenFills = 4 * Minute

--- a/test/e2e/wan_sync_test.go
+++ b/test/e2e/wan_sync_test.go
@@ -27,9 +27,6 @@ var _ = Describe("Hazelcast WAN Sync", Group("wan_sync"), func() {
 
 	Context("Basic WAN Sync functionality", func() {
 		It("should sync one map with another cluster", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hws-1")
 
 			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
@@ -51,9 +48,6 @@ var _ = Describe("Hazelcast WAN Sync", Group("wan_sync"), func() {
 		})
 
 		It("should sync two maps with another cluster", Tag(Fast|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hws-2")
 
 			// Hazelcast and Map CRs

--- a/test/e2e/wan_test.go
+++ b/test/e2e/wan_test.go
@@ -34,9 +34,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 
 	Context("Basic WAN Replication functionality", func() {
 		It("successfully replicates data to another cluster", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hw-1")
 
 			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
@@ -57,9 +54,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("maintains replication after source members restart", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hw-2")
 
 			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
@@ -87,9 +81,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 
 	Context("Handling WAN Replication status", func() {
 		It("sets WAN status to 'Failed' when delete Map CR which present as a Map resource in WAN spec", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-3")
 
 			// Hazelcast and Map CRs
@@ -120,9 +111,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("sets WAN status to 'Pending' when delete Map which present as a Hazelcast resource in WAN spec", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-4")
 
 			// Hazelcast and Map CRs
@@ -152,9 +140,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("sets WAN status to 'Success' when resource map is created after the WAN CR", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-5")
 
 			// Hazelcast CRs
@@ -220,9 +205,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 
 	Context("Updating WAN configuration", func() {
 		It("initially fails after removal of replicated Hazelcast CR, then succeeds after removal it from the WAN spec", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-6")
 
 			// Hazelcast and Map CRs
@@ -264,9 +246,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("stops replication for maps removed from WAN spec", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-7")
 
 			// Hazelcast and Map CRs
@@ -332,9 +311,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("continues replication when 1 of 2 maps references is deleted from WAN spec", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-8")
 
 			// Hazelcast and Map CRs
@@ -367,9 +343,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("verifies replication initiation for maps added after WAN setup", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-9")
 
 			// Hazelcast CRs
@@ -440,9 +413,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("handles different map names for target cluster replication", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-10")
 
 			// Hazelcast and Map CRs


### PR DESCRIPTION
## Description

Add `&& EE` label condition by overriding the label-selector before starting the suite when the `--ee` flag is passed.
https://onsi.github.io/ginkgo/#overriding-ginkgos-command-line-configuration-in-the-suite

This is how we set license (`EE`, `OS`) labelFilter regarding the `--ee` flag.

```go
func SetLicenseLabelFilters(suiteConfig *ginkgoTypes.SuiteConfig) {
	if ee {
		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[EE])
	} else {
		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[OS])
	}
}
```

## User Impact
