### PR TITLE
Update get_image() function in utils.sh

### DIFF
--- a/.github/scripts/utils.sh
+++ b/.github/scripts/utils.sh
@@ -15,7 +15,7 @@ get_image()
     fi
 
     local FILTER="filter=deleted==false;${PUBLISHED_FILTER};repositories.tags.name==${VERSION}"
-    local INCLUDE="include=total,data.repositories.tags.name,data.scan_status,data._id"
+    local INCLUDE="include=total,data.repositories.tags.name,data._id,data.container_grades.status"
 
     local RESPONSE=$( \
         curl --silent \


### PR DESCRIPTION
## Description

Openshift update their API and removed filter fields from response. This changes is required to successfully release our operator.
