### PR TITLE
[CN-1291] Update publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -407,6 +407,7 @@ jobs:
           --body ""
 
   validate-release:
+    if: always()
     name: Approve/Reject release?
     needs: ['publish_docker_image', 'publish_image_to_redhat', 'helm_chart_release']
     runs-on: ubuntu-latest
@@ -417,7 +418,7 @@ jobs:
   revert_changes:
     name: Revert Release Changes
     needs: validate-release
-    if: needs.validate-release.result == 'failure'
+    if: always() && needs.validate-release.result == 'failure'
     runs-on: ubuntu-latest
     env:
       CURRENT_LATEST_TAG: ${{ needs.publish_docker_image.outputs.CURRENT_LATEST_TAG }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -63,8 +63,8 @@ jobs:
             "password": "${{ env.DOCKERHUB_PASSWORD }}"
           }'| jq -r '.token')
 
-          CURRENT_LATEST_TAG=$(curl --fail -L -s -X GET 'https://hub.docker.com/v2/namespaces/hazelcast/repositories/hazelcast-platform-operator/images?status=active&currently_tagged=true&page_size=100' \
-          -H "Authorization: Bearer $token" | jq -r  '.results[] | select(any(.tags[]; .tag == "latest" and .is_current == true)) | .tags[] | select(.is_current == true and .tag != "latest" and (.tag | test("\\d+\\.\\d+\\.\\d+")))| .tag')
+          CURRENT_LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/hazelcast/hazelcast-platform-operator/tags/?page_size=100" \
+          -H "Authorization: Bearer $token" | jq -r '[.results[] | select(.name | test("\\d+\\.\\d+\\.\\d+")) | {name, last_updated}] | sort_by(.last_updated) | last.name')
           echo "CURRENT_LATEST_TAG=${CURRENT_LATEST_TAG}" >> $GITHUB_ENV
           echo "CURRENT_LATEST_TAG=${CURRENT_LATEST_TAG}" >> $GITHUB_OUTPUT
 
@@ -147,13 +147,25 @@ jobs:
           source .github/scripts/utils.sh
           sync_certificated_image_tags "${{ env.PREFLIGHT_PROJECT_ID }}" "$CERT_IMAGE_ID" "${{ env.PFLT_PYXIS_API_TOKEN }}"
 
-  redhat_certified_operator_release:
-    name: Create a PR in 'certified-operators' Repository
+  operator_bundle_release:
+    name: Create a PR in
     runs-on: ubuntu-latest
     needs: ['publish_docker_image', 'publish_image_to_redhat']
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo-name: community-operators
+            repo-owner: k8s-operatorhub
+
+          - repo-name: certified-operators
+            repo-owner: redhat-openshift-ecosystem
+
+          - repo-name: community-operators-prod
+            repo-owner: redhat-openshift-ecosystem
     env:
-      REPO_NAME: certified-operators
-      REPO_OWNER: redhat-openshift-ecosystem
+      REPO_NAME: ${{ matrix.repo-name }}
+      REPO_OWNER: ${{ matrix.repo-owner }}
       RELEASE_VERSION: ${{ needs.publish_docker_image.outputs.RELEASE_VERSION }}
       IMAGE_DIGEST: ${{ needs.publish_docker_image.outputs.IMAGE_DIGEST }}
       BUNDLE_RELEASE_VERSION: ${{ needs.publish_docker_image.outputs.BUNDLE_RELEASE_VERSION }}
@@ -188,7 +200,7 @@ jobs:
         run: |
           make bundle-ocp-validate
 
-      - name: Checkout to devOpsHelm
+      - name: Checkout to devOpsHelm/${{ env.REPO_NAME }}
         uses: actions/checkout@v4
         with:
           repository: devOpsHelm/${{ env.REPO_NAME }}
@@ -212,6 +224,11 @@ jobs:
 
           # Copy bundle files under new version of the operator
           git checkout -b $BRANCH_NAME
+          if [ "${{ env.REPO_NAME }}" == "certified-operators" ]; then
+          cat >> operators/${OPERATOR_NAME}/ci.yaml <<EOF
+          merge: false
+          EOF
+          fi
           mkdir -p operators/${OPERATOR_NAME}/${BUNDLE_RELEASE_VERSION}
           cp -r ../bundle/* operators/${OPERATOR_NAME}/${BUNDLE_RELEASE_VERSION}/
 
@@ -226,96 +243,18 @@ jobs:
           echo ${{ env.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
           gh pr create --title \
           "operator ${OPERATOR_NAME} (${BUNDLE_RELEASE_VERSION})" --body "" --repo ${REPO_OWNER}/${REPO_NAME}
-
-  operatorhub_release:
-    name: Create a PR in
-    runs-on: ubuntu-latest
-    needs: ['publish_docker_image', 'publish_image_to_redhat']
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - repo-name: community-operators
-            repo-owner: k8s-operatorhub
-
-          - repo-name: community-operators-prod
-            repo-owner: redhat-openshift-ecosystem
-    env:
-      REPO_NAME: ${{ matrix.repo-name }}
-      REPO_OWNER: ${{ matrix.repo-owner }}
-      RELEASE_VERSION: ${{ needs.publish_docker_image.outputs.RELEASE_VERSION }}
-      IMAGE_DIGEST: ${{ needs.publish_docker_image.outputs.IMAGE_DIGEST }}
-      BUNDLE_RELEASE_VERSION: ${{ needs.publish_docker_image.outputs.BUNDLE_RELEASE_VERSION }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build Red Hat Bundle
-        run: |
-          IMAGE_NAME_DIGEST=docker.io/hazelcast/${OPERATOR_NAME}@${IMAGE_DIGEST}
-          make bundle IMG=${IMAGE_NAME_DIGEST} VERSION=${RELEASE_VERSION}
-          cat >> ./bundle/metadata/annotations.yaml <<EOF
-            # OpenShift annotations.
-            com.redhat.openshift.versions: v4.8
-            operators.operatorframework.io.bundle.channel.default.v1: alpha
-          EOF
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            DEVOPS_GITHUB_TOKEN,CN/DEVOPS_GITHUB_TOKEN
-
-      - name: Checkout to devOpsHelm/${{ env.REPO_NAME }}
-        uses: actions/checkout@v4
-        with:
-          repository: devopsHelm/${{ env.REPO_NAME }}
-          path: ${{ env.REPO_NAME }}
-          token: ${{ env.DEVOPS_GITHUB_TOKEN }}
-
-      - name: Update main branch of the fork
-        working-directory: ${{ env.REPO_NAME}}
-        run: |
-          git checkout main
-          git remote add upstream https://github.com/${REPO_OWNER}/${REPO_NAME}.git
-          git pull upstream main
-          git push origin main
-
-      - name: Commit and push changes to bundle
-        working-directory: ${{ env.REPO_NAME}}
-        run: |
-          git config user.email "devopshelm@hazelcast.com"
-          git config user.name "devOpsHelm"
-          BRANCH_NAME=${OPERATOR_NAME}-${BUNDLE_RELEASE_VERSION}-${{ github.run_id }}
-
-          # Copy bundle files under new version of the operator
-          git checkout -b $BRANCH_NAME
-          mkdir -p operators/${OPERATOR_NAME}/${BUNDLE_RELEASE_VERSION}
-          cp -r ../bundle/* operators/${OPERATOR_NAME}/${BUNDLE_RELEASE_VERSION}/
-
-          # Commit and push changes
-          git add  ./operators/${OPERATOR_NAME}
-          git commit --signoff -m "Update ${OPERATOR_NAME} to ${BUNDLE_RELEASE_VERSION}"
-          git push -u origin $BRANCH_NAME
-
-      - name: Create PR
-        working-directory: ${{ env.REPO_NAME }}
-        run: |
-          echo ${{ env.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --title "operator ${OPERATOR_NAME} (${BUNDLE_RELEASE_VERSION})" \
-            --body "" --repo ${REPO_OWNER}/${REPO_NAME}
+          if ! gh pr view ${{ github.event.pull_request.number }} &> /dev/null; then
+              echo "Pull request ${{ github.event.pull_request.number }} not found, retrying in 10 seconds..."
+              sleep 10
+          fi
+          if [ "${{ env.REPO_NAME }}" != "certified-operators" ]; then
+            gh pr comment ${{ github.event.pull_request.number }} --body "/hold"
+          fi
 
   helm_chart_release:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: ['operatorhub_release']
+    needs: ['operator_bundle_release']
     steps:
       - name: Checkout 'Hazelcast Operator' Repository
         uses: actions/checkout@v4
@@ -467,14 +406,21 @@ jobs:
           --milestone "${RELEASE_VERSION}" \
           --body ""
 
+  validate-release:
+    name: Approve/Reject release?
+    needs: ['publish_docker_image', 'publish_image_to_redhat', 'helm_chart_release']
+    runs-on: ubuntu-latest
+    environment: 'prod'
+    steps:
+      - run: ""
+
   revert_changes:
     name: Revert Release Changes
-    needs: ['publish_docker_image', 'publish_image_to_redhat', 'helm_chart_release']
-    if: always() && (needs.publish_docker_image.result == 'failure' || needs.publish_image_to_redhat.result == 'failure' || needs.operatorhub_release.result == 'failure' || needs.helm_chart_release.result == 'failure')
+    needs: validate-release
+    if: needs.validate-release.result == 'failure'
     runs-on: ubuntu-latest
     env:
       CURRENT_LATEST_TAG: ${{ needs.publish_docker_image.outputs.CURRENT_LATEST_TAG }}
-      IMAGE_DIGEST: ${{ needs.publish_docker_image.outputs.IMAGE_DIGEST }}
       BUNDLE_RELEASE_VERSION: ${{ needs.publish_docker_image.outputs.BUNDLE_RELEASE_VERSION }}
     steps:
       - name: Checkout
@@ -498,6 +444,7 @@ jobs:
             PFLT_PYXIS_API_TOKEN,CN/PREFLIGHT_RHEL_API_KEY
 
       - name: Removing Published Docker Image
+        if: always() && !contains(needs.publish_docker_image.result, 'skipped')
         run: |
           auth_token=$(curl --fail -L -s -X POST 'https://hub.docker.com/v2/users/login' \
           -H 'Content-Type: application/json' \
@@ -505,45 +452,37 @@ jobs:
             "username": "${{ env.DOCKERHUB_USERNAME }}",
             "password": "${{ env.DOCKERHUB_PASSWORD }}"
           }'| jq -r '.token')
-
-          curl --fail -L -s -X POST 'https://hub.docker.com/v2/namespaces/hazelcast/delete-images' \
-          -H "Authorization: Bearer $auth_token" \
-          -H 'Content-Type: application/json' \
-          --data-raw '{
-              "manifests": [
-                  {
-                      "repository": "${{ env.OPERATOR_NAME }}",
-                      "digest": "${{ env.IMAGE_DIGEST }}"
-                  }
-              ],
-              "ignore_warnings": [
-                  {
-                      "repository": "${{ env.OPERATOR_NAME }}",
-                      "digest": "${{ env.IMAGE_DIGEST }}",
-                      "warning": "is_active"
-                  },
-                  {
-                      "repository": "${{ env.OPERATOR_NAME }}",
-                      "digest": "${{ env.IMAGE_DIGEST }}",
-                      "warning": "current_tag",
-                      "tags": [
-                          "${{ env.RELEASE_VERSION }}",
-                          "latest"
-                      ]
-                  }
-              ]
-          }'
+          
+           curl "https://hub.docker.com/v2/repositories/hazelcast/hazelcast-platform-operator/tags/${{ env.RELEASE_VERSION }}/" -X DELETE -H "Authorization: JWT ${auth_token}"
+           curl "https://hub.docker.com/v2/repositories/hazelcast/hazelcast-platform-operator/tags/latest/" -X DELETE -H "Authorization: JWT ${auth_token}"
 
       - name: Login to Docker Hub
+        if: always() && !contains(needs.publish_docker_image.result, 'skipped')
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_PASSWORD }}
 
       - name: Making Previous Docker Image Tag As 'latest'
+        if: always() && !contains(needs.publish_docker_image.result, 'skipped')
         run: |
           docker pull docker.io/hazelcast/${OPERATOR_NAME}:${CURRENT_LATEST_TAG}
           make docker-push-latest IMG="docker.io/hazelcast/${OPERATOR_NAME}:${CURRENT_LATEST_TAG}"
+
+      - name: Delete Published and Certified Opehshift Image
+        if: always() && !contains(needs.publish_image_to_redhat.result, 'skipped')
+        run: |
+          source .github/scripts/utils.sh
+          delete_container_image "${{ env.PREFLIGHT_PROJECT_ID }}" "${RELEASE_VERSION}" "${{ env.PFLT_PYXIS_API_TOKEN }}" "5"
+
+      - name: Close PR's in 'certified-operators, community-operators and community-operators-prod' Repo's
+        if: always()
+        run: |
+          echo ${{ env.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
+          for REPO in "redhat-openshift-ecosystem/certified-operators" "k8s-operatorhub/community-operators" "redhat-openshift-ecosystem/community-operators-prod"; do   
+            PR_NUMBER=$(gh pr list --repo $REPO --search "operator ${{ env.OPERATOR_NAME }} (${BUNDLE_RELEASE_VERSION})" --json number | jq -r '.[].number')
+            gh pr close $PR_NUMBER --repo $REPO --delete-branch 2>/dev/null
+          done
 
       - name: Removing Release Notes and Tag in 'Hazelcast Operator' Repo
         if: always()
@@ -552,12 +491,14 @@ jobs:
           gh release delete v${RELEASE_VERSION} --cleanup-tag --yes
 
       - name: Checkout to 'Hazelcast Charts' Repo
+        if: always() && !contains(needs.helm_chart_release.result, 'skipped')
         uses: actions/checkout@v4
         with:
           repository: hazelcast/charts
           token: ${{ env.DEVOPS_GITHUB_TOKEN }}
 
       - name: Deleting Branch and Tag in 'Hazelcast Charts' Repo
+        if: always() && !contains(needs.helm_chart_release.result, 'skipped')
         run: |
           set +e
           TAG_VERSION=v${RELEASE_VERSION}-operator
@@ -566,33 +507,23 @@ jobs:
           set -e
 
       - name: Download a Backup of the Helm Chart Index
+        if: always() && ${{ ! (contains(needs.helm_chart_release.result, 'skipped')) }}
         uses: actions/download-artifact@v3
         with:
           name: index.yaml
           path: ./index.yaml
 
       - name: Restore the Helm Chart Index
+        if: always() && !contains(needs.helm_chart_release.result, 'skipped')
         run: |
           aws s3 rm s3://hazelcast-charts/hazelcast-platform-operator-${RELEASE_VERSION}.tgz
           aws s3 rm s3://hazelcast-charts/hazelcast-platform-operator-crds-${RELEASE_VERSION}.tgz
           aws s3 cp ./index.yaml s3://hazelcast-charts
 
-      - name: Close PR's in 'certified-operators, community-operators and community-operators-prod' Repo's
-        run: |
-          echo ${{ env.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
-          for REPO in "redhat-openshift-ecosystem/certified-operators" "k8s-operatorhub/community-operators" "redhat-openshift-ecosystem/community-operators-prod"; do   
-            PR_NUMBER=$(gh pr list --repo $REPO --search "operator ${{ env.OPERATOR_NAME }} (${BUNDLE_RELEASE_VERSION})" --json number | jq -r '.[].number')
-            gh pr close $PR_NUMBER --repo $REPO --delete-branch 2>/dev/null
-          done
-
-      - name: Delete Published and Certified Opehshift Image
-        run: |
-          delete_container_image "${{ env.PREFLIGHT_PROJECT_ID }}" "${RELEASE_VERSION}" "${{ env.PFLT_PYXIS_API_TOKEN }}" "5"
-
   slack_notify:
     name: Slack Notify
-    needs: ['publish_docker_image', 'publish_image_to_redhat', 'operatorhub_release', 'redhat_certified_operator_release', 'helm_chart_release']
-    if: needs.operatorhub_release.result != 'success' && needs.redhat_certified_operator_release.result != 'success' && needs.helm_chart_release.result != 'success'
+    needs: ['publish_docker_image', 'publish_image_to_redhat', 'operator_bundle_release', 'redhat_certified_operator_release', 'helm_chart_release']
+    if: needs.operator_bundle_release.result != 'success' && needs.redhat_certified_operator_release.result != 'success' && needs.helm_chart_release.result != 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
## Description

* Fixed issue with DockerHub API to get the latest tag before the release
* Fixed DockerHub API to remove the published images correctly
* Added command to update ci.yaml with `merge: false` property in certified-operators repo. Also added option to pause merge in community-operators-prod and community-operators
* Added `validate-release` job that will wait manual approval for the success release. In case of rejection - revert job will be triggered.
* Made all revert steps async
