### PR TITLE
[CN-1124] Expose WAN port for Member service(a.k.a service-per-pod)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,11 +60,11 @@ jobs:
       - name: Check if tests are unfocused
         if: ${{ !cancelled() }}
         run: |
-           make ginkgo
-           if [[ $($(make ginkgo PRINT_TOOL_NAME=true) unfocus | wc -l) -gt 1 ]]; then
-             echo "Some tests have 'F' before the test name. Run the 'ginkgo unfocus' command against your branch '${{ github.event.pull_request.head.ref }}' and push the changes."
-             exit 1
-           fi
+          make ginkgo
+          if [[ $($(make ginkgo PRINT_TOOL_NAME=true) unfocus | wc -l) -gt 1 ]]; then
+            echo "Some tests have 'F' before the test name. Run the 'ginkgo unfocus' command against your branch '${{ github.event.pull_request.head.ref }}' and push the changes."
+            exit 1
+          fi
 
       - name: Check if all manifests are synced
         run: |
@@ -81,12 +81,12 @@ jobs:
       - name: Check formating
         if: ${{ !cancelled() }}
         run: |
-           make fmt
+          make fmt
 
       - name: Run vet tool
         if: ${{ !cancelled() }}
         run: |
-           make vet
+          make vet
 
   unit-tests:
     name: Run unit and integration tests
@@ -273,33 +273,33 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
-              kubectl create namespace ${NAMESPACE}
-              kubectl config set-context --current --namespace=$NAMESPACE
-              kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
-              kubectl wait --for=condition=ready --timeout=60s -n metallb-system pod -l app=metallb
-              HOST_MIN=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.200/p')
-              HOST_MAX=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.250/p')
-              IP_RANGE=$HOST_MIN-$HOST_MAX
+            kubectl create namespace ${NAMESPACE}
+            kubectl config set-context --current --namespace=$NAMESPACE
+            kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
+            kubectl wait --for=condition=ready --timeout=60s -n metallb-system pod -l app=metallb
+            HOST_MIN=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.200/p')
+            HOST_MAX=$(docker network inspect -f '{{json .IPAM.Config}}' ${{ env.CLUSTER_NAME }} | jq -r '.[0].Subnet' |  sed  -n 's/.0.0.16/.255.250/p')
+            IP_RANGE=$HOST_MIN-$HOST_MAX
 
-              cat <<EOF | kubectl apply -f -
-              apiVersion: metallb.io/v1beta1
-              kind: IPAddressPool
-              metadata:
-                name: kind-pool
-                namespace: metallb-system
-              spec:
-                addresses:
-                - $IP_RANGE
-              ---
-              apiVersion: metallb.io/v1beta1
-              kind: L2Advertisement
-              metadata:
-                name: l2
-                namespace: metallb-system
-              spec:
-                ipAddressPools:
-                - kind-pool
-              EOF
+            cat <<EOF | kubectl apply -f -
+            apiVersion: metallb.io/v1beta1
+            kind: IPAddressPool
+            metadata:
+              name: kind-pool
+              namespace: metallb-system
+            spec:
+              addresses:
+              - $IP_RANGE
+            ---
+            apiVersion: metallb.io/v1beta1
+            kind: L2Advertisement
+            metadata:
+              name: l2
+              namespace: metallb-system
+            spec:
+              ipAddressPools:
+              - kind-pool
+            EOF
 
       - name: Create Secrets
         if: matrix.edition == 'ee'

--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -629,10 +629,6 @@ type AgentConfiguration struct {
 
 // HazelcastPersistenceConfiguration contains the configuration for Hazelcast Persistence and K8s storage.
 type HazelcastPersistenceConfiguration struct {
-	// Persistence base directory.
-	// +required
-	BaseDir string `json:"baseDir"`
-
 	// Configuration of the cluster recovery strategy.
 	// +kubebuilder:default:="FullRecoveryOnly"
 	// +optional

--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
 	"reflect"
 	"regexp"
 	"sort"
@@ -212,10 +211,6 @@ func (v *hazelcastValidator) validatePersistence(h *Hazelcast) {
 	if p.StartupAction == PartialStart && p.ClusterDataRecoveryPolicy == FullRecovery {
 		v.Forbidden(Path("spec", "persistence", "startupAction"), "PartialStart can be used only with Partial clusterDataRecoveryPolicy")
 	}
-
-	if !path.IsAbs(p.BaseDir) {
-		v.Invalid(Path("spec", "persistence", "baseDir"), p.BaseDir, "must be absolute path")
-	}
 }
 
 func (v *hazelcastValidator) validateClusterSize(h *Hazelcast) {
@@ -364,9 +359,6 @@ func (v *hazelcastValidator) validateNotUpdatableHzPersistenceFields(current, la
 	if current != nil && last == nil {
 		v.Forbidden(Path("spec", "persistence"), "field cannot be disabled after creation")
 		return
-	}
-	if current.BaseDir != last.BaseDir {
-		v.Forbidden(Path("spec", "persistence", "baseDir"), "field cannot be updated")
 	}
 	if !reflect.DeepEqual(current.Pvc, last.Pvc) {
 		v.Forbidden(Path("spec", "persistence", "pvc"), "field cannot be updated")

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -482,9 +482,6 @@ spec:
               persistence:
                 description: Persistence configuration
                 properties:
-                  baseDir:
-                    description: Persistence base directory.
-                    type: string
                   clusterDataRecoveryPolicy:
                     default: FullRecoveryOnly
                     description: Configuration of the cluster recovery strategy.
@@ -559,8 +556,6 @@ spec:
                     - ForceStart
                     - PartialStart
                     type: string
-                required:
-                - baseDir
                 type: object
               properties:
                 additionalProperties:

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -474,10 +474,7 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 		return nil
 	}
 
-	isAddWANPort := false
-	if h.Spec.AdvancedNetwork == nil || len(h.Spec.AdvancedNetwork.WAN) == 0 {
-		isAddWANPort = true
-	}
+	isAddWANPort := h.Spec.AdvancedNetwork == nil || len(h.Spec.AdvancedNetwork.WAN) == 0
 	for i := 0; i < int(*h.Spec.ClusterSize); i++ {
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -57,8 +57,7 @@ var DefaultProperties = map[string]string{
 	"hazelcast.cluster.version.auto.upgrade.enabled": "true",
 	// https://docs.hazelcast.com/hazelcast/5.3/kubernetes/kubernetes-auto-discovery#configuration
 	// We added the following properties to here with their default values, because DefaultProperties cannot be overridden
-	"hazelcast.persistence.auto.cluster.state":          "true",
-	"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+	"hazelcast.persistence.auto.cluster.state": "true",
 }
 
 func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -1079,8 +1079,8 @@ func hazelcastBasicConfig(h *hazelcastv1alpha1.Hazelcast) config.Hazelcast {
 	if h.Spec.Persistence.IsEnabled() {
 		cfg.Persistence = config.Persistence{
 			Enabled:                   pointer.Bool(true),
-			BaseDir:                   h.Spec.Persistence.BaseDir,
-			BackupDir:                 path.Join(h.Spec.Persistence.BaseDir, "hot-backup"),
+			BaseDir:                   n.BaseDir,
+			BackupDir:                 path.Join(n.BaseDir, "hot-backup"),
 			Parallelism:               1,
 			ValidationTimeoutSec:      120,
 			ClusterDataRecoveryPolicy: clusterDataRecoveryPolicy(h.Spec.Persistence.ClusterDataRecoveryPolicy),
@@ -2190,7 +2190,7 @@ func restoreAgentContainer(h *hazelcastv1alpha1.Hazelcast, secretName, bucket st
 			},
 			{
 				Name:  "RESTORE_DESTINATION",
-				Value: h.Spec.Persistence.BaseDir,
+				Value: n.BaseDir,
 			},
 			{
 				Name:  "RESTORE_ID",
@@ -2210,7 +2210,7 @@ func restoreAgentContainer(h *hazelcastv1alpha1.Hazelcast, secretName, bucket st
 		TerminationMessagePolicy: "File",
 		VolumeMounts: []v1.VolumeMount{{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		}},
 		SecurityContext: containerSecurityContext(),
 	}
@@ -2231,7 +2231,7 @@ func restoreLocalAgentContainer(h *hazelcastv1alpha1.Hazelcast, backupFolder str
 			},
 			{
 				Name:  "RESTORE_LOCAL_BACKUP_BASE_DIR",
-				Value: h.Spec.Persistence.BaseDir,
+				Value: n.BaseDir,
 			},
 			{
 				Name:  "RESTORE_LOCAL_ID",
@@ -2251,7 +2251,7 @@ func restoreLocalAgentContainer(h *hazelcastv1alpha1.Hazelcast, backupFolder str
 		TerminationMessagePolicy: "File",
 		VolumeMounts: []v1.VolumeMount{{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		}},
 		SecurityContext: containerSecurityContext(),
 	}
@@ -2425,7 +2425,7 @@ func sidecarVolumeMounts(h *hazelcastv1alpha1.Hazelcast) []v1.VolumeMount {
 	if h.Spec.Persistence.IsEnabled() {
 		vm = append(vm, v1.VolumeMount{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		})
 	}
 	return vm
@@ -2449,7 +2449,7 @@ func hzContainerVolumeMounts(h *hazelcastv1alpha1.Hazelcast) []corev1.VolumeMoun
 	if h.Spec.Persistence.IsEnabled() {
 		mounts = append(mounts, v1.VolumeMount{
 			Name:      n.PersistenceVolumeName,
-			MountPath: h.Spec.Persistence.BaseDir,
+			MountPath: n.BaseDir,
 		})
 	}
 

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -474,6 +474,10 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 		return nil
 	}
 
+	isAddWANPort := false
+	if h.Spec.AdvancedNetwork == nil || len(h.Spec.AdvancedNetwork.WAN) == 0 {
+		isAddWANPort = true
+	}
 	for i := 0; i < int(*h.Spec.ClusterSize); i++ {
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -501,7 +505,7 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 				delete(service.Labels, n.ServiceEndpointTypeLabelName)
 			}
 
-			service.Spec.Ports = util.EnrichServiceNodePorts([]corev1.ServicePort{clientPort()}, service.Spec.Ports)
+			service.Spec.Ports = util.EnrichServiceNodePorts(servicePerPodPort(isAddWANPort), service.Spec.Ports)
 			service.Spec.Type = h.Spec.ExposeExternally.MemberAccessServiceType()
 
 			return nil
@@ -582,12 +586,21 @@ func (r *HazelcastReconciler) reconcileHazelcastEndpoints(ctx context.Context, h
 				}
 			}
 		case n.ServiceEndpointTypeMemberLabelValue:
-			endpointNn := types.NamespacedName{
-				Name:      svc.Name,
-				Namespace: svc.Namespace,
-			}
-			hzEndpoints = []*hazelcastv1alpha1.HazelcastEndpoint{
-				hazelcastEndpointFromService(endpointNn, h, hazelcastv1alpha1.HazelcastEndpointTypeMember, clientPort().Port),
+			for _, port := range svc.Spec.Ports {
+				endpointNn := types.NamespacedName{
+					Name:      svc.Name,
+					Namespace: svc.Namespace,
+				}
+				// For the default Wan port when the WANConfig is not configured under the AdvancedNetwork config
+				if port.Name == n.WanDefaultPortName {
+					endpointNn.Name = fmt.Sprintf("%s-%s", endpointNn.Name, "wan")
+					hzEndpoints = append(hzEndpoints, hazelcastEndpointFromService(endpointNn, h, hazelcastv1alpha1.HazelcastEndpointTypeWAN, port.Port))
+					continue
+				}
+				if port.Name == n.HazelcastPortName {
+					hzEndpoints = append(hzEndpoints, hazelcastEndpointFromService(endpointNn, h, hazelcastv1alpha1.HazelcastEndpointTypeMember, port.Port))
+					continue
+				}
 			}
 		case n.ServiceEndpointTypeWANLabelValue:
 			for i, port := range svc.Spec.Ports {
@@ -747,6 +760,16 @@ func servicePerPodLabels(h *hazelcastv1alpha1.Hazelcast) map[string]string {
 	ls := labels(h)
 	ls[n.ServicePerPodLabelName] = n.LabelValueTrue
 	return ls
+}
+
+func servicePerPodPort(isAddWANPort bool) []v1.ServicePort {
+	p := []corev1.ServicePort{
+		clientPort(),
+	}
+	if isAddWANPort {
+		p = append(p, defaultWANPort())
+	}
+	return p
 }
 
 func hazelcastPort(isAddWANPort bool) []v1.ServicePort {

--- a/controllers/hazelcast/hot_backup_controller.go
+++ b/controllers/hazelcast/hot_backup_controller.go
@@ -301,7 +301,7 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 				b, err := localbackup.NewLocalBackup(&localbackup.Config{
 					MemberAddress: m.Address,
 					MTLSClient:    mtlsClient,
-					BackupBaseDir: hz.Spec.Persistence.BaseDir,
+					BackupBaseDir: n.BaseDir,
 					MemberID:      i,
 				})
 				if err != nil {
@@ -324,7 +324,7 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 				MemberAddress: m.Address,
 				MTLSClient:    mtlsClient,
 				BucketURI:     hb.Spec.BucketURI,
-				BackupBaseDir: hz.Spec.Persistence.BaseDir,
+				BackupBaseDir: n.BaseDir,
 				HazelcastName: hb.Spec.HazelcastResourceName,
 				SecretName:    hb.Spec.GetSecretName(),
 				MemberID:      i,

--- a/controllers/hazelcast/hot_backup_controller_test.go
+++ b/controllers/hazelcast/hot_backup_controller_test.go
@@ -247,7 +247,6 @@ func TestHotBackupReconciler_shouldFailIfDeletedWhenReferencedByHazelcastRestore
 
 	// enable persistence and restore from the hotbackup
 	h.Spec = hazelcastv1alpha1.HazelcastSpec{Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-		BaseDir: "/baseDir/",
 		Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		},
@@ -356,9 +355,7 @@ func defaultCRs() (types.NamespacedName, *hazelcastv1alpha1.Hazelcast, *hazelcas
 			Namespace: nn.Namespace,
 		},
 		Spec: hazelcastv1alpha1.HazelcastSpec{
-			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "basedir",
-			},
+			Persistence: &hazelcastv1alpha1.HazelcastPersistenceConfiguration{},
 		},
 		Status: hazelcastv1alpha1.HazelcastStatus{
 			Phase: hazelcastv1alpha1.Running,

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -860,9 +860,6 @@ spec:
               persistence:
                 description: Persistence configuration
                 properties:
-                  baseDir:
-                    description: Persistence base directory.
-                    type: string
                   clusterDataRecoveryPolicy:
                     default: FullRecoveryOnly
                     description: Configuration of the cluster recovery strategy.
@@ -937,8 +934,6 @@ spec:
                     - ForceStart
                     - PartialStart
                     type: string
-                required:
-                - baseDir
                 type: object
               properties:
                 additionalProperties:

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -63,6 +63,7 @@ const (
 	JetConfigMapNamePrefix      = "jet-cm-"
 	UserCodeURLVolumeName       = "user-code-url"
 	UserCodeConfigMapNamePrefix = "user-code-cm-"
+	BaseDir                     = "/data/hot-restart"
 
 	SidecarAgent        = "sidecar-agent"
 	BackupAgentPortName = "backup-agent-port"

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -74,9 +74,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 
 	Context("The hot backup process", func() {
 		It("triggers successfully", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 
 			setLabelAndCRName("br-1")
 			clusterSize := int32(3)
@@ -107,9 +104,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("starts after the cluster becomes ready", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-2")
 			clusterSize := int32(1)
 			hazelcast := hazelcastconfig.HazelcastPersistencePVC(hzLookupKey, clusterSize, labels)
@@ -130,9 +124,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 
 		It("is interrupted when the HotBackup CR is deleted", Tag(Fast|EE|AnyCloud), func() {
 			setLabelAndCRName("br-3")
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			ctx := context.Background()
 			bucketURI := "gs://operator-e2e-external-backup"
 			secretName := "br-secret-gcp"
@@ -200,9 +191,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("fails when external backup credentials are incorrect", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-4")
 			ctx := context.Background()
 			clusterSize := int32(1)
@@ -258,9 +246,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("triggers multiple times using CronHotBackup", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-5")
 			By("creating cron hot backup")
 			hbSpec := &hazelcastcomv1alpha1.HotBackupSpec{}
@@ -287,9 +272,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should backup, restore and backup data again successfully", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-6")
 			var mapSizeInMb = 1072
 			var additionalEntries = 111
@@ -363,9 +345,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 
 	Context("Restoring and verifying data", func() {
 		It("should restore from LocalBackup using PVC and HotBackupResourceName", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-7")
 			clusterSize := int32(3)
 
@@ -375,9 +354,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should restore 3 GB from an external backup using a GCP bucket", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-8")
 			ctx := context.Background()
 			var mapSizeInMb = 3072
@@ -446,9 +422,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should restore multiple times from HotBackupResourceName", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-8")
 			clusterSize := int32(3)
 
@@ -509,9 +482,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		It("should check cache entry persistence after HotBackup", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-9")
 			clusterSize := int32(3)
 
@@ -555,9 +525,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		})
 
 		DescribeTable("when restoring from ExternalBackup with bucket secret", func(bucketURI, secretName string, useBucketConfig bool) {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("br-10")
 			By("creating cluster with backup enabled")
 			clusterSize := int32(3)
@@ -592,9 +559,6 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 	Context("Startup actions configuration", func() {
 		DescribeTable("should start the cluster successfully triggering",
 			func(action hazelcastcomv1alpha1.PersistenceStartupAction, dataPolicy hazelcastcomv1alpha1.DataRecoveryPolicyType) {
-				if !ee {
-					Skip("This test will only run in EE configuration")
-				}
 				setLabelAndCRName("br-12")
 				clusterSize := int32(3)
 

--- a/test/e2e/cache_test.go
+++ b/test/e2e/cache_test.go
@@ -54,9 +54,6 @@ var _ = Describe("Hazelcast Cache Config", Group("cache"), func() {
 		})
 
 		It("should persist and remove cache config in/from Hazelcast config", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hch-2")
 			caches := []string{"cache1", "cache2", "cache3", "cachefail"}
 			hazelcast := hazelcastconfig.Default(hzLookupKey, ee, labels)

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -156,7 +156,6 @@ var (
 				LicenseKeySecretName: licenseKey(true),
 				LoggingLevel:         hazelcastcomv1alpha1.LoggingLevelDebug,
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -301,7 +300,6 @@ var (
 					},
 				},
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -334,7 +332,6 @@ var (
 					},
 				},
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -463,7 +460,6 @@ var (
 				Version:              *hazelcastVersion,
 				LicenseKeySecretName: licenseKey(true),
 				Persistence: &hazelcastcomv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart",
 					ClusterDataRecoveryPolicy: hazelcastcomv1alpha1.FullRecovery,
 					Pvc: &hazelcastcomv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,10 +1,12 @@
 package e2e
 
 import (
-	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"fmt"
 	"testing"
 
+	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
+	ginkgoTypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,7 +32,18 @@ var controllerManagerName = types.NamespacedName{
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, GetSuiteName())
+	suiteConfig, _ := GinkgoConfiguration()
+	SetLicenseLabelFilters(&suiteConfig)
+
+	RunSpecs(t, GetSuiteName(), suiteConfig)
+}
+
+func SetLicenseLabelFilters(suiteConfig *ginkgoTypes.SuiteConfig) {
+	if ee {
+		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[EE])
+	} else {
+		suiteConfig.LabelFilter += fmt.Sprintf(" && %s", tagNames[OS])
+	}
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/test/e2e/expose_externally_test.go
+++ b/test/e2e/expose_externally_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Group("expose_ex
 					matched = true
 					service := getServiceOfMember(ctx, hzLookupKey.Namespace, member)
 					Expect(service.Spec.Type).Should(Equal(corev1.ServiceTypeNodePort))
-					Expect(service.Spec.Ports).Should(HaveLen(1))
+					Expect(service.Spec.Ports).Should(HaveLen(2))
 					nodePort := service.Spec.Ports[0].NodePort
 					node := getNodeOfMember(ctx, hzLookupKey.Namespace, member)
 					externalAddresses := filterNodeAddressesByExternalIP(node.Status.Addresses)

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -121,9 +121,6 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 
 	Context("Cluster deletion", func() {
 		It("should delete dependent data structures and backups on Hazelcast CR deletion", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("h-6")
 			clusterSize := int32(3)
 
@@ -159,9 +156,6 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 
 	Context("TLS Configuration", func() {
 		It("should form a cluster with TLS configuration enabled", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("h-7")
 			hz := hazelcastconfig.HazelcastTLS(hzLookupKey, ee, labels)
 
@@ -182,9 +176,6 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 		})
 
 		It("should support mutual TLS authentication in Hazelcast cluster", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("h-8")
 			hz := hazelcastconfig.HazelcastMTLS(hzLookupKey, ee, labels)
 

--- a/test/e2e/jetjob_test.go
+++ b/test/e2e/jetjob_test.go
@@ -173,9 +173,6 @@ var _ = Describe("Hazelcast JetJob", Group("jetjob"), func() {
 		})
 
 		It("persists JetJob on a new cluster when LosslessRestartEnabled", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			longRunJar := "jet-pipeline-longrun-2.0.0.jar"
 			setLabelAndCRName("jj-5")
 

--- a/test/e2e/jetjobsnapshot_test.go
+++ b/test/e2e/jetjobsnapshot_test.go
@@ -37,10 +37,6 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 
 	Context("JetJob snapshot utilization", func() {
 		It("should export snapshot and initialize new job from that snapshot", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-
 			setLabelAndCRName("jjs-1")
 
 			hazelcast := hazelcastconfig.JetConfigured(hzLookupKey, ee, labels)
@@ -155,10 +151,6 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 
 	Context("Operational behavior", func() {
 		It("cancel the JetJob after successful snapshot export", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-
 			setLabelAndCRName("jjs-2")
 
 			hazelcast := hazelcastconfig.JetConfigured(hzLookupKey, ee, labels)
@@ -187,10 +179,6 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 		})
 
 		It("fails when export snapshot from a suspended JetJob", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
-
 			setLabelAndCRName("jjs-3")
 
 			hazelcast := hazelcastconfig.JetConfigured(hzLookupKey, ee, labels)

--- a/test/e2e/management_center_test.go
+++ b/test/e2e/management_center_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
-	"github.com/hazelcast/hazelcast-platform-operator/internal/platform"
 	mcconfig "github.com/hazelcast/hazelcast-platform-operator/test/e2e/config/managementcenter"
 )
 
@@ -124,9 +123,6 @@ var _ = Describe("Management-Center", Group("mc"), func() {
 
 	Context("ManagementCenter CR with Route", func() {
 		It("should be able to access route in Openshift env.", Tag(Fast|AnyLicense|OCP), func() {
-			if platform.GetType() != platform.OpenShift {
-				Skip("This test will only run in OpenShift environments")
-			}
 			setLabelAndCRName("mc-4")
 			mc := mcconfig.RouteEnabled(mcLookupKey, ee, labels)
 			create(mc)

--- a/test/e2e/map_test.go
+++ b/test/e2e/map_test.go
@@ -154,9 +154,6 @@ var _ = Describe("Hazelcast Map - ", Group("map"), func() {
 		})
 
 		It("persist and removed map config in/from Hazelcast config", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hm-4")
 			maps := []string{"map1", "map2", "map3", "mapfail"}
 

--- a/test/e2e/multi_ns_test.go
+++ b/test/e2e/multi_ns_test.go
@@ -61,9 +61,6 @@ var _ = Describe("Hazelcast Multi-Namespace", Group("multi_namespace"), func() {
 					setCRNamespace(deployNamespace)
 				}
 
-				if !ee {
-					Skip("This test will only run in EE configuration")
-				}
 				setLabelAndCRName("mns-2")
 				clusterSize := int32(3)
 

--- a/test/e2e/paltform_wan_test.go
+++ b/test/e2e/paltform_wan_test.go
@@ -39,9 +39,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 3 GB data by each cluster in active-passive mode in the different namespaces", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		SwitchContext(context1)
 		setupEnv()
 		setLabelAndCRName("hpwan-1")
@@ -103,9 +100,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 6 GB data by each cluster in active-active mode in the different namespaces", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		SwitchContext(context1)
 		setupEnv()
 		var mapSizeInMb = 1024
@@ -238,9 +232,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 3 GB data by each cluster in active-passive mode in the different GKE clusters", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hpwan-3")
 		var mapSizeInMb = 1024
 		/**
@@ -311,9 +302,6 @@ var _ = Describe("Hazelcast WAN", Group("platform_wan"), func() {
 	})
 
 	It("should send 6 GB data by each cluster in active-active mode in the different GKE clusters", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		var mapSizeInMb = 1024
 		/**
 		2 (entries per single goroutine) = 1048576  (Bytes per 1Mb)  / 8192 (Bytes per entry) / 64 (goroutines)

--- a/test/e2e/platform_persistence_test.go
+++ b/test/e2e/platform_persistence_test.go
@@ -36,9 +36,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should successfully start after one member restart", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-1")
 		ctx := context.Background()
 		clusterSize := int32(3)
@@ -75,9 +72,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should restore 3 GB data after planned shutdown", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-2")
 		var mapSizeInMb = 3072
 		var pvcSizeInMb = mapSizeInMb * 2 // Taking backup duplicates the used storage
@@ -142,9 +136,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should not start repartitioning after one member restart", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-3")
 		ctx := context.Background()
 		clusterSize := int32(3)
@@ -187,9 +178,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should not start repartitioning after planned shutdown", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-4")
 		ctx := context.Background()
 		clusterSize := int32(3)
@@ -248,9 +236,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	It("should persist SQL mappings", Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-5")
 
 		hazelcast := hazelcastconfig.HazelcastSQLPersistence(hzLookupKey, 1, labels)
@@ -275,9 +260,6 @@ var _ = Describe("Platform Persistence", Group("platform_persistence"), func() {
 	})
 
 	DescribeTable("Hazelcast", func(policyType hazelcastcomv1alpha1.DataRecoveryPolicyType, mapNameSuffix string) {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hps-6")
 		var mapSizeInMb = 500
 		var pvcSizeInMb = 14500

--- a/test/e2e/platform_resilience_test.go
+++ b/test/e2e/platform_resilience_test.go
@@ -84,9 +84,6 @@ var _ = Describe("Platform Resilience Tests", Group("resilience"), func() {
 	})
 
 	It("should kill the pod randomly and preserve the data after restore", Tag(Slow|Any), Serial, func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hr-3")
 		duration := "30s"
 		mapSizeInMb := 500

--- a/test/e2e/platform_rolling_upgrade_test.go
+++ b/test/e2e/platform_rolling_upgrade_test.go
@@ -33,9 +33,6 @@ var _ = Describe("Platform Rolling UpgradeTests", Group("rolling_upgrade"), func
 	})
 
 	It("should upgrade HZ version after pause/resume with 7999 partition count", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hra-1")
 		var mapSizeInMb = 500
 		var pvcSizeInMb = 14500

--- a/test/e2e/platform_rollout_restart_test.go
+++ b/test/e2e/platform_rollout_restart_test.go
@@ -32,9 +32,6 @@ var _ = Describe("Platform Rollout Restart Tests", Group("rollout_restart"), fun
 	})
 
 	It("should perform rollout restart with 14Gb data", Serial, Tag(Slow|EE|AnyCloud), func() {
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("hrr-1")
 		var mapSizeInMb = 500
 		var pvcSizeInMb = 14500

--- a/test/e2e/platform_soak_test.go
+++ b/test/e2e/platform_soak_test.go
@@ -33,10 +33,6 @@ var _ = Describe("Platform Soak Tests", Group("soak"), func() {
 	})
 
 	It("should upgrade HZ version after pause/resume with default partition count during 4 hours and keep 45 GB data", Serial, Tag(Slow|EE|AnyCloud), func() {
-
-		if !ee {
-			Skip("This test will only run in EE configuration")
-		}
 		setLabelAndCRName("soak-1")
 		var pvcSizeInMb = 14500
 		var pauseBetweenFills = 4 * Minute

--- a/test/e2e/wan_sync_test.go
+++ b/test/e2e/wan_sync_test.go
@@ -27,9 +27,6 @@ var _ = Describe("Hazelcast WAN Sync", Group("wan_sync"), func() {
 
 	Context("Basic WAN Sync functionality", func() {
 		It("should sync one map with another cluster", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hws-1")
 
 			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
@@ -51,9 +48,6 @@ var _ = Describe("Hazelcast WAN Sync", Group("wan_sync"), func() {
 		})
 
 		It("should sync two maps with another cluster", Tag(Fast|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hws-2")
 
 			// Hazelcast and Map CRs

--- a/test/e2e/wan_test.go
+++ b/test/e2e/wan_test.go
@@ -34,9 +34,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 
 	Context("Basic WAN Replication functionality", func() {
 		It("successfully replicates data to another cluster", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hw-1")
 
 			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
@@ -57,9 +54,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("maintains replication after source members restart", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			setLabelAndCRName("hw-2")
 
 			hzCrs, _ := createWanResources(context.Background(), map[string][]string{
@@ -87,9 +81,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 
 	Context("Handling WAN Replication status", func() {
 		It("sets WAN status to 'Failed' when delete Map CR which present as a Map resource in WAN spec", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-3")
 
 			// Hazelcast and Map CRs
@@ -120,9 +111,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("sets WAN status to 'Pending' when delete Map which present as a Hazelcast resource in WAN spec", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-4")
 
 			// Hazelcast and Map CRs
@@ -152,9 +140,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("sets WAN status to 'Success' when resource map is created after the WAN CR", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-5")
 
 			// Hazelcast CRs
@@ -220,9 +205,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 
 	Context("Updating WAN configuration", func() {
 		It("initially fails after removal of replicated Hazelcast CR, then succeeds after removal it from the WAN spec", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-6")
 
 			// Hazelcast and Map CRs
@@ -264,9 +246,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("stops replication for maps removed from WAN spec", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-7")
 
 			// Hazelcast and Map CRs
@@ -332,9 +311,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("continues replication when 1 of 2 maps references is deleted from WAN spec", Tag(Fast|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-8")
 
 			// Hazelcast and Map CRs
@@ -367,9 +343,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("verifies replication initiation for maps added after WAN setup", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-9")
 
 			// Hazelcast CRs
@@ -440,9 +413,6 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		})
 
 		It("handles different map names for target cluster replication", Tag(Slow|EE|AnyCloud), func() {
-			if !ee {
-				Skip("This test will only run in EE configuration")
-			}
 			suffix := setLabelAndCRName("hw-10")
 
 			// Hazelcast and Map CRs

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -51,10 +51,9 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
-				"hazelcast.graceful.shutdown.max.wait":              "300",
-				"hazelcast.persistence.auto.cluster.state":          "true",
-				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.graceful.shutdown.max.wait":           "300",
+				"hazelcast.persistence.auto.cluster.state":       "true",
 			}))
 		})
 
@@ -64,9 +63,8 @@ var _ = Describe("Hazelcast Properties", func() {
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
 			}
 			hz.Spec.Properties = map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "false",
-				"hazelcast.persistence.auto.cluster.state":          "false",
-				"hazelcast.persistence.auto.cluster.state.strategy": "FROZEN",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "false",
+				"hazelcast.persistence.auto.cluster.state":       "false",
 			}
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
@@ -82,9 +80,8 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
-				"hazelcast.persistence.auto.cluster.state":          "true",
-				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.persistence.auto.cluster.state":       "true",
 			}))
 		})
 	})

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -724,48 +724,9 @@ var _ = Describe("Hazelcast CR", func() {
 	})
 
 	Context("with Persistence configuration", func() {
-		It("should fail to create with empty baseDir", Label("fast"), func() {
-			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
-			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "",
-				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
-					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				},
-			}
-
-			hz := &hazelcastv1alpha1.Hazelcast{
-				ObjectMeta: randomObjectMeta(namespace),
-				Spec:       spec,
-			}
-
-			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
-		})
-	})
-
-	Context("with Persistence configuration", func() {
-		It("should fail to create with invalid baseDir", Label("fast"), func() {
-			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
-			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "baseDir/",
-				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
-					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				},
-			}
-
-			hz := &hazelcastv1alpha1.Hazelcast{
-				ObjectMeta: randomObjectMeta(namespace),
-				Spec:       spec,
-			}
-
-			Expect(k8sClient.Create(context.Background(), hz)).ShouldNot(Succeed())
-		})
-	})
-
-	Context("with Persistence configuration", func() {
 		It("should create with default values", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},
@@ -781,7 +742,6 @@ var _ = Describe("Hazelcast CR", func() {
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("checking the Persistence CR configuration", func() {
-				Expect(fetchedCR.Spec.Persistence.BaseDir).Should(Equal("/baseDir/"))
 				Expect(fetchedCR.Spec.Persistence.ClusterDataRecoveryPolicy).
 					Should(Equal(hazelcastv1alpha1.FullRecovery))
 				Expect(fetchedCR.Spec.Persistence.Pvc.AccessModes).Should(ConsistOf(corev1.ReadWriteOnce))
@@ -792,7 +752,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should create volumeClaimTemplates", Label("fast"), func() {
 			s := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			s.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir:                   "/data/hot-restart/",
 				ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -810,7 +769,6 @@ var _ = Describe("Hazelcast CR", func() {
 			test.CheckHazelcastCR(fetchedCR, defaultHazelcastSpecValues(), ee)
 
 			By("checking the Persistence CR configuration", func() {
-				Expect(fetchedCR.Spec.Persistence.BaseDir).Should(Equal("/data/hot-restart/"))
 				Expect(fetchedCR.Spec.Persistence.ClusterDataRecoveryPolicy).
 					Should(Equal(hazelcastv1alpha1.FullRecovery))
 				Expect(fetchedCR.Spec.Persistence.Pvc.AccessModes).Should(ConsistOf(corev1.ReadWriteOnce))
@@ -842,7 +800,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should add RBAC PolicyRule for watch StatefulSets", Label("fast"), func() {
 			s := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			s.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir:                   "/data/hot-restart/",
 				ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -875,7 +832,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should not create PartialStart with FullRecovery", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir:                   "/baseDir/",
 				ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 				StartupAction:             hazelcastv1alpha1.PartialStart,
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
@@ -894,9 +850,7 @@ var _ = Describe("Hazelcast CR", func() {
 
 		It("should not create if pvc is not specified", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
-			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
-			}
+			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{}
 
 			hz := &hazelcastv1alpha1.Hazelcast{
 				ObjectMeta: randomObjectMeta(namespace),
@@ -910,7 +864,6 @@ var _ = Describe("Hazelcast CR", func() {
 		It("should not create if pvc accessModes is not specified", Label("fast"), func() {
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					RequestStorage: &[]resource.Quantity{resource.MustParse("8Gi")}[0],
 				},
@@ -1163,7 +1116,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should be deployed as a sidecar container", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -1716,9 +1668,7 @@ var _ = Describe("Hazelcast CR", func() {
 				spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
 					AllocatorType: hazelcastv1alpha1.NativeMemoryStandard,
 				}
-				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir: "/data/hot-restart/",
-				}
+				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{}
 				hz := &hazelcastv1alpha1.Hazelcast{
 					ObjectMeta: randomObjectMeta(namespace),
 					Spec:       spec,
@@ -2056,7 +2006,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should be created successfully if persistence is enabled", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -2174,7 +2123,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should be created successfully if Hazelcast persistence is enabled", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -2198,7 +2146,6 @@ var _ = Describe("Hazelcast CR", func() {
 			It("should fail to disable catalogPersistence", Label("fast"), func() {
 				spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 				spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-					BaseDir:                   "/data/hot-restart/",
 					ClusterDataRecoveryPolicy: hazelcastv1alpha1.FullRecovery,
 					Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 						AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/test/integration/hazelcastendpoint_test.go
+++ b/test/integration/hazelcastendpoint_test.go
@@ -336,7 +336,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 			services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 			setLoadBalancerIngressAddress(ctx, services)
 			expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)

--- a/test/integration/hazelcastendpoint_test.go
+++ b/test/integration/hazelcastendpoint_test.go
@@ -225,7 +225,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -247,7 +247,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -269,7 +269,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -368,7 +368,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 			services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 			setLoadBalancerIngressAddress(ctx, services)
 			expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)

--- a/test/integration/hotbackup_test.go
+++ b/test/integration/hotbackup_test.go
@@ -58,7 +58,6 @@ var _ = Describe("HotBackup CR", func() {
 
 			spec := test.HazelcastSpec(defaultHazelcastSpecValues(), ee)
 			spec.Persistence = &hazelcastv1alpha1.HazelcastPersistenceConfiguration{
-				BaseDir: "/baseDir/",
 				Pvc: &hazelcastv1alpha1.PersistencePvcConfiguration{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},


### PR DESCRIPTION
## Description

We decided to expose default wan port(5710) for Member services like we did for discovery service. With the additional port for Member services, corresponding `hazelcastendpoints` with the type `WAN` are created directly.

### Old version

```yaml
exposeExternally:
  type: Smart
  discoveryServiceType: LoadBalancer
  memberAccess: NodePortExternalIP
```

```sh
$ k get svc
NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                       AGE
hazelcast        LoadBalancer   10.164.15.134   35.226.75.101   5701:31425/TCP,5702:30574/TCP,8081:30858/TCP,5710:31016/TCP   75s
hazelcast-0      NodePort       10.164.5.33     <none>          5701:31001/TCP                                                75s
hazelcast-1      NodePort       10.164.3.158    <none>          5701:30343/TCP                                                75s
hazelcast-2      NodePort       10.164.5.104    <none>          5701:32602/TCP                                                75s
```

```sh
$ k get hazelcastendpoints.hazelcast.com
NAME              TYPE        ADDRESS
hazelcast         Discovery   35.226.75.101:5701
hazelcast-0       Member      34.31.31.174:31001
hazelcast-1       Member      34.31.31.174:30343
hazelcast-2       Member      34.134.146.100:32602
hazelcast-wan     WAN         35.226.75.101:5710
```


### New Version

_Notice additional  `port` for `WAN` on each `Member service` and corresponding `hazelcastEndpoints`._

```yaml
  exposeExternally:
    type: Smart
    discoveryServiceType: LoadBalancer
    memberAccess: NodePortExternalIP
```

```sh
$ k get svc
NAME                             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                       AGE
hazelcast                        LoadBalancer   10.164.15.134   35.226.75.101   5701:31425/TCP,5702:30574/TCP,8081:30858/TCP,5710:31016/TCP   75s
hazelcast-0                      NodePort       10.164.5.33     <none>          5701:31001/TCP,5710:31375/TCP                                 75s
hazelcast-1                      NodePort       10.164.3.158    <none>          5701:30343/TCP,5710:31322/TCP                                 75s
hazelcast-2                      NodePort       10.164.5.104    <none>          5701:32602/TCP,5710:32292/TCP                                 75s
```

```sh
$ k get hazelcastendpoints.hazelcast.com
NAME              TYPE        ADDRESS
hazelcast         Discovery   35.226.75.101:5701
hazelcast-0       Member      34.31.31.174:31001
hazelcast-0-wan   WAN         34.31.31.174:31375
hazelcast-1       Member      34.31.31.174:30343
hazelcast-1-wan   WAN         34.31.31.174:31322
hazelcast-2       Member      34.134.146.100:32602
hazelcast-2-wan   WAN         34.134.146.100:32292
hazelcast-wan     WAN         35.226.75.101:5710
```

## User Impact

Users can now use the default `WAN` port for each member when the Hazelcast cluster is exposed as the type `Smart`. Also users will see the corresponding `hazelcastendpoints` resources for the newly exposed `WAN` port. 