### PR TITLE
[CN-1135]: make hazelcast.persistence.auto.cluster.state.strategy configurable

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -57,8 +57,7 @@ var DefaultProperties = map[string]string{
 	"hazelcast.cluster.version.auto.upgrade.enabled": "true",
 	// https://docs.hazelcast.com/hazelcast/5.3/kubernetes/kubernetes-auto-discovery#configuration
 	// We added the following properties to here with their default values, because DefaultProperties cannot be overridden
-	"hazelcast.persistence.auto.cluster.state":          "true",
-	"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+	"hazelcast.persistence.auto.cluster.state": "true",
 }
 
 func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -51,10 +51,9 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
-				"hazelcast.graceful.shutdown.max.wait":              "300",
-				"hazelcast.persistence.auto.cluster.state":          "true",
-				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.graceful.shutdown.max.wait":           "300",
+				"hazelcast.persistence.auto.cluster.state":       "true",
 			}))
 		})
 
@@ -82,9 +81,8 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
-				"hazelcast.persistence.auto.cluster.state":          "true",
-				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.persistence.auto.cluster.state":       "true",
 			}))
 		})
 	})

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -63,9 +63,8 @@ var _ = Describe("Hazelcast Properties", func() {
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
 			}
 			hz.Spec.Properties = map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "false",
-				"hazelcast.persistence.auto.cluster.state":          "false",
-				"hazelcast.persistence.auto.cluster.state.strategy": "FROZEN",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "false",
+				"hazelcast.persistence.auto.cluster.state":       "false",
 			}
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())


### PR DESCRIPTION
## Description

Makes `hazelcast.persistence.auto.cluster.state.strategy` configurable.

## User Impact

Users will be able to configure `hazelcast.persistence.auto.cluster.state.strategy`.
