### PR TITLE
Fix publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -425,14 +425,14 @@ jobs:
             fi
 
       - name: Checkout to hazelcast/hazelcast-platform-operator
-        if: always() && matrix.repo-name == "hazelcast-platform-operator"
+        if: always() && matrix.repo-name == 'hazelcast-platform-operator'
         uses: actions/checkout@v4
         with:
           repository: ${{ env.REPO_OWNER }}/${{ env.REPO_NAME }}
           token: ${{ env.DEVOPS_GITHUB_TOKEN }}
 
       - name: Merge Helm Chart PR
-        if: always() && matrix.repo-name == "hazelcast-platform-operator"
+        if: always() && matrix.repo-name == 'hazelcast-platform-operator'
         run: |
           echo ${{ env.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
           HELM_CHART_PR_NUMBER=$(gh pr list --repo hazelcast/hazelcast-platform-operator --search "Update Helm Chart Version to ${REPLACED_VERSION}-snapshot" --json number | jq -r '.[].number')

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -99,10 +99,8 @@ jobs:
 
       - name: Deploy and Run Migration test
         run: |
-          STABLE_VERSION=$(curl -s https://artifacthub.io/api/v1/packages/helm/hazelcast/hazelcast-platform-operator | jq -r '.version')
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$STABLE_VERSION"
-          ((MINOR++))
-          LATEST_VERSION="$MAJOR.$MINOR.$PATCH-snapshot"
+          LATEST_VERSION=$(curl -s https://artifacthub.io/api/v1/packages/helm/hazelcast/hazelcast-platform-operator | jq -r '.version')
+          STABLE_VERSION=$(curl -s https://artifacthub.io/api/v1/packages/helm/hazelcast/hazelcast-platform-operator | jq -r '.available_versions | map(select(.version | contains("snapshot") | not)) | .[0].version')
           
           kubectl create secret generic hazelcast-license-key --from-literal=license-key=${{ env.HZ_LICENSE_KEY }}
           helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com && \

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -546,7 +546,6 @@ jobs:
       - name: Delete Bundle Artifact
         uses: geekyeggo/delete-artifact@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           name: |
             bundle-artifacts
 


### PR DESCRIPTION
## Description

- Fix minor issue in getting helm chart version. Recent API call return 5.13.0-snapshot as stable version instead of 5.12.0
- Fix warning "Input 'token' has been deprecated with message: Token is no longer required."
- Remove double quotes from if condition