### PR TITLE
Refactoring on property logs

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -969,7 +969,7 @@ func mergeProperties(logger logr.Logger, inputProps map[string]string) map[strin
 		// ignore the provided property without overriding the default one.
 		if existingVal, exist := m[k]; exist {
 			if v != existingVal {
-				logger.V(util.DebugLevel).Info("property ignored", "property", k, "value", v)
+				logger.V(util.DebugLevel).Info("Property ignored", "property", k, "value", v)
 			}
 		} else {
 			m[k] = v

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -965,8 +965,12 @@ func mergeProperties(logger logr.Logger, inputProps map[string]string) map[strin
 		m[k] = v
 	}
 	for k, v := range inputProps {
-		if _, exist := m[k]; exist { // if user's input is an immutable property, ignore user's input
-			logger.V(util.DebugLevel).Info("Property ignored", "property", k)
+		// if the property provided by the used is one of the default (immutable) property,
+		// ignore the provided property without overriding the default one.
+		if existingVal, exist := m[k]; exist {
+			if v != existingVal {
+				logger.V(util.DebugLevel).Info("property ignored", "property", k, "value", v)
+			}
 		} else {
 			m[k] = v
 		}

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -965,7 +965,7 @@ func mergeProperties(logger logr.Logger, inputProps map[string]string) map[strin
 		m[k] = v
 	}
 	for k, v := range inputProps {
-		// if the property provided by the used is one of the default (immutable) property,
+		// if the property provided by the user is one of the default (immutable) property,
 		// ignore the provided property without overriding the default one.
 		if existingVal, exist := m[k]; exist {
 			if v != existingVal {


### PR DESCRIPTION
## Description

The Hazelcast reconciler keeps printing the repetitive logs related to the properties, although I don't set any field for properties.

```
1.708432147727583e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321477277038e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
1.7084321477277675e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.7084321478103867e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321478106349e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
1.708432147810668e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.7084321478749192e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321478749628e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
1.708432147874972e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.7084321479115143e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321479115758e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
1.7084321479115863e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.708432148030365e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
1.7084321480304282e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.7084321480304375e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321489644787e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.7084321489645333e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321489645407e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
1.7084321490111678e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state.strategy"}
1.7084321490112162e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.cluster.version.auto.upgrade.enabled"}
1.7084321490112247e+09	DEBUG	controllers.Hazelcast	Property ignored	{"hazelcast": "default/hz-external", "property": "hazelcast.persistence.auto.cluster.state"}
```

Better to print the logs only when the provided value is different than the actual value of the default property.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
