### PR TITLE
[CN-1100]: remove base-dir

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -624,10 +624,6 @@ type AgentConfiguration struct {
 
 // HazelcastPersistenceConfiguration contains the configuration for Hazelcast Persistence and K8s storage.
 type HazelcastPersistenceConfiguration struct {
-	// Persistence base directory.
-	// +required
-	BaseDir string `json:"baseDir"`
-
 	// Configuration of the cluster recovery strategy.
 	// +kubebuilder:default:="FullRecoveryOnly"
 	// +optional

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
 	"reflect"
 	"regexp"
 	"sort"
@@ -212,10 +211,6 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 	if p.StartupAction == PartialStart && p.ClusterDataRecoveryPolicy == FullRecovery {
 		v.Forbidden(Path("spec", "persistence", "startupAction"), "PartialStart can be used only with Partial clusterDataRecoveryPolicy")
 	}
-
-	if !path.IsAbs(p.BaseDir) {
-		v.Invalid(Path("spec", "persistence", "baseDir"), p.BaseDir, "must be absolute path")
-	}
 }
 
 func (v *hazelcastValidator) validateClusterSize(h *Hazelcast) {
@@ -364,9 +359,6 @@ func (v *hazelcastValidator) validateNotUpdatableHzPersistenceFields(current, la
 	if current != nil && last == nil {
 		v.Forbidden(Path("spec", "persistence"), "field cannot be disabled after creation")
 		return
-	}
-	if current.BaseDir != last.BaseDir {
-		v.Forbidden(Path("spec", "persistence", "baseDir"), "field cannot be updated")
 	}
 	if !reflect.DeepEqual(current.Pvc, last.Pvc) {
 		v.Forbidden(Path("spec", "persistence", "pvc"), "field cannot be updated")

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -482,9 +482,6 @@ spec:
               persistence:
                 description: Persistence configuration
                 properties:
-                  baseDir:
-                    description: Persistence base directory.
-                    type: string
                   clusterDataRecoveryPolicy:
                     default: FullRecoveryOnly
                     description: Configuration of the cluster recovery strategy.
@@ -559,8 +556,6 @@ spec:
                     - ForceStart
                     - PartialStart
                     type: string
-                required:
-                - baseDir
                 type: object
               properties:
                 additionalProperties:

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1069,8 +1069,8 @@ func hazelcastBasicConfig(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 	if h.Spec.Persistence.IsEnabled() {
 		cfg.Persistence = config.Persistence{
 			Enabled:                   pointer.Bool(true),
-			BaseDir:                   h.Spec.Persistence.BaseDir,
-			BackupDir:                 path.Join(h.Spec.Persistence.BaseDir, "hot-backup"),
+			BaseDir:                   n.BaseDir,
+			BackupDir:                 path.Join(n.BaseDir, "hot-backup"),
 			Parallelism:               1,
 			ValidationTimeoutSec:      120,
 			ClusterDataRecoveryPolicy: clusterDataRecoveryPolicy(h.Spec.Persistence.ClusterDataRecoveryPolicy),
@@ -2179,7 +2179,7 @@ func restoreAgentContainer(h *hazelcastv1alpha1.Hazelcast, secretName, bucket st
 			},
 			{
 				Name:  "RESTORE_DESTINATION",
-				Value: h.Spec.Persistence.BaseDir,
+				Value: n.BaseDir,
 			},
 			{
 				Name:  "RESTORE_ID",
@@ -2199,7 +2199,7 @@ func restoreAgentContainer(h *hazelcastv1alpha1.Hazelcast, secretName, bucket st
 		TerminationMessagePolicy: "File",
 		VolumeMounts: []v1.VolumeMount{{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		}},
 		SecurityContext: containerSecurityContext(),
 	}
@@ -2220,7 +2220,7 @@ func restoreLocalAgentContainer(h *hazelcastv1alpha1.Hazelcast, backupFolder str
 			},
 			{
 				Name:  "RESTORE_LOCAL_BACKUP_BASE_DIR",
-				Value: h.Spec.Persistence.BaseDir,
+				Value: n.BaseDir,
 			},
 			{
 				Name:  "RESTORE_LOCAL_ID",
@@ -2240,7 +2240,7 @@ func restoreLocalAgentContainer(h *hazelcastv1alpha1.Hazelcast, backupFolder str
 		TerminationMessagePolicy: "File",
 		VolumeMounts: []v1.VolumeMount{{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		}},
 		SecurityContext: containerSecurityContext(),
 	}
@@ -2414,7 +2414,7 @@ func sidecarVolumeMounts(h *hazelcastv1alpha1.Hazelcast) []v1.VolumeMount {
 	if h.Spec.Persistence.IsEnabled() {
 		vm = append(vm, v1.VolumeMount{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		})
 	}
 	return vm
@@ -2438,7 +2438,7 @@ func hzContainerVolumeMounts(h *hazelcastv1alpha1.Hazelcast) []corev1.VolumeMoun
 	if h.Spec.Persistence.IsEnabled() {
 		mounts = append(mounts, v1.VolumeMount{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		})
 	}
 

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -301,7 +301,7 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 				b, err := localbackup.NewLocalBackup(&localbackup.Config{
 					MemberAddress: m.Address,
 					MTLSClient:    mtlsClient,
-					BackupBaseDir: hz.Spec.Persistence.BaseDir,
+					BackupBaseDir: n.BaseDir,
 					MemberID:      i,
 				})
 				if err != nil {
@@ -324,7 +324,7 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 				MemberAddress: m.Address,
 				MTLSClient:    mtlsClient,
 				BucketURI:     hb.Spec.BucketURI,
-				BackupBaseDir: hz.Spec.Persistence.BaseDir,
+				BackupBaseDir: n.BaseDir,
 				HazelcastName: hb.Spec.HazelcastResourceName,
 				SecretName:    hb.Spec.GetSecretName(),
 				MemberID:      i,

--- a/controllers/hazelcast/hot_backup_controller_test.go
+++ b/controllers/hazelcast/hot_backup_controller_test.go
@@ -247,7 +247,6 @@ func TestHotBackupReconciler_shouldFailIfDeletedWhenReferencedByHazelcastRestore
 
 	// enable persistence and restore from the hotbackup
 	h.Spec = hazelcastv1alpha1.HazelcastSpec{Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-		BaseDir: "/baseDir/",
 		Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		},
@@ -356,9 +355,7 @@ func defaultCRs() (types.NamespacedName, *hazelcastv1alpha1.Hazelcast, *hazelcas
 			Namespace: nn.Namespace,
 		},
 		Spec: hazelcastv1alpha1.HazelcastSpec{
-			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "basedir",
-			},
+			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{},
 		},
 		Status: hazelcastv1alpha1.HazelcastStatus{
 			Phase: hazelcastv1alpha1.Running,

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -860,9 +860,6 @@ spec:
               persistence:
                 description: Persistence configuration
                 properties:
-                  baseDir:
-                    description: Persistence base directory.
-                    type: string
                   clusterDataRecoveryPolicy:
                     default: FullRecoveryOnly
                     description: Configuration of the cluster recovery strategy.
@@ -937,8 +934,6 @@ spec:
                     - ForceStart
                     - PartialStart
                     type: string
-                required:
-                - baseDir
                 type: object
               properties:
                 additionalProperties:

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -63,6 +63,7 @@ const (
 	JetConfigMapNamePrefix      = "jet-cm-"
 	UserCodeURLVolumeName       = "user-code-url"
 	UserCodeConfigMapNamePrefix = "user-code-cm-"
+	BaseDir                     = "/data/hot-restart"
 
 	SidecarAgent        = "sidecar-agent"
 	BackupAgentPortName = "backup-agent-port"

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -616,6 +616,7 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 				hazelcast.Spec.Persistence.DataRecoveryTimeout = 60
 				hazelcast.Spec.Persistence.ClusterDataRecoveryPolicy = dataPolicy
 				hazelcast.Spec.Persistence.StartupAction = action
+				hazelcast.Spec.Persistence.Restore.HotBackupResourceName = hotBackup.Name
 				CreateHazelcastCR(hazelcast)
 				evaluateReadyMembers(hzLookupKey)
 				assertClusterStatePortForward(context.Background(), hazelcast, localPort, codecTypes.ClusterStateActive)

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -603,19 +603,15 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 				evaluateReadyMembers(hzLookupKey)
 
 				By("creating HotBackup CR")
-				t := Now()
 				hotBackup := hazelcastconfig.HotBackup(hbLookupKey, hazelcast.Name, labels)
 				Expect(k8sClient.Create(context.Background(), hotBackup)).Should(Succeed())
 				assertHotBackupSuccess(hotBackup, 1*Minute)
 
-				seq := GetBackupSequence(t, hzLookupKey)
 				RemoveHazelcastCR(hazelcast)
 
 				By("creating new Hazelcast cluster from existing backup with 2 members")
-				baseDir := "/data/hot-restart/hot-backup/backup-" + seq
 
 				hazelcast = hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
-				hazelcast.Spec.Persistence.BaseDir = baseDir
 				hazelcast.Spec.ClusterSize = &[]int32{2}[0]
 				hazelcast.Spec.Persistence.DataRecoveryTimeout = 60
 				hazelcast.Spec.Persistence.ClusterDataRecoveryPolicy = dataPolicy

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -156,7 +156,6 @@ var (
 				LicenseKeySecretName: licenseKey(true),
 				LoggingLevel:         hazelcastcomv1alpha1.LoggingLevelDebug,
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -301,7 +300,6 @@ var (
 					},
 				},
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -334,7 +332,6 @@ var (
 					},
 				},
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -463,7 +460,6 @@ var (
 				Version:              *hazelcastVersion,
 				LicenseKeySecretName: licenseKey(true),
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -724,42 +724,6 @@ var _ = Describe("Hazelcast CR", func() {
 	})
 
 	Context("with Persistence configuration", func() {
-		It("should fail to create with empty baseDir", Label("fast"), func() {
-			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
-			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
-					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				},
-			}
-
-			hz := &hazelcastv1alpha1.Hazelcast{
-				ObjectMeta: randomObjectMeta(namespace),
-				Spec:       spec,
-			}
-
-			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
-		})
-	})
-
-	Context("with Persistence configuration", func() {
-		It("should fail to create with invalid baseDir", Label("fast"), func() {
-			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
-			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
-					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				},
-			}
-
-			hz := &hazelcastv1alpha1.Hazelcast{
-				ObjectMeta: randomObjectMeta(namespace),
-				Spec:       spec,
-			}
-
-			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
-		})
-	})
-
-	Context("with Persistence configuration", func() {
 		It("should create with default values", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -727,7 +727,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should fail to create with empty baseDir", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},
@@ -746,7 +745,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should fail to create with invalid baseDir", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},
@@ -765,7 +763,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should create with default values", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},
@@ -781,7 +778,6 @@ var _ = Describe("Hazelcast CR", func() {
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("checking the Persistence CR configuration", func() {
-				Expect(fetchedCR.Spec.Persistence.BaseDir).Should(Equal("/baseDir/"))
 				Expect(fetchedCR.Spec.Persistence.ClusterDataRecoveryPolicy).
 					Should(Equal(hazelcastv1alpha1.FullRecovery))
 				Expect(fetchedCR.Spec.Persistence.Pvc.AccessModes).Should(ConsistOf(corev1.ReadWriteOnce))
@@ -792,7 +788,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should create volumeClaimTemplates", Label("fast"), func() {
 			s := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			s.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir:                   "/data/hot-restart/",
 				ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -810,7 +805,6 @@ var _ = Describe("Hazelcast CR", func() {
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("checking the Persistence CR configuration", func() {
-				Expect(fetchedCR.Spec.Persistence.BaseDir).Should(Equal("/data/hot-restart/"))
 				Expect(fetchedCR.Spec.Persistence.ClusterDataRecoveryPolicy).
 					Should(Equal(hazelcastv1alpha1.FullRecovery))
 				Expect(fetchedCR.Spec.Persistence.Pvc.AccessModes).Should(ConsistOf(corev1.ReadWriteOnce))
@@ -842,7 +836,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should add RBAC PolicyRule for watch StatefulSets", Label("fast"), func() {
 			s := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			s.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir:                   "/data/hot-restart/",
 				ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -875,7 +868,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should not create PartialStart with FullRecovery", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir:                   "/baseDir/",
 				ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 				StartupAction:             hazelcastv1alpha1.PartialStart,
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
@@ -894,9 +886,7 @@ var _ = Describe("Hazelcast CR", func() {
 
 		It("should not create if pvc is not specified", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
-			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
-			}
+			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{}
 
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
@@ -910,7 +900,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should not create if pvc accessModes is not specified", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					RequestStorage: &[]resource.Quantity{resource.MustParse("8Gi")}[0],
 				},
@@ -1163,7 +1152,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should be deployed as a sidecar container", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -1716,9 +1704,7 @@ var _ = Describe("Hazelcast CR", func() {
 				spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
 					AllocatorType: hazelcastv1alpha1.NativeMemoryStandard,
 				}
-				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir: "/data/hot-restart/",
-				}
+				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{}
 				hz := &hazelcastv1alpha1.Hazelcast{
 					ObjectMeta: randomObjectMeta(namespace),
 					Spec:       spec,
@@ -2056,7 +2042,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should be created successfully if persistence is enabled", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -2194,7 +2179,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should be created successfully if Hazelcast persistence is enabled", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -2218,7 +2202,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should fail to disable catalogPersistence", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/test/integration/hotbackup_test.go
+++ b/test/integration/hotbackup_test.go
@@ -58,7 +58,6 @@ var _ = Describe("HotBackup CR", func() {
 
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},


### PR DESCRIPTION
## Description

Hazelcast CR's `persistence.baseDir` field is not configurable anymore, it will managed by the operator.

## User Impact

Users don't need to configure Hazelcast CR's `persistence.baseDir` field that it will be managed by the operator internally.