### PR TITLE
Fix error with MTLS client registry after operator restart [CN-1254]

### DIFF
--- a/internal/controller/hazelcast/fakes_test.go
+++ b/internal/controller/hazelcast/fakes_test.go
@@ -222,13 +222,6 @@ func (hr *fakeHttpClientRegistry) GetOrCreate(ctx context.Context, kubeClient cl
 	return hr.Create(ctx, kubeClient, ns)
 }
 
-func (hr *fakeHttpClientRegistry) Get(ns string) (*http.Client, bool) {
-	if v, ok := hr.clients.Load(types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: ns}); ok {
-		return v.(*http.Client), ok
-	}
-	return nil, false
-}
-
 func (hr *fakeHttpClientRegistry) Delete(ns string) {
 	hr.clients.Delete(types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: ns})
 }

--- a/internal/controller/hazelcast/fakes_test.go
+++ b/internal/controller/hazelcast/fakes_test.go
@@ -177,28 +177,16 @@ func setupTlsConfig(k8sClient client.Client, namespace string) *tls.Config {
 	return tlsConf
 }
 
-func fakeHttpServer(url string, handler http.HandlerFunc) (*httptest.Server, error) {
-	l, err := net.Listen("tcp", url)
-	if err != nil {
-		return nil, err
-	}
-	ts := httptest.NewUnstartedServer(handler)
-	_ = ts.Listener.Close()
-	ts.Listener = l
-	ts.Start()
-	return ts, nil
-}
-
 type fakeHzClientRegistry struct {
 	Clients sync.Map
 }
 
 func (cr *fakeHzClientRegistry) GetOrCreate(ctx context.Context, nn types.NamespacedName) (hzclient.Client, error) {
-	client, ok := cr.Get(nn)
+	c, ok := cr.Get(nn)
 	if !ok {
-		return client, fmt.Errorf("fake client was not set before test")
+		return c, fmt.Errorf("fake client was not set before test")
 	}
-	return client, nil
+	return c, nil
 }
 
 func (cr *fakeHzClientRegistry) Set(ns types.NamespacedName, cl hzclient.Client) {

--- a/internal/controller/hazelcast/hot_backup_controller.go
+++ b/internal/controller/hazelcast/hot_backup_controller.go
@@ -283,10 +283,9 @@ func (r *HotBackupReconciler) startBackup(ctx context.Context, backupName types.
 	backupUUIDs := make([]string, len(b.Members()))
 	// for each member monitor and upload backup if needed
 	g, groupCtx = errgroup.WithContext(ctx)
-	mtlsClient, ok := r.mtlsClientRegistry.Get(hazelcastName.Namespace)
-	if !ok {
-		returnErr := errors.New("failed to get MTLS client")
-		return r.updateStatus(ctx, backupName, recoptions.Error(returnErr),
+	mtlsClient, err := r.mtlsClientRegistry.GetOrCreate(ctx, r.Client, hazelcastName.Namespace)
+	if err != nil {
+		return r.updateStatus(ctx, backupName, recoptions.Error(err),
 			withHotBackupFailedState(err.Error()))
 	}
 

--- a/internal/controller/hazelcast/hot_backup_controller_test.go
+++ b/internal/controller/hazelcast/hot_backup_controller_test.go
@@ -2,6 +2,7 @@ package hazelcast
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,12 +43,9 @@ func TestHotBackupReconciler_shouldBeSuccessful(t *testing.T) {
 	nn, h, hb := defaultCRs()
 	fakeHzClient, fakeHzStatusService, _ := defaultFakeClientAndService()
 
-	defer defaultFakeHttpServer()()
-
 	cr := &fakeHzClientRegistry{}
 	sr := &fakeHzStatusServiceRegistry{}
-	hr := &fakeHttpClientRegistry{}
-	hr.Set(nn.Namespace, &http.Client{})
+	hr := mtls.NewHttpClientRegistry()
 	cr.Set(nn, &fakeHzClient)
 	sr.Set(nn, &fakeHzStatusService)
 
@@ -60,7 +58,18 @@ func TestHotBackupReconciler_shouldBeSuccessful(t *testing.T) {
 		Data:       make(map[string][]byte),
 	}
 	cm.Data["hazelcast.yaml"] = cfg
-	r := hotBackupReconcilerWithCRs(cr, sr, hr, h, hb, cm)
+
+	k8sClient := fakeK8sClient([]client.Object{h, hb, cm}...)
+	defer defaultFakeMtlsHttpServer(setupTlsConfig(k8sClient, nn.Namespace))()
+
+	r := NewHotBackupReconciler(
+		k8sClient,
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		hr,
+		cr,
+		sr,
+	)
 	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
 	Expect(err).Should(BeNil())
 
@@ -82,16 +91,23 @@ func TestHotBackupReconciler_shouldSetStatusToFailedWhenHbCallFails(t *testing.T
 		return nil, nil
 	}
 
-	defer defaultFakeHttpServer()()
-
 	sr := &fakeHzStatusServiceRegistry{}
 	cr := &fakeHzClientRegistry{}
-	hr := &fakeHttpClientRegistry{}
-	hr.Set(nn.Namespace, &http.Client{})
+	hr := mtls.NewHttpClientRegistry()
 	sr.Set(nn, &fakeHzStatusService)
 	cr.Set(nn, &fakeHzClient)
 
-	r := hotBackupReconcilerWithCRs(cr, sr, hr, h, hb)
+	k8sClient := fakeK8sClient([]client.Object{h, hb}...)
+	defer defaultFakeMtlsHttpServer(setupTlsConfig(k8sClient, nn.Namespace))()
+
+	r := NewHotBackupReconciler(
+		k8sClient,
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		hr,
+		cr,
+		sr,
+	)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
 	Expect(err).Should(BeNil())
 
@@ -108,16 +124,23 @@ func TestHotBackupReconciler_shouldSetStatusToFailedWhenTimedMemberStateFails(t 
 	fakeHzClient, fakeHzStatusService, mm := defaultFakeClientAndService()
 	fakeHzStatusService.timedMemberStateMap[mm[0].UUID].TimedMemberState.MemberState.HotRestartState.BackupTaskState = "FAILURE"
 
-	defer defaultFakeHttpServer()()
-
 	sr := &fakeHzStatusServiceRegistry{}
 	cr := &fakeHzClientRegistry{}
-	hr := &fakeHttpClientRegistry{}
-	hr.Set(nn.Namespace, &http.Client{})
+	hr := mtls.NewHttpClientRegistry()
 	sr.Set(nn, &fakeHzStatusService)
 	cr.Set(nn, &fakeHzClient)
 
-	r := hotBackupReconcilerWithCRs(cr, sr, hr, h, hb)
+	k8sClient := fakeK8sClient([]client.Object{h, hb}...)
+	defer defaultFakeMtlsHttpServer(setupTlsConfig(k8sClient, nn.Namespace))()
+
+	r := NewHotBackupReconciler(
+		k8sClient,
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		hr,
+		cr,
+		sr,
+	)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
 	Expect(err).Should(BeNil())
 
@@ -144,16 +167,23 @@ func TestHotBackupReconciler_shouldNotTriggerHotBackupTwice(t *testing.T) {
 		return nil, nil
 	}
 
-	defer defaultFakeHttpServer()()
-
 	sr := &fakeHzStatusServiceRegistry{}
 	cr := &fakeHzClientRegistry{}
-	hr := &fakeHttpClientRegistry{}
-	hr.Set(nn.Namespace, &http.Client{})
+	hr := mtls.NewHttpClientRegistry()
 	sr.Set(nn, &fakeHzStatusService)
 	cr.Set(nn, &fakeHzClient)
 
-	r := hotBackupReconcilerWithCRs(cr, sr, hr, h, hb)
+	k8sClient := fakeK8sClient([]client.Object{h, hb}...)
+	defer defaultFakeMtlsHttpServer(setupTlsConfig(k8sClient, nn.Namespace))()
+
+	r := NewHotBackupReconciler(
+		k8sClient,
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		hr,
+		cr,
+		sr,
+	)
 	var reconcileWg sync.WaitGroup
 	reconcileWg.Add(1)
 	go func() {
@@ -182,16 +212,24 @@ func TestHotBackupReconciler_shouldCancelContextIfHotbackupCRIsDeleted(t *testin
 	nn, h, hb := defaultCRs()
 
 	fakeHzClient, fakeHzStatusService, _ := defaultFakeClientAndService()
-	defer defaultFakeHttpServer()()
 
 	cr := &fakeHzClientRegistry{}
 	sr := &fakeHzStatusServiceRegistry{}
-	hr := &fakeHttpClientRegistry{}
-	hr.Set(nn.Namespace, &http.Client{})
+	hr := mtls.NewHttpClientRegistry()
 	cr.Set(nn, &fakeHzClient)
 	sr.Set(nn, &fakeHzStatusService)
 
-	r := hotBackupReconcilerWithCRs(cr, sr, hr, h, hb)
+	k8sClient := fakeK8sClient([]client.Object{h, hb}...)
+	defer defaultFakeMtlsHttpServer(setupTlsConfig(k8sClient, nn.Namespace))()
+
+	r := NewHotBackupReconciler(
+		k8sClient,
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		hr,
+		cr,
+		sr,
+	)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
 	Expect(err).Should(BeNil())
 
@@ -211,7 +249,14 @@ func TestHotBackupReconciler_shouldNotSetStatusToFailedIfHazelcastCRNotFound(t *
 	RegisterFailHandler(fail(t))
 	nn, _, hb := defaultCRs()
 
-	r := hotBackupReconcilerWithCRs(&fakeHzClientRegistry{}, &fakeHzStatusServiceRegistry{}, &fakeHttpClientRegistry{}, hb)
+	r := NewHotBackupReconciler(
+		fakeK8sClient([]client.Object{hb}...),
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		mtls.NewHttpClientRegistry(),
+		&fakeHzClientRegistry{},
+		&fakeHzStatusServiceRegistry{},
+	)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
 	if err != nil {
 		t.Errorf("Error expecting Reconcile to return without error")
@@ -230,7 +275,14 @@ func TestHotBackupReconciler_shouldFailIfPersistenceNotEnabledAtHazelcast(t *tes
 		n.LastSuccessfulSpecAnnotation: string(hs),
 	}
 
-	r := hotBackupReconcilerWithCRs(&fakeHzClientRegistry{}, &fakeHzStatusServiceRegistry{}, &fakeHttpClientRegistry{}, h, hb)
+	r := NewHotBackupReconciler(
+		fakeK8sClient([]client.Object{h, hb}...),
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		mtls.NewHttpClientRegistry(),
+		&fakeHzClientRegistry{},
+		&fakeHzStatusServiceRegistry{},
+	)
 	_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nn})
 	if err == nil {
 		t.Errorf("Error expecting Reconcile to return error")
@@ -267,7 +319,14 @@ func TestHotBackupReconciler_shouldFailIfDeletedWhenReferencedByHazelcastRestore
 		n.LastSuccessfulSpecAnnotation: string(hs),
 	}
 
-	r := hotBackupReconcilerWithCRs(&fakeHzClientRegistry{}, &fakeHzStatusServiceRegistry{}, &fakeHttpClientRegistry{}, h, hb)
+	r := NewHotBackupReconciler(
+		fakeK8sClient([]client.Object{h, hb}...),
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil,
+		mtls.NewHttpClientRegistry(),
+		&fakeHzClientRegistry{},
+		&fakeHzStatusServiceRegistry{},
+	)
 
 	// setup and start kubeclient for validator
 	err := kubeclient.Setup(r.Client).Start(context.Background())
@@ -283,17 +342,6 @@ func TestHotBackupReconciler_shouldFailIfDeletedWhenReferencedByHazelcastRestore
 		return hb.Status.State
 	}, 2*time.Second, 100*time.Millisecond).Should(Equal(hazelcastv1alpha1.HotBackupFailure))
 	Expect(hb.Status.Message).Should(ContainSubstring(fmt.Sprintf("Hazelcast '%s' has a restore reference to the Hotbackup", h.Name)))
-}
-
-func hotBackupReconcilerWithCRs(clientReg hzclient.ClientRegistry, serviceReg hzclient.StatusServiceRegistry, httpReg mtls.HttpClientRegistry, initObjs ...client.Object) *HotBackupReconciler {
-	return NewHotBackupReconciler(
-		fakeK8sClient(initObjs...),
-		ctrl.Log.WithName("test").WithName("Hazelcast"),
-		nil,
-		httpReg,
-		clientReg,
-		serviceReg,
-	)
 }
 
 func defaultFakeClientAndService() (fakeHzClient, fakeHzStatusService, []cluster.MemberInfo) {
@@ -378,11 +426,13 @@ func defaultCRs() (types.NamespacedName, *hazelcastv1alpha1.Hazelcast, *hazelcas
 	return nn, h, hb
 }
 
-func defaultFakeHttpServer() func() {
-	ts, err := fakeHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort), func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(200)
-		_, _ = writer.Write([]byte(`{"backups" : ["backup-123"]}`))
-	})
+func defaultFakeMtlsHttpServer(tlsConfig *tls.Config) func() {
+	ts, err := fakeMtlsHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort),
+		tlsConfig,
+		func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(200)
+			_, _ = writer.Write([]byte(`{"backups" : ["backup-123"]}`))
+		})
 	Expect(err).Should(BeNil())
 	return ts.Close
 }

--- a/internal/controller/hazelcast/hot_backup_controller_test.go
+++ b/internal/controller/hazelcast/hot_backup_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -284,18 +283,6 @@ func TestHotBackupReconciler_shouldFailIfDeletedWhenReferencedByHazelcastRestore
 		return hb.Status.State
 	}, 2*time.Second, 100*time.Millisecond).Should(Equal(hazelcastv1alpha1.HotBackupFailure))
 	Expect(hb.Status.Message).Should(ContainSubstring(fmt.Sprintf("Hazelcast '%s' has a restore reference to the Hotbackup", h.Name)))
-}
-
-func fail(t *testing.T) func(message string, callerSkip ...int) {
-	return func(message string, callerSkip ...int) {
-		if len(callerSkip) > 0 {
-			_, file, line, _ := runtime.Caller(callerSkip[0])
-			lineInfo := fmt.Sprintf("%s:%d", file, line)
-			t.Errorf("%s\n%s", lineInfo, message)
-		} else {
-			t.Error(message)
-		}
-	}
 }
 
 func hotBackupReconcilerWithCRs(clientReg hzclient.ClientRegistry, serviceReg hzclient.StatusServiceRegistry, httpReg mtls.HttpClientRegistry, initObjs ...client.Object) *HotBackupReconciler {

--- a/internal/controller/hazelcast/jetjob_controller.go
+++ b/internal/controller/hazelcast/jetjob_controller.go
@@ -3,7 +3,6 @@ package hazelcast
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"path"
@@ -228,10 +227,9 @@ func (r *JetJobReconciler) applyJetJob(ctx context.Context, job *hazelcastv1alph
 
 func (r *JetJobReconciler) downloadFile(ctx context.Context, job *hazelcastv1alpha1.JetJob, hazelcastName types.NamespacedName, jjnn types.NamespacedName, client hzclient.Client, logger logr.Logger) error {
 	g, groupCtx := errgroup.WithContext(ctx)
-	mtlsClient, ok := r.mtlsClientRegistry.Get(hazelcastName.Namespace)
-	if !ok {
-		returnErr := errors.New("failed to get MTLS client")
-		_, _ = r.updateStatus(ctx, jjnn, failedJetJobStatus(returnErr))
+	mtlsClient, err := r.mtlsClientRegistry.GetOrCreate(ctx, r.Client, hazelcastName.Namespace)
+	if err != nil {
+		_, _ = r.updateStatus(ctx, jjnn, failedJetJobStatus(err))
 	}
 	for _, m := range client.OrderedMembers() {
 		m := m

--- a/internal/controller/hazelcast/usercodenamespace_controller_test.go
+++ b/internal/controller/hazelcast/usercodenamespace_controller_test.go
@@ -1,0 +1,118 @@
+package hazelcast
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	hazelcastv1alpha1 "github.com/hazelcast/hazelcast-platform-operator/api/v1alpha1"
+	hzclient "github.com/hazelcast/hazelcast-platform-operator/internal/hazelcast-client"
+	"github.com/hazelcast/hazelcast-platform-operator/internal/mtls"
+	n "github.com/hazelcast/hazelcast-platform-operator/internal/naming"
+)
+
+func Test_UcnReconciler_mtlsClientShouldBeRecreated(t *testing.T) {
+	RegisterFailHandler(fail(t))
+
+	nn, h, ucn := defaultCrsUCN()
+	hs, _ := json.Marshal(h.Spec)
+	h.ObjectMeta.Annotations = map[string]string{
+		n.LastSuccessfulSpecAnnotation: string(hs),
+	}
+	k8sClient := fakeK8sClient(h, ucn)
+
+	certNn := types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: nn.Namespace}
+	_, err := mtls.NewClient(context.Background(), k8sClient, certNn)
+	Expect(err).To(BeNil())
+	certSecret := &v1.Secret{}
+	Expect(k8sClient.Get(context.TODO(), certNn, certSecret)).Should(Succeed())
+	defer ucnFakeMTLSHttpServer(certSecret.Data[mtls.TLSCAKey], certSecret.Data[v1.TLSCertKey], certSecret.Data[v1.TLSPrivateKeyKey])()
+
+	fakeHzClient, _, _ := defaultFakeClientAndService()
+	cr := &fakeHzClientRegistry{}
+	cr.Set(nn, &fakeHzClient)
+
+	r := NewUserCodeNamespaceReconciler(
+		k8sClient,
+		ctrl.Log.WithName("test").WithName("Hazelcast"),
+		nil, nil,
+		cr,
+		mtls.NewHttpClientRegistry())
+	_, err = r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: nn})
+	Expect(err).Should(BeNil())
+	Expect(k8sClient.Get(context.TODO(), nn, ucn)).Should(Succeed())
+	Expect(ucn.Status.State).Should(Equal(hazelcastv1alpha1.UserCodeNamespaceSuccess))
+}
+
+func defaultCrsUCN() (types.NamespacedName, *hazelcastv1alpha1.Hazelcast, *hazelcastv1alpha1.UserCodeNamespace) {
+	nn := types.NamespacedName{
+		Name:      "hazelcast",
+		Namespace: "default",
+	}
+	h := &hazelcastv1alpha1.Hazelcast{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.HazelcastSpec{
+			UserCodeNamespaces: &hazelcastv1alpha1.UserCodeNamespacesConfig{},
+		},
+		Status: hazelcastv1alpha1.HazelcastStatus{
+			Phase: hazelcastv1alpha1.Running,
+		},
+	}
+	hs, _ := json.Marshal(h.Spec)
+	h.ObjectMeta.Annotations = map[string]string{
+		n.LastSuccessfulSpecAnnotation: string(hs),
+	}
+	ucn := &hazelcastv1alpha1.UserCodeNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: hazelcastv1alpha1.UserCodeNamespaceSpec{
+			HazelcastResourceName: h.Name,
+			BucketConfiguration: &hazelcastv1alpha1.BucketConfiguration{
+				SecretName: "my-secret",
+				BucketURI:  "s3://my-bucket-uri",
+			},
+		},
+	}
+	controllerutil.AddFinalizer(ucn, n.Finalizer)
+	ucns, _ := json.Marshal(h.Spec)
+	ucn.ObjectMeta.Annotations = map[string]string{
+		n.LastAppliedSpecAnnotation: string(ucns),
+	}
+	return nn, h, ucn
+}
+
+func ucnFakeMTLSHttpServer(ca, cert, key []byte) func() {
+	pool := x509.NewCertPool()
+	Expect(pool.AppendCertsFromPEM(ca)).To(BeTrue())
+
+	pair, err := tls.X509KeyPair(cert, key)
+	Expect(err).Should(BeNil())
+	ts, err := fakeMtlsHttpServer(fmt.Sprintf("%s:%d", defaultMemberIP, hzclient.AgentPort),
+		&tls.Config{
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientCAs:    pool,
+			Certificates: []tls.Certificate{pair},
+		},
+		func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(200)
+			_, _ = writer.Write([]byte{})
+		})
+	Expect(err).Should(BeNil())
+	return ts.Close
+}

--- a/internal/controller/hazelcast/usercodenamespace_status.go
+++ b/internal/controller/hazelcast/usercodenamespace_status.go
@@ -2,6 +2,7 @@ package hazelcast
 
 import (
 	"context"
+	"errors"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +41,9 @@ func updateUserCodeNamespaceStatus(ctx context.Context, c client.Client, ucn *ha
 	err := c.Status().Update(ctx, ucn)
 	if options.state == hazelcastv1alpha1.UserCodeNamespacePending {
 		return ctrl.Result{Requeue: true}, nil
+	}
+	if options.state == hazelcastv1alpha1.UserCodeNamespaceFailure {
+		return ctrl.Result{}, errors.New(options.message)
 	}
 	return ctrl.Result{}, err
 }

--- a/internal/controller/hazelcast/wanreplication_controller.go
+++ b/internal/controller/hazelcast/wanreplication_controller.go
@@ -3,7 +3,6 @@ package hazelcast
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -331,9 +330,9 @@ func (r *WanReplicationReconciler) checkConnectivity(ctx context.Context, req ct
 			memberAddresses = append(memberAddresses, v.Address)
 		}
 
-		mtlsClient, ok := r.mtlsClientRegistry.Get(req.Namespace)
-		if !ok {
-			return errors.New("failed to get MTLS client")
+		mtlsClient, err := r.mtlsClientRegistry.GetOrCreate(ctx, r.Client, req.Namespace)
+		if err != nil {
+			return err
 		}
 		for _, memberAddress := range memberAddresses {
 			p, err := dialer.NewDialer(&dialer.Config{

--- a/internal/hazelcast-client/config_test_unit.go
+++ b/internal/hazelcast-client/config_test_unit.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	localUrl  = "127.0.0.1:8000"
-	AgentPort = 8080
+	AgentPort = 8443
 )
 
 func BuildConfig(h *hazelcastv1alpha1.Hazelcast, pool *x509.CertPool, cert *tls.Certificate, logger hzlogger.Logger) hazelcast.Config {
@@ -57,5 +57,5 @@ func HazelcastUrl(_ *hazelcastv1alpha1.Hazelcast) string {
 }
 
 func AgentUrl(host string) string {
-	return fmt.Sprintf("http://%s:%d", host, AgentPort)
+	return fmt.Sprintf("https://%s:%d", host, AgentPort)
 }

--- a/internal/local_backup/local_backup.go
+++ b/internal/local_backup/local_backup.go
@@ -49,7 +49,7 @@ func (u *LocalBackup) GetLatestLocalBackup(ctx context.Context) (string, error) 
 	}
 
 	if len(localBackups.Backups) == 0 {
-		return "", errors.New("There are no local backups")
+		return "", errors.New("there are no local backups")
 	}
 
 	return localBackups.Backups[len(localBackups.Backups)-1], nil

--- a/internal/mtls/client_registry.go
+++ b/internal/mtls/client_registry.go
@@ -14,7 +14,6 @@ import (
 type HttpClientRegistry interface {
 	Create(ctx context.Context, kubeClient client.Client, ns string) (*http.Client, error)
 	GetOrCreate(ctx context.Context, kubeClient client.Client, ns string) (*http.Client, error)
-	Get(ns string) (*http.Client, bool)
 	Delete(ns string)
 }
 
@@ -27,7 +26,7 @@ type httpClientRegistry struct {
 }
 
 func (cr *httpClientRegistry) Create(ctx context.Context, kubeClient client.Client, ns string) (*http.Client, error) {
-	c, ok := cr.Get(ns)
+	c, ok := cr.get(ns)
 	if ok {
 		return c, nil
 	}
@@ -48,14 +47,14 @@ func (cr *httpClientRegistry) GetOrCreate(ctx context.Context, kubeClient client
 	return cr.Create(ctx, kubeClient, ns)
 }
 
-func (cr *httpClientRegistry) Get(ns string) (*http.Client, bool) {
+func (cr *httpClientRegistry) Delete(ns string) {
+	cr.clients.Delete(types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: ns})
+}
+
+func (cr *httpClientRegistry) get(ns string) (*http.Client, bool) {
 	nn := types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: ns}
 	if v, ok := cr.clients.Load(nn); ok {
 		return v.(*http.Client), true
 	}
 	return nil, false
-}
-
-func (cr *httpClientRegistry) Delete(ns string) {
-	cr.clients.Delete(types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: ns})
 }

--- a/internal/mtls/client_registry.go
+++ b/internal/mtls/client_registry.go
@@ -13,6 +13,7 @@ import (
 
 type HttpClientRegistry interface {
 	Create(ctx context.Context, kubeClient client.Client, ns string) (*http.Client, error)
+	GetOrCreate(ctx context.Context, kubeClient client.Client, ns string) (*http.Client, error)
 	Get(ns string) (*http.Client, bool)
 	Delete(ns string)
 }
@@ -37,6 +38,14 @@ func (cr *httpClientRegistry) Create(ctx context.Context, kubeClient client.Clie
 	}
 	cr.clients.Store(nn, c)
 	return c, nil
+}
+
+func (cr *httpClientRegistry) GetOrCreate(ctx context.Context, kubeClient client.Client, ns string) (*http.Client, error) {
+	nn := types.NamespacedName{Name: n.MTLSCertSecretName, Namespace: ns}
+	if v, ok := cr.clients.Load(nn); ok {
+		return v.(*http.Client), nil
+	}
+	return cr.Create(ctx, kubeClient, ns)
 }
 
 func (cr *httpClientRegistry) Get(ns string) (*http.Client, bool) {


### PR DESCRIPTION
## User Impact

Fix the error `failed to get MTLS client` that can occur after the operator restart
