### PR TITLE
Fix E2E test focus

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -44,12 +44,11 @@ func TestE2E(t *testing.T) {
 
 func SetLicenseLabelFilters(suiteConfig *ginkgoTypes.SuiteConfig) {
 	if len(suiteConfig.LabelFilter) > 0 {
-		suiteConfig.LabelFilter += " && "
-	}
-	if ee {
-		suiteConfig.LabelFilter += tagNames[EE]
-	} else {
-		suiteConfig.LabelFilter += tagNames[OS]
+		if ee {
+			suiteConfig.LabelFilter += "&& " + tagNames[EE]
+		} else {
+			suiteConfig.LabelFilter += "&& " + tagNames[OS]
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

`focus` requires no `LabelFilter`

Therefore, we shouldn't even set license labels to be able trigger focus.

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
