### PR TITLE
[CN-1168] Update test-and-release.yaml

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -129,7 +129,6 @@ jobs:
               memberAccess: NodePortExternalIP
             licenseKeySecret: hazelcast-license-key
             persistence:
-              baseDir: "/data/hot-restart/"
               clusterDataRecoveryPolicy: "FullRecoveryOnly"
               pvc:
                 accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
## Description

5.11.0 doesn't support baseDir so it should be removed

