### PR TITLE
[CN-1118] Add Platform Tiered-Storage tests

### DIFF
--- a/api/v1alpha1/map_validation.go
+++ b/api/v1alpha1/map_validation.go
@@ -150,8 +150,6 @@ func (v *mapValidator) validateTSMemory(m *Map, h *Hazelcast) {
 	if nativeMemorySize < mapMemoryCapacity {
 		v.Invalid(Path("spec", "tieredStore", "memoryCapacity"), m.Spec.TieredStore.MemoryCapacity, fmt.Sprintf("Memory capacity must be less than Native Memory size. Map memoryCapacity is %v and Native Memory size is %v", mapMemoryCapacity, nativeMemorySize))
 	}
-
-	return
 }
 
 func (v *mapValidator) validateMapSpecUpdate(m *Map) {

--- a/internal/controller/hazelcast/map_resources_test.go
+++ b/internal/controller/hazelcast/map_resources_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -22,27 +24,47 @@ func Test_mapTieredStoreConfig(t *testing.T) {
 	nn, h, m := defaultCRsMap()
 	h.Spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
 		AllocatorType: hazelcastv1alpha1.NativeMemoryPooled,
+		Size:          []resource.Quantity{resource.MustParse("512M")}[0],
+	}
+	h.Spec.LocalDevices = []hazelcastv1alpha1.LocalDeviceConfig{
+		{
+			Name: "test-device",
+			PVC: &hazelcastv1alpha1.PvcConfiguration{
+				AccessModes:    []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				RequestStorage: &[]resource.Quantity{resource.MustParse("256M")}[0],
+			},
+		},
 	}
 
 	tests := []struct {
-		name        string
-		localDevice hazelcastv1alpha1.LocalDeviceConfig
-		mapSpec     hazelcastv1alpha1.MapSpec
-		errMessage  string
+		name       string
+		mapSpec    hazelcastv1alpha1.MapSpec
+		errMessage string
 	}{
 		{
-			name:        "Wrong InMemoryFormat",
-			localDevice: hazelcastv1alpha1.LocalDeviceConfig{Name: "test-device"},
+			name: "Wrong InMemoryFormat",
 			mapSpec: hazelcastv1alpha1.MapSpec{
 				TieredStore: &hazelcastv1alpha1.TieredStore{
 					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
 				},
 			},
 			errMessage: "In-memory format of the map must be NATIVE to enable the Tiered Storage",
 		},
 		{
-			name:        "Index Configured",
-			localDevice: hazelcastv1alpha1.LocalDeviceConfig{Name: "test-device"},
+			name: "Persistence Enabled",
+			mapSpec: hazelcastv1alpha1.MapSpec{
+				PersistenceEnabled: true,
+				InMemoryFormat:     hazelcastv1alpha1.InMemoryFormatNative,
+				TieredStore: &hazelcastv1alpha1.TieredStore{
+					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
+				},
+			},
+			errMessage: "Tiered store and data persistence are mutually exclusive features. Persistence must be disabled to enable the Tiered Storage",
+		},
+		{
+			name: "Index Configured",
 			mapSpec: hazelcastv1alpha1.MapSpec{
 				Indexes: []hazelcastv1alpha1.IndexConfig{
 					{
@@ -52,29 +74,76 @@ func Test_mapTieredStoreConfig(t *testing.T) {
 				InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
 				TieredStore: &hazelcastv1alpha1.TieredStore{
 					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
 				},
 			},
-			errMessage: "Indexes can not be created on maps that have Tiered Storage enabled",
+			errMessage: "Indexes is not supported for Tiered-Store map",
 		},
 		{
-			name:        "LocalDevice does not exist",
-			localDevice: hazelcastv1alpha1.LocalDeviceConfig{Name: "test-device-2"},
+			name: "Eviction Configured",
+			mapSpec: hazelcastv1alpha1.MapSpec{
+				Eviction: hazelcastv1alpha1.EvictionConfig{
+					EvictionPolicy: "LRU",
+				},
+				InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
+				TieredStore: &hazelcastv1alpha1.TieredStore{
+					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
+				},
+			},
+			errMessage: "Eviction is not supported for Tiered-Store map",
+		},
+		{
+			name: "TTL Configured",
+			mapSpec: hazelcastv1alpha1.MapSpec{
+				TimeToLiveSeconds: int32(100),
+				InMemoryFormat:    hazelcastv1alpha1.InMemoryFormatNative,
+				TieredStore: &hazelcastv1alpha1.TieredStore{
+					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
+				},
+			},
+			errMessage: "TTL expiry is not supported for Tiered-Store map",
+		},
+		{
+			name: "MaxIdle Configured",
+			mapSpec: hazelcastv1alpha1.MapSpec{
+				MaxIdleSeconds: int32(100),
+				InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
+				TieredStore: &hazelcastv1alpha1.TieredStore{
+					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
+				},
+			},
+			errMessage: "MaxIdle expiry is not supported for Tiered-Store map",
+		},
+		{
+			name: "LocalDevice does not exist",
+			mapSpec: hazelcastv1alpha1.MapSpec{
+				InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
+				TieredStore: &hazelcastv1alpha1.TieredStore{
+					DiskDeviceName: "missing-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("128M")}[0],
+				},
+			},
+			errMessage: "device with the name missing-device does not exist",
+		},
+		{
+			name: "Memory tier is bigger than Disk tier",
 			mapSpec: hazelcastv1alpha1.MapSpec{
 				InMemoryFormat: hazelcastv1alpha1.InMemoryFormatNative,
 				TieredStore: &hazelcastv1alpha1.TieredStore{
 					DiskDeviceName: "test-device",
+					MemoryCapacity: &[]resource.Quantity{resource.MustParse("512M")}[0],
 				},
 			},
-			errMessage: "device with the name test-device does not exist",
+			errMessage: "Tiered Storage in-memory tier must be smaller than the disk tier",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			RegisterFailHandler(fail(t))
-			h.Spec.LocalDevices = []hazelcastv1alpha1.LocalDeviceConfig{
-				test.localDevice,
-			}
 			hs, _ := json.Marshal(h.Spec)
 			h.ObjectMeta.Annotations = map[string]string{
 				n.LastSuccessfulSpecAnnotation: string(hs),

--- a/internal/naming/constants.go
+++ b/internal/naming/constants.go
@@ -42,7 +42,7 @@ const (
 
 	OperatorName         = "hazelcast-platform-operator"
 	Hazelcast            = "hazelcast"
-	HazelcastPortName    = "hazelcast-port"
+	HazelcastPortName    = "hazelcast"
 	HazelcastStorageName = Hazelcast + "-storage"
 	HazelcastMountPath   = "/data/hazelcast"
 	TmpDirVolName        = "tmp-vol"

--- a/test/e2e/config/hazelcast/config.go
+++ b/test/e2e/config/hazelcast/config.go
@@ -655,7 +655,6 @@ var (
 			Spec: hazelcastcomv1alpha1.MapSpec{
 				DataStructureSpec: hazelcastcomv1alpha1.DataStructureSpec{
 					HazelcastResourceName: hzName,
-					BackupCount:           pointer.Int32(0),
 				},
 				InMemoryFormat: hazelcastcomv1alpha1.InMemoryFormatNative,
 				TieredStore: &hazelcastcomv1alpha1.TieredStore{

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1368,3 +1368,17 @@ func GetPodLogs(ctx context.Context, pod types.NamespacedName, podLogOptions *co
 	}
 	return podLogs
 }
+
+func CheckPodStatus(pod types.NamespacedName, status corev1.PodPhase) {
+	clientSet := getKubernetesClientSet()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	Eventually(func() corev1.PodPhase {
+		pod, err := clientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			panic(err)
+		}
+		return pod.Status.Phase
+	}, 10*Minute, interval).Should(Equal(status))
+}

--- a/test/e2e/platform_tiered_storage_test.go
+++ b/test/e2e/platform_tiered_storage_test.go
@@ -2,6 +2,13 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
+	"github.com/hazelcast/hazelcast-platform-operator/test"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"strconv"
 	. "time"
 
@@ -33,15 +40,17 @@ var _ = Describe("Hazelcast CR with Tiered Storage feature enabled", Group("plat
 			setLabelAndCRName("hpts-1")
 
 			deviceName := "test-device"
-			var memorySizeInMb = 1536      // 1.5Gi
-			var mapSizeInMb = 2048         // 2 Gi
+			var nativeMemorySizeInMb = 1536 // 1.5Gi
+			var mapMemory = 32
+			var mapSizeInMb = 128
 			var totalMemorySizeInMb = 2048 // 2 Gi
-			var diskSizeInMb = mapSizeInMb * 2
+			var diskSizeInMb = 2048 * 2
 			var expectedMapSize = int(float64(mapSizeInMb) * 128)
 			ctx := context.Background()
 
 			totalMemorySize := strconv.Itoa(totalMemorySizeInMb) + "Mi"
-			nativeMemorySize := strconv.Itoa(memorySizeInMb) + "Mi"
+			nativeMemorySize := strconv.Itoa(nativeMemorySizeInMb) + "Mi"
+			mapMemoryCapacitySize := strconv.Itoa(mapMemory) + "Mi"
 			diskSize := strconv.Itoa(diskSizeInMb) + "Mi"
 			hazelcast := hazelcastconfig.HazelcastTieredStorage(hzLookupKey, deviceName, labels)
 			hazelcast.Spec.ExposeExternally = &hazelcastv1alpha1.ExposeExternallyConfiguration{
@@ -62,12 +71,192 @@ var _ = Describe("Hazelcast CR with Tiered Storage feature enabled", Group("plat
 
 			By("creating the map config and putting entries")
 			tsMap := hazelcastconfig.DefaultTieredStoreMap(mapLookupKey, hazelcast.Name, deviceName, labels)
-			tsMap.Spec.TieredStore.MemoryCapacity = &[]resource.Quantity{resource.MustParse(nativeMemorySize)}[0]
+			tsMap.Spec.TieredStore.MemoryCapacity = &[]resource.Quantity{resource.MustParse(mapMemoryCapacitySize)}[0]
 			Expect(k8sClient.Create(context.Background(), tsMap)).Should(Succeed())
 			assertMapStatus(tsMap, hazelcastv1alpha1.MapSuccess)
 			FillMapBySizeInMb(ctx, tsMap.MapName(), mapSizeInMb, mapSizeInMb, hazelcast)
 
 			WaitForMapSize(context.Background(), hzLookupKey, tsMap.MapName(), expectedMapSize, 30*Minute)
+		})
+
+		It("should fail to fill the map with more than allocated memory + disk size", Tag(EE|AnyCloud), func() {
+			setLabelAndCRName("hpts-2")
+
+			deviceName := "test-device"
+			var nativeMemorySizeInMb = 1536 // 1.5Gi
+			var mapMemory = 32
+			var mapSizeInMb = 3000         // 3 Gi
+			var totalMemorySizeInMb = 2048 // 2 Gi
+			var diskSizeInMb = 1000
+			ctx := context.Background()
+
+			totalMemorySize := strconv.Itoa(totalMemorySizeInMb) + "Mi"
+			nativeMemorySize := strconv.Itoa(nativeMemorySizeInMb) + "Mi"
+			mapMemoryCapacitySize := strconv.Itoa(mapMemory) + "Mi"
+			diskSize := strconv.Itoa(diskSizeInMb) + "Mi"
+			hazelcast := hazelcastconfig.HazelcastTieredStorage(hzLookupKey, deviceName, labels)
+			hazelcast.Spec.ClusterSize = pointer.Int32(2)
+			hazelcast.Spec.ExposeExternally = &hazelcastv1alpha1.ExposeExternallyConfiguration{
+				Type:                 hazelcastv1alpha1.ExposeExternallyTypeUnisocket,
+				DiscoveryServiceType: corev1.ServiceTypeLoadBalancer,
+			}
+			hazelcast.Spec.LocalDevices[0].PVC.RequestStorage = &[]resource.Quantity{resource.MustParse(diskSize)}[0]
+			hazelcast.Spec.Resources = &corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse(totalMemorySize)},
+			}
+			hazelcast.Spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
+				Size: []resource.Quantity{resource.MustParse(nativeMemorySize)}[0],
+			}
+
+			CreateHazelcastCR(hazelcast)
+			evaluateReadyMembers(hzLookupKey)
+
+			By("creating the map config and putting entries")
+			tsMap := hazelcastconfig.DefaultTieredStoreMap(mapLookupKey, hazelcast.Name, deviceName, labels)
+			tsMap.Spec.TieredStore.MemoryCapacity = &[]resource.Quantity{resource.MustParse(mapMemoryCapacitySize)}[0]
+			Expect(k8sClient.Create(context.Background(), tsMap)).Should(Succeed())
+			assertMapStatus(tsMap, hazelcastv1alpha1.MapSuccess)
+
+			fmt.Printf("filling the map '%s' with '%d' MB data\n", tsMap.MapName(), mapSizeInMb)
+			hzAddress := hzclient.HazelcastUrl(hazelcast)
+			clientHz := GetHzClient(ctx, types.NamespacedName{Name: hazelcast.Name, Namespace: hazelcast.Namespace}, true)
+			defer func() {
+				err := clientHz.Shutdown(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			}()
+			t := Now()
+			mapLoaderPod := createMapLoaderPod(hzAddress, hazelcast.Spec.ClusterName, mapSizeInMb, tsMap.MapName(), types.NamespacedName{Name: hazelcast.Name, Namespace: hazelcast.Namespace})
+			defer DeletePod(mapLoaderPod.Name, 10, types.NamespacedName{Namespace: hazelcast.Namespace})
+
+			CheckPodStatus(types.NamespacedName{Name: mapLoaderPod.Name, Namespace: mapLoaderPod.Namespace}, corev1.PodFailed)
+
+			var logs io.ReadCloser
+
+			logs = GetPodLogs(context.Background(), types.NamespacedName{
+				Name:      mapLoaderPod.Name,
+				Namespace: mapLoaderPod.Namespace,
+			}, &corev1.PodLogOptions{
+				Follow:    true,
+				SinceTime: &metav1.Time{Time: t},
+			})
+
+			logReader := test.NewLogReader(logs)
+			defer logReader.Close()
+			test.EventuallyInLogs(logReader, 300*Second, logInterval/2).
+				Should(ContainSubstring("com.hazelcast.internal.tstore.device.DeviceOutOfCapacityException"))
+		})
+
+		It("should get all data after scale down and up", Tag(EE|AnyCloud), func() {
+			setLabelAndCRName("hpts-3")
+
+			deviceName := "test-device"
+			var nativeMemorySizeInMb = 1536 // 1.5Gi
+			var mapMemory = 32
+			var mapSizeInMb = 200
+			var totalMemorySizeInMb = 2048 // 2 Gi
+			var diskSizeInMb = 1024        // 1 Gi
+			var expectedMapSize = int(float64(mapSizeInMb) * 128)
+			ctx := context.Background()
+
+			totalMemorySize := strconv.Itoa(totalMemorySizeInMb) + "Mi"
+			nativeMemorySize := strconv.Itoa(nativeMemorySizeInMb) + "Mi"
+			mapMemoryCapacitySize := strconv.Itoa(mapMemory) + "Mi"
+			diskSize := strconv.Itoa(diskSizeInMb) + "Mi"
+			hazelcast := hazelcastconfig.HazelcastTieredStorage(hzLookupKey, deviceName, labels)
+			hazelcast.Spec.ExposeExternally = &hazelcastv1alpha1.ExposeExternallyConfiguration{
+				Type:                 hazelcastv1alpha1.ExposeExternallyTypeUnisocket,
+				DiscoveryServiceType: corev1.ServiceTypeLoadBalancer,
+			}
+			hazelcast.Spec.LocalDevices[0].PVC.RequestStorage = &[]resource.Quantity{resource.MustParse(diskSize)}[0]
+			hazelcast.Spec.Resources = &corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse(totalMemorySize)},
+			}
+			hazelcast.Spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
+				Size: []resource.Quantity{resource.MustParse(nativeMemorySize)}[0],
+			}
+
+			CreateHazelcastCR(hazelcast)
+			evaluateReadyMembers(hzLookupKey)
+
+			By("creating the map config and putting entries")
+			tsMap := hazelcastconfig.DefaultTieredStoreMap(mapLookupKey, hazelcast.Name, deviceName, labels)
+			tsMap.Spec.TieredStore.MemoryCapacity = &[]resource.Quantity{resource.MustParse(mapMemoryCapacitySize)}[0]
+			Expect(k8sClient.Create(context.Background(), tsMap)).Should(Succeed())
+			assertMapStatus(tsMap, hazelcastv1alpha1.MapSuccess)
+			FillMapBySizeInMb(ctx, tsMap.MapName(), mapSizeInMb, mapSizeInMb, hazelcast)
+
+			WaitForMapSize(context.Background(), hzLookupKey, tsMap.MapName(), expectedMapSize, 3*Minute)
+
+			By("scale down Hazelcast")
+			UpdateHazelcastCR(hazelcast, func(hazelcast *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1.Hazelcast {
+				hazelcast.Spec.ClusterSize = pointer.Int32(2)
+				return hazelcast
+			})
+			WaitForReplicaSize(hazelcast.Namespace, hazelcast.Name, 2)
+
+			WaitForMapSize(context.Background(), hzLookupKey, tsMap.MapName(), expectedMapSize, 3*Minute)
+
+			By("scale up Hazelcast")
+			UpdateHazelcastCR(hazelcast, func(hazelcast *hazelcastv1alpha1.Hazelcast) *hazelcastv1alpha1.Hazelcast {
+				hazelcast.Spec.ClusterSize = pointer.Int32(3)
+				return hazelcast
+			})
+			evaluateReadyMembers(hzLookupKey)
+
+			WaitForMapSize(context.Background(), hzLookupKey, tsMap.MapName(), expectedMapSize, 3*Minute)
+
+		})
+
+		It("should get all data and member should join the cluster after ungraceful shutdown", Tag(EE|AnyCloud), func() {
+			setLabelAndCRName("hpts-4")
+
+			deviceName := "test-device"
+			var nativeMemorySizeInMb = 1536 // 1.5Gi
+			var mapMemory = 32
+			var mapSizeInMb = 200
+			var totalMemorySizeInMb = 2048 // 2 Gi
+			var diskSizeInMb = 1024        // 1 Gi
+			var expectedMapSize = int(float64(mapSizeInMb) * 128)
+			ctx := context.Background()
+
+			totalMemorySize := strconv.Itoa(totalMemorySizeInMb) + "Mi"
+			nativeMemorySize := strconv.Itoa(nativeMemorySizeInMb) + "Mi"
+			mapMemoryCapacitySize := strconv.Itoa(mapMemory) + "Mi"
+			diskSize := strconv.Itoa(diskSizeInMb) + "Mi"
+			hazelcast := hazelcastconfig.HazelcastTieredStorage(hzLookupKey, deviceName, labels)
+			hazelcast.Spec.ExposeExternally = &hazelcastv1alpha1.ExposeExternallyConfiguration{
+				Type:                 hazelcastv1alpha1.ExposeExternallyTypeUnisocket,
+				DiscoveryServiceType: corev1.ServiceTypeLoadBalancer,
+			}
+			hazelcast.Spec.LocalDevices[0].PVC.RequestStorage = &[]resource.Quantity{resource.MustParse(diskSize)}[0]
+			hazelcast.Spec.Resources = &corev1.ResourceRequirements{
+				Limits: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceMemory: resource.MustParse(totalMemorySize)},
+			}
+			hazelcast.Spec.NativeMemory = &hazelcastv1alpha1.NativeMemoryConfiguration{
+				Size: []resource.Quantity{resource.MustParse(nativeMemorySize)}[0],
+			}
+
+			CreateHazelcastCR(hazelcast)
+			evaluateReadyMembers(hzLookupKey)
+
+			By("creating the map config and putting entries")
+			tsMap := hazelcastconfig.DefaultTieredStoreMap(mapLookupKey, hazelcast.Name, deviceName, labels)
+			tsMap.Spec.TieredStore.MemoryCapacity = &[]resource.Quantity{resource.MustParse(mapMemoryCapacitySize)}[0]
+			Expect(k8sClient.Create(context.Background(), tsMap)).Should(Succeed())
+			assertMapStatus(tsMap, hazelcastv1alpha1.MapSuccess)
+			FillMapBySizeInMb(ctx, tsMap.MapName(), mapSizeInMb, mapSizeInMb, hazelcast)
+
+			WaitForMapSize(context.Background(), hzLookupKey, tsMap.MapName(), expectedMapSize, 3*Minute)
+
+			DeletePod(hazelcast.Name+"-2", 0, hzLookupKey)
+			WaitForPodReady(hazelcast.Name+"-2", hzLookupKey, 1*Minute)
+			evaluateReadyMembers(hzLookupKey)
+
+			WaitForMapSize(context.Background(), hzLookupKey, tsMap.MapName(), expectedMapSize, 3*Minute)
+
 		})
 	})
 

--- a/test/e2e/platform_tiered_storage_test.go
+++ b/test/e2e/platform_tiered_storage_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Hazelcast CR with Tiered Storage feature enabled", Group("plat
 
 			logReader := test.NewLogReader(logs)
 			defer logReader.Close()
-			test.EventuallyInLogs(logReader, 300*Second, logInterval/2).
+			test.EventuallyInLogs(logReader, 10*Minute, logInterval/2).
 				Should(ContainSubstring("com.hazelcast.internal.tstore.device.DeviceOutOfCapacityException"))
 		})
 

--- a/test/e2e/platform_tiered_storage_test.go
+++ b/test/e2e/platform_tiered_storage_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
 	"github.com/hazelcast/hazelcast-platform-operator/test"
-	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -131,9 +130,7 @@ var _ = Describe("Hazelcast CR with Tiered Storage feature enabled", Group("plat
 
 			CheckPodStatus(types.NamespacedName{Name: mapLoaderPod.Name, Namespace: mapLoaderPod.Namespace}, corev1.PodFailed)
 
-			var logs io.ReadCloser
-
-			logs = GetPodLogs(context.Background(), types.NamespacedName{
+			logs := GetPodLogs(context.Background(), types.NamespacedName{
 				Name:      mapLoaderPod.Name,
 				Namespace: mapLoaderPod.Namespace,
 			}, &corev1.PodLogOptions{

--- a/test/maploader/maploader.go
+++ b/test/maploader/maploader.go
@@ -76,7 +76,6 @@ func main() {
 }
 
 func mapInjector(ctx context.Context, m *hazelcast.Map, key, value string) {
-	log.Printf("Key: %s is putting into map.", key)
 	_, err := m.Put(ctx, key, value)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Description

Added 3 tests:
* Ensure that the cluster throws DeviceOutOfCapacityException when the data load exceeds the sum of memory-tier capacity and device capacity.
* Ensure that scaling down and up back should successfully formed the cluster and no data loss.
* Ensure that member join the cluster after ungraceful member shutdown.

