### PR TITLE
Reland use resource tracker to cleanup after tests (#1036)

### DIFF
--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -62,13 +62,8 @@ var _ = Describe("Hazelcast CR with Persistence feature enabled", Group("backup_
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Cache{}, &hazelcastcomv1alpha1.CacheList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.CronHotBackup{}, &hazelcastcomv1alpha1.CronHotBackupList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.HotBackup{}, &hazelcastcomv1alpha1.HotBackupList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/cache_test.go
+++ b/test/e2e/cache_test.go
@@ -23,11 +23,8 @@ var _ = Describe("Hazelcast Cache Config", Group("cache"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Cache{}, &hazelcastcomv1alpha1.CacheList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.HotBackup{}, &hazelcastcomv1alpha1.HotBackupList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/expose_externally_test.go
+++ b/test/e2e/expose_externally_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Group("expose_ex
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/hazelcast_test.go
+++ b/test/e2e/hazelcast_test.go
@@ -24,9 +24,8 @@ var _ = Describe("Hazelcast", Group("hz"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/jetjob_test.go
+++ b/test/e2e/jetjob_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	hazelcastcomv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
@@ -24,12 +23,8 @@ var _ = Describe("Hazelcast JetJob", Group("jetjob"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.JetJob{}, &hazelcastcomv1alpha1.JetJobList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.HotBackup{}, &hazelcastcomv1alpha1.HotBackupList{}, hzNamespace, labels)
-		DeleteAllOf(&corev1.Secret{}, &corev1.SecretList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/jetjobsnapshot_test.go
+++ b/test/e2e/jetjobsnapshot_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
@@ -25,13 +24,8 @@ var _ = Describe("Hazelcast JetJobSnapshot", Group("jetjobsnapshot"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.JetJobSnapshot{}, &hazelcastcomv1alpha1.JetJobSnapshotList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.JetJob{}, &hazelcastcomv1alpha1.JetJobList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&corev1.Secret{}, &corev1.SecretList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/management_center_test.go
+++ b/test/e2e/management_center_test.go
@@ -23,8 +23,7 @@ var _ = Describe("Management-Center", Group("mc"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.ManagementCenter{}, nil, hzNamespace, labels)
-		deletePVCs(mcLookupKey)
+		Cleanup(context.Background())
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/map_test.go
+++ b/test/e2e/map_test.go
@@ -35,11 +35,8 @@ var _ = Describe("Hazelcast Map - ", Group("map"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.HotBackup{}, &hazelcastcomv1alpha1.HotBackupList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/multi_ns_test.go
+++ b/test/e2e/multi_ns_test.go
@@ -17,21 +17,8 @@ var _ = Describe("Hazelcast Multi-Namespace", Label("multi_namespace"), func() {
 		if skipCleanup() {
 			return
 		}
-
-		if deployNamespace != "" {
-			DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, deployNamespace, labels)
-		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-
-		if deployNamespace != "" {
-			tmp := hzLookupKey
-			tmp.Namespace = deployNamespace
-			assertDoesNotExist(tmp, &hazelcastcomv1alpha1.Hazelcast{})
-		}
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
-
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/multimap_test.go
+++ b/test/e2e/multimap_test.go
@@ -22,10 +22,8 @@ var _ = Describe("Hazelcast MultiMap Config", Group("multimap"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.MultiMap{}, &hazelcastcomv1alpha1.MultiMapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/paltform_wan_test.go
+++ b/test/e2e/paltform_wan_test.go
@@ -30,11 +30,7 @@ var _ = Describe("Hazelcast WAN", Label("platform_wan"), func() {
 		if skipCleanup() {
 			return
 		}
-		for _, ns := range []string{sourceLookupKey.Namespace, targetLookupKey.Namespace} {
-			DeleteAllOf(&hazelcastcomv1alpha1.WanReplication{}, &hazelcastcomv1alpha1.WanReplicationList{}, ns, labels)
-			DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, ns, labels)
-			DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, ns, labels)
-		}
+		Cleanup(context.Background())
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/platform_persistence_test.go
+++ b/test/e2e/platform_persistence_test.go
@@ -27,11 +27,8 @@ var _ = Describe("Platform Persistence", Label("platform_persistence"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.HotBackup{}, &hazelcastcomv1alpha1.HotBackupList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/platform_resilience_test.go
+++ b/test/e2e/platform_resilience_test.go
@@ -72,12 +72,8 @@ var _ = Describe("Platform Resilience Tests", Label("resilience"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
-		DeleteAllOf(&hazelcastcomv1alpha1.ManagementCenter{}, nil, hzNamespace, labels)
-		deletePVCs(mcLookupKey)
-		DeleteConfigMap(hzNamespace, "split-brain-config")
 		By("waiting for all nodes are ready", func() {
 			waitForDroppedNodes(context.Background(), 0)
 		})

--- a/test/e2e/platform_rolling_upgrade_test.go
+++ b/test/e2e/platform_rolling_upgrade_test.go
@@ -23,12 +23,8 @@ var _ = Describe("Platform Rolling UpgradeTests", Label("rolling_upgrade"), func
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.ManagementCenter{}, nil, hzNamespace, labels)
-
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/platform_rollout_restart_test.go
+++ b/test/e2e/platform_rollout_restart_test.go
@@ -22,12 +22,8 @@ var _ = Describe("Platform Rollout Restart Tests", Label("rollout_restart"), fun
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.ManagementCenter{}, nil, hzNamespace, labels)
-
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/platform_soak_test.go
+++ b/test/e2e/platform_soak_test.go
@@ -24,11 +24,8 @@ var _ = Describe("Platform Soak Tests", Label("soak"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.ManagementCenter{}, nil, hzNamespace, labels)
-
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/queue_test.go
+++ b/test/e2e/queue_test.go
@@ -22,10 +22,8 @@ var _ = Describe("Hazelcast Queue Config", Group("queue"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Queue{}, &hazelcastcomv1alpha1.QueueList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/replicatedmap_test.go
+++ b/test/e2e/replicatedmap_test.go
@@ -22,10 +22,8 @@ var _ = Describe("Hazelcast ReplicatedMap Config", Group("replicatedmap"), func(
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.ReplicatedMap{}, &hazelcastcomv1alpha1.ReplicatedMapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/topic_test.go
+++ b/test/e2e/topic_test.go
@@ -20,10 +20,8 @@ var _ = Describe("Hazelcast Topic Config", Group("topic"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Topic{}, &hazelcastcomv1alpha1.TopicList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/user_code_test.go
+++ b/test/e2e/user_code_test.go
@@ -25,11 +25,8 @@ var _ = Describe("Hazelcast User Code Deployment", Group("user_code"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
-		DeleteAllOf(&corev1.Secret{}, &corev1.SecretList{}, hzNamespace, labels)
+		Cleanup(context.Background())
 		deletePVCs(hzLookupKey)
-		assertDoesNotExist(hzLookupKey, &hazelcastcomv1alpha1.Hazelcast{})
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/wan_sync_test.go
+++ b/test/e2e/wan_sync_test.go
@@ -18,10 +18,7 @@ var _ = Describe("Hazelcast WAN Sync", Group("wan_sync"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.WanSync{}, &hazelcastcomv1alpha1.WanSyncList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.WanReplication{}, &hazelcastcomv1alpha1.WanReplicationList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 

--- a/test/e2e/wan_test.go
+++ b/test/e2e/wan_test.go
@@ -26,9 +26,7 @@ var _ = Describe("Hazelcast WAN", Group("hz_wan"), func() {
 		if skipCleanup() {
 			return
 		}
-		DeleteAllOf(&hazelcastcomv1alpha1.WanReplication{}, &hazelcastcomv1alpha1.WanReplicationList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Map{}, &hazelcastcomv1alpha1.MapList{}, hzNamespace, labels)
-		DeleteAllOf(&hazelcastcomv1alpha1.Hazelcast{}, nil, hzNamespace, labels)
+		Cleanup(context.Background())
 		GinkgoWriter.Printf("Aftereach end time is %v\n", Now().String())
 	})
 


### PR DESCRIPTION
* Use resource tracker to cleanup after tests

* Add pvc cleanup

## Description

<!--- Please include a summary of the change. Please provide the motivation for why this change is necessary at this stage of the product development cycle. -->

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
