### PR TITLE
[CN-1289] Set different cluster names for each platform in distribution tests

### DIFF
--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Update kubeconfig
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-e2e-test-aks-${GITHUB_SHA::8}-${{ github.run_number }}"
           az aks get-credentials --resource-group "${AZURE_RESOURCE_GROUP}" --name "${CLUSTER_NAME}"
 
       - name: Authenticate to GAR
@@ -341,7 +341,7 @@ jobs:
         with:
           azcliversion: 2.31.0
           inlineScript: |
-            CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+            CLUSTER_NAME="operator-e2e-test-aks-${GITHUB_SHA::8}-${{ github.run_number }}"
             az aks delete --name "${CLUSTER_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" -y
 
   slack_notify:

--- a/.github/workflows/e2e-aks.yaml
+++ b/.github/workflows/e2e-aks.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           azcliversion: 2.31.0
           inlineScript: |
-            CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+            CLUSTER_NAME="operator-e2e-test-aks-${GITHUB_SHA::8}-${{ github.run_number }}"
             echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
             NRG=$(az aks create \
               --resource-group=${AZURE_RESOURCE_GROUP} \

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Update kubeconfig
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-e2e-test-eks-${GITHUB_SHA::8}-${{ github.run_number }}"
           aws eks update-kubeconfig --name "${CLUSTER_NAME}"
 
       - name: Authenticate to GAR

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Create EKS cluster
         id: create-cluster
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-e2e-test-eks-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_ENV
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           eksctl create cluster \

--- a/.github/workflows/e2e-gke.yaml
+++ b/.github/workflows/e2e-gke.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Create GKE cluster
         id: set-cluster-name
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-e2e-test-gke-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \

--- a/.github/workflows/e2e-istio.yaml
+++ b/.github/workflows/e2e-istio.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Create GKE cluster
         id: set-cluster-name
         run: |-
-          CLUSTER_NAME="operator-istio-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-istio-e2e-test-istio-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           gcloud container clusters create ${CLUSTER_NAME} \
             --zone=${{ env.GKE_ZONE }} \

--- a/.github/workflows/e2e-platfrom-soak.yaml
+++ b/.github/workflows/e2e-platfrom-soak.yaml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Update kubeconfig
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-e2e-test-soak-${GITHUB_SHA::8}-${{ github.run_number }}"
           aws eks update-kubeconfig --name "${CLUSTER_NAME}"
 
       - name: Authenticate to GAR

--- a/.github/workflows/e2e-platfrom-soak.yaml
+++ b/.github/workflows/e2e-platfrom-soak.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Create EKS cluster
         id: create-cluster
         run: |-
-          CLUSTER_NAME="operator-e2e-test-${GITHUB_SHA::8}-${{ github.run_number }}"
+          CLUSTER_NAME="operator-e2e-test-soak-${GITHUB_SHA::8}-${{ github.run_number }}"
           echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           eksctl create cluster --name "${CLUSTER_NAME}" \
             --region=${AWS_REGION} \


### PR DESCRIPTION
## Description

The distribution workflow calls `run-aks` , `run-eks` and `run-gke` jobs referencing to yaml files. All these jobs create cluster with the same name. This makes it harder to filter logs by cluster in `Grafana` board. We need to create clusters with different names to be able to filter the distribution test logs.

## User Impact

<!--- Please describe any user facing impact of this change. This can be positive or negative impact. -->
