### PR TITLE
Delete EKS test clusters using 'eksctl'

### DIFF
--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -321,10 +321,12 @@ jobs:
 
       - name: Delete EKS cluster
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
-          source .github/scripts/utils.sh
-          wait_for_eks_stack_deleted eksctl-$CLUSTER_NAME $DELETE_EKS_STACK_TIMEOUT_IN_MINS
-          clean_open_id_connect_providers ${{ env.AWS_REGION }} $CLUSTER_NAME
+          CLUSTER_NAME=${{ needs.prepare-env.outputs.CLUSTER_NAME }}
+          REGION=${{ env.AWS_REGION }}
+          eksctl delete cluster \
+            --region=${REGION} \
+            --name=${CLUSTER_NAME} \
+            --wait
 
   slack_notify:
     name: Slack Notify

--- a/.github/workflows/e2e-platfrom-soak.yaml
+++ b/.github/workflows/e2e-platfrom-soak.yaml
@@ -252,10 +252,12 @@ jobs:
 
       - name: Delete EKS cluster
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
-          source .github/scripts/utils.sh
-          wait_for_eks_stack_deleted eksctl-$CLUSTER_NAME $DELETE_EKS_STACK_TIMEOUT_IN_MINS
-          clean_open_id_connect_providers ${{ env.AWS_REGION }} $CLUSTER_NAME
+          CLUSTER_NAME=${{ needs.prepare-env.outputs.CLUSTER_NAME }}
+          REGION=${{ env.AWS_REGION }}
+          eksctl delete cluster \
+            --region=${REGION} \
+            --name=${CLUSTER_NAME} \
+            --wait
 
   slack_notify:
     name: Slack Notify


### PR DESCRIPTION
## Description

Use `eksctl` to delete EKS clusters after the AWS tests.
If it fails, we can continue using the current method defined in #546

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
