### PR TITLE
[CN-1255]: add threadName to logging pattern

### DIFF
--- a/internal/controller/hazelcast/hazelcast_resources.go
+++ b/internal/controller/hazelcast/hazelcast_resources.go
@@ -2789,7 +2789,7 @@ func env(h *hazelcastv1alpha1.Hazelcast) []v1.EnvVar {
 		},
 		{
 			Name:  "LOGGING_PATTERN",
-			Value: `{"time":"%date{ISO8601}", "logger": "%logger{36}", "level": "%level", "msg": "%enc{%m %xEx}{JSON}"}%n`,
+			Value: `{"time":"%date{ISO8601}", "threadName": "%threadName", "logger": "%logger{36}", "level": "%level", "msg": "%enc{%m %xEx}{JSON}"}%n`,
 		},
 		{
 			Name:  "LOGGING_LEVEL",

--- a/internal/controller/hazelcast/hazelcast_resources.go
+++ b/internal/controller/hazelcast/hazelcast_resources.go
@@ -2789,7 +2789,7 @@ func env(h *hazelcastv1alpha1.Hazelcast) []v1.EnvVar {
 		},
 		{
 			Name:  "LOGGING_PATTERN",
-			Value: `{"time":"%date{ISO8601}", "threadName": "%threadName", "logger": "%logger{36}", "level": "%level", "msg": "%enc{%m %xEx}{JSON}"}%n`,
+			Value: `{"time":"%date{ISO8601}", "level": "%level", "threadName": "%threadName", "logger": "%logger{36}", "msg": "%enc{%m %xEx}{JSON}"}%n`,
 		},
 		{
 			Name:  "LOGGING_LEVEL",


### PR DESCRIPTION
## Description

Change Hazelcast members' logging pattern to include thread name as well.

## User Impact

Users will be able to see thread name in the logs of Hazelcast members.
