### PR TITLE
[CN-1248]Remove reports creation for non-distribution tests

### DIFF
--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -295,7 +295,7 @@ jobs:
 
   report-generation:
     needs: ["prepare-env", "aks-e2e-tests"]
-    if: always() && (needs.aks-e2e-tests.result == 'success' || needs.aks-e2e-tests.result == 'failure')
+    if: always() && (needs.aks-e2e-tests.result == 'success' || needs.aks-e2e-tests.result == 'failure') && github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -279,7 +279,7 @@ jobs:
 
   report-generation:
     needs: ["prepare-env", "eks-e2e-tests"]
-    if: always() && (needs.eks-e2e-tests.result == 'success' || needs.eks-e2e-tests.result == 'failure')
+    if: always() && (needs.eks-e2e-tests.result == 'success' || needs.eks-e2e-tests.result == 'failure') && github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/e2e-gke.yaml
+++ b/.github/workflows/e2e-gke.yaml
@@ -297,7 +297,7 @@ jobs:
 
   report-generation:
     needs: ["gke-e2e-tests", "create-gke-cluster"]
-    if: always() && (needs.gke-e2e-tests.result == 'success' || needs.gke-e2e-tests.result == 'failure')
+    if: always() && (needs.gke-e2e-tests.result == 'success' || needs.gke-e2e-tests.result == 'failure') && github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/generate-test-report.yaml
     secrets: inherit
     with:

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -243,11 +243,3 @@ jobs:
           *)  echo Unexpected edition: ${{ matrix.edition }} && exit 1;;
           esac
           make test-e2e REPORT_SUFFIX=${{ matrix.edition }}_${{ inputs.k8s-cluster-version }} GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=${NAMESPACE} RELEASE_NAME=${RELEASE_NAME} WORKFLOW_ID=pr
-
-      - name: Upload Test Report
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-report-kind
-          path: allure-results/pr/
-          retention-days: 5


### PR DESCRIPTION
## Description

To avoid the wrong order in report, the report creation was disabled in WF if it’s not triggered by Push event into main
