### PR TITLE
Fix map status when MapConfig creation failed [CN-1226]

### DIFF
--- a/internal/controller/hazelcast/fakes_test.go
+++ b/internal/controller/hazelcast/fakes_test.go
@@ -121,7 +121,7 @@ func fakeK8sClient(initObjs ...client.Object) client.Client {
 		}).
 		WithIndex(&hazelcastv1alpha1.WanReplication{}, "hazelcastResourceName", func(o client.Object) []string {
 			wr := o.(*hazelcastv1alpha1.WanReplication)
-			hzResources := []string{}
+			var hzResources []string
 			for k := range wr.Status.WanReplicationMapsStatus {
 				hzName, _ := splitWanMapKey(k)
 				hzResources = append(hzResources, hzName)

--- a/internal/controller/hazelcast/map_controller.go
+++ b/internal/controller/hazelcast/map_controller.go
@@ -137,8 +137,8 @@ func (r *MapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	ms, err := r.ReconcileMapConfig(ctx, m, h, cl, createdBefore)
 	if err != nil {
-		return updateMapStatus(ctx, r.Client, m, recoptions.RetryAfter(retryAfterForMap),
-			withMapState(hazelcastv1alpha1.MapPending),
+		return updateMapStatus(ctx, r.Client, m, recoptions.Error(err),
+			withMapState(hazelcastv1alpha1.MapFailed),
 			withMapMessage(err.Error()),
 			withMapMemberStatuses(ms))
 	}


### PR DESCRIPTION
## User Impact

When MapConfig creation fails to apply, the Map status will be set to Failed
