### PR TITLE
[CN-1259] Fix Failed to watch *v1.Node: unknown (get nodes)

### DIFF
--- a/helm-charts/hazelcast-platform-operator/templates/_helpers.tpl
+++ b/helm-charts/hazelcast-platform-operator/templates/_helpers.tpl
@@ -126,6 +126,7 @@ Rules needed for giving Hazelcast node read permissions
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
Here is the error seen in the operator log:
`E0425 15:01:06.189842      34 reflector.go:147] pkg/mod/k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: Failed to watch *v1.Node: unknown (get nodes)`