### PR TITLE
Update make install-crds and uninstall-crds commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,13 +302,13 @@ sync-manifests: manifests yq
 # Role and ClusterRole syncing is done manually
 
 install-crds: helm sync-manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config. NOTE: 'default' namespace is used for the CRD chart release since we are checking if the CRDs is installed before, then we are skipping CRDs installation. To be able to achieve this, we need static CRD_RELEASE_NAME and namespace
-	$(HELM) template $(CRD_RELEASE_NAME) $(CRD_CHART) | $(KUBECTL) apply -f -
+	$(HELM) upgrade $(CRD_RELEASE_NAME) $(CRD_CHART) --install
 
 install-operator: helm sync-manifests
 	$(HELM) upgrade --install $(RELEASE_NAME) $(OPERATOR_CHART) --set $(STRING_SET_VALUES) -n $(NAMESPACE)
 
 uninstall-crds: helm sync-manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(HELM) template $(CRD_RELEASE_NAME) $(CRD_CHART) | $(KUBECTL) delete -f -
+	$(HELM) uninstall $(CRD_RELEASE_NAME)
 
 uninstall-operator: helm sync-manifests
 	$(HELM) uninstall $(RELEASE_NAME) -n $(NAMESPACE)


### PR DESCRIPTION
In the previous command we were using `helm template` which is not an actual helm installation. So following annotations and labels were not appended. 
```
meta.helm.sh/release-name: operator-crds
meta.helm.sh/release-namespace: default
app.kubernetes.io/managed-by: Helm
``` 
When we try to use `helm install` or `helm upgrade` command for the crds in our ocp cluster, we were getting the following error 
```
Error: INSTALLATION FAILED: Unable to continue with install: CustomResourceDefinition "caches.hazelcast.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "operator-crds";
```

You may ask why don't we use `helm install` instead of `helm upgrade --install` in the new approach. It's because we don't delete crds in ocp workflow. But we always call `make install-crds` at the beginning in the workflow to update the crds if there is any change on the main. If we use just `helm install`, we would get the following error
```
Error: INSTALLATION FAILED: cannot re-use a name that is still in use
```
With the help of `helm upgrade --install`, we can do installation and upgrade in a single command which is perfectly suitable for our ocp workflow. Here is the `--install` flag definition.
```
-i, --install                      if a release by this name doesn't already exist, run an install
```