### PR TITLE
Fix restore comparison in validation

### DIFF
--- a/api/v1alpha1/hazelcast_validation.go
+++ b/api/v1alpha1/hazelcast_validation.go
@@ -363,7 +363,7 @@ func (v *hazelcastValidator) validateNotUpdatableHzPersistenceFields(current, la
 	if !reflect.DeepEqual(current.Pvc, last.Pvc) {
 		v.Forbidden(Path("spec", "persistence", "pvc"), "field cannot be updated")
 	}
-	if current.Restore != last.Restore {
+	if !reflect.DeepEqual(current.Restore, last.Restore) {
 		v.Forbidden(Path("spec", "persistence", "restore"), "field cannot be updated")
 	}
 }


### PR DESCRIPTION
## Description

The `current` and `last` should have been compared by `DeepEqual`, since the `BucketConfiguration` is a pointer type in `RestoreConfiguration`.

```go
type RestoreConfiguration struct {
	// Bucket Configuration from which the backup will be downloaded.
	// +optional
	BucketConfiguration *BucketConfiguration `json:"bucketConfig,omitempty"`

	// Name of the HotBackup resource from which backup will be fetched.
	// +optional
	HotBackupResourceName string `json:"hotBackupResourceName,omitempty"`
}
```

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
