### PR TITLE
[CN-1124] Expose WAN port for Member service

### DIFF
--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -474,10 +474,7 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 		return nil
 	}
 
-	isAddWANPort := false
-	if h.Spec.AdvancedNetwork == nil || len(h.Spec.AdvancedNetwork.WAN) == 0 {
-		isAddWANPort = true
-	}
+	isAddWANPort := h.Spec.AdvancedNetwork == nil || len(h.Spec.AdvancedNetwork.WAN) == 0
 	for i := 0; i < int(*h.Spec.ClusterSize); i++ {
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -57,8 +57,7 @@ var DefaultProperties = map[string]string{
 	"hazelcast.cluster.version.auto.upgrade.enabled": "true",
 	// https://docs.hazelcast.com/hazelcast/5.3/kubernetes/kubernetes-auto-discovery#configuration
 	// We added the following properties to here with their default values, because DefaultProperties cannot be overridden
-	"hazelcast.persistence.auto.cluster.state":          "true",
-	"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+	"hazelcast.persistence.auto.cluster.state": "true",
 }
 
 func (r *HazelcastReconciler) executeFinalizer(ctx context.Context, h *hazelcastv1alpha1.Hazelcast, logger logr.Logger) error {

--- a/controllers/hazelcast/hazelcast_resources.go
+++ b/controllers/hazelcast/hazelcast_resources.go
@@ -474,6 +474,10 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 		return nil
 	}
 
+	isAddWANPort := false
+	if h.Spec.AdvancedNetwork == nil || len(h.Spec.AdvancedNetwork.WAN) == 0 {
+		isAddWANPort = true
+	}
 	for i := 0; i < int(*h.Spec.ClusterSize); i++ {
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -501,7 +505,7 @@ func (r *HazelcastReconciler) reconcileServicePerPod(ctx context.Context, h *haz
 				delete(service.Labels, n.ServiceEndpointTypeLabelName)
 			}
 
-			service.Spec.Ports = util.EnrichServiceNodePorts([]corev1.ServicePort{clientPort()}, service.Spec.Ports)
+			service.Spec.Ports = util.EnrichServiceNodePorts(servicePerPodPort(isAddWANPort), service.Spec.Ports)
 			service.Spec.Type = h.Spec.ExposeExternally.MemberAccessServiceType()
 
 			return nil
@@ -582,12 +586,21 @@ func (r *HazelcastReconciler) reconcileHazelcastEndpoints(ctx context.Context, h
 				}
 			}
 		case n.ServiceEndpointTypeMemberLabelValue:
-			endpointNn := types.NamespacedName{
-				Name:      svc.Name,
-				Namespace: svc.Namespace,
-			}
-			hzEndpoints = []*hazelcastv1alpha1.HazelcastEndpoint{
-				hazelcastEndpointFromService(endpointNn, h, hazelcastv1alpha1.HazelcastEndpointTypeMember, clientPort().Port),
+			for _, port := range svc.Spec.Ports {
+				endpointNn := types.NamespacedName{
+					Name:      svc.Name,
+					Namespace: svc.Namespace,
+				}
+				// For the default Wan port when the WANConfig is not configured under the AdvancedNetwork config
+				if port.Name == n.WanDefaultPortName {
+					endpointNn.Name = fmt.Sprintf("%s-%s", endpointNn.Name, "wan")
+					hzEndpoints = append(hzEndpoints, hazelcastEndpointFromService(endpointNn, h, hazelcastv1alpha1.HazelcastEndpointTypeWAN, port.Port))
+					continue
+				}
+				if port.Name == n.HazelcastPortName {
+					hzEndpoints = append(hzEndpoints, hazelcastEndpointFromService(endpointNn, h, hazelcastv1alpha1.HazelcastEndpointTypeMember, port.Port))
+					continue
+				}
 			}
 		case n.ServiceEndpointTypeWANLabelValue:
 			for i, port := range svc.Spec.Ports {
@@ -747,6 +760,16 @@ func servicePerPodLabels(h *hazelcastv1alpha1.Hazelcast) map[string]string {
 	ls := labels(h)
 	ls[n.ServicePerPodLabelName] = n.LabelValueTrue
 	return ls
+}
+
+func servicePerPodPort(isAddWANPort bool) []v1.ServicePort {
+	p := []corev1.ServicePort{
+		clientPort(),
+	}
+	if isAddWANPort {
+		p = append(p, defaultWANPort())
+	}
+	return p
 }
 
 func hazelcastPort(isAddWANPort bool) []v1.ServicePort {

--- a/test/e2e/expose_externally_test.go
+++ b/test/e2e/expose_externally_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Hazelcast CR with expose externally feature", Group("expose_ex
 					matched = true
 					service := getServiceOfMember(ctx, hzLookupKey.Namespace, member)
 					Expect(service.Spec.Type).Should(Equal(corev1.ServiceTypeNodePort))
-					Expect(service.Spec.Ports).Should(HaveLen(1))
+					Expect(service.Spec.Ports).Should(HaveLen(2))
 					nodePort := service.Spec.Ports[0].NodePort
 					node := getNodeOfMember(ctx, hzLookupKey.Namespace, member)
 					externalAddresses := filterNodeAddressesByExternalIP(node.Status.Addresses)

--- a/test/integration/hazelcast_properties_test.go
+++ b/test/integration/hazelcast_properties_test.go
@@ -51,10 +51,9 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
-				"hazelcast.graceful.shutdown.max.wait":              "300",
-				"hazelcast.persistence.auto.cluster.state":          "true",
-				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.graceful.shutdown.max.wait":           "300",
+				"hazelcast.persistence.auto.cluster.state":       "true",
 			}))
 		})
 
@@ -64,9 +63,8 @@ var _ = Describe("Hazelcast Properties", func() {
 				Spec:       test.HazelcastSpec(defaultHazelcastSpecValues(), ee),
 			}
 			hz.Spec.Properties = map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "false",
-				"hazelcast.persistence.auto.cluster.state":          "false",
-				"hazelcast.persistence.auto.cluster.state.strategy": "FROZEN",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "false",
+				"hazelcast.persistence.auto.cluster.state":       "false",
 			}
 
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
@@ -82,9 +80,8 @@ var _ = Describe("Hazelcast Properties", func() {
 
 				return a.Hazelcast.Properties
 			}, timeout, interval).Should(Equal(map[string]string{
-				"hazelcast.cluster.version.auto.upgrade.enabled":    "true",
-				"hazelcast.persistence.auto.cluster.state":          "true",
-				"hazelcast.persistence.auto.cluster.state.strategy": "NO_MIGRATION",
+				"hazelcast.cluster.version.auto.upgrade.enabled": "true",
+				"hazelcast.persistence.auto.cluster.state":       "true",
 			}))
 		})
 	})

--- a/test/integration/hazelcastendpoint_test.go
+++ b/test/integration/hazelcastendpoint_test.go
@@ -336,7 +336,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 			services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 			setLoadBalancerIngressAddress(ctx, services)
 			expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)

--- a/test/integration/hazelcastendpoint_test.go
+++ b/test/integration/hazelcastendpoint_test.go
@@ -225,7 +225,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -247,7 +247,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -269,7 +269,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 				Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 				services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+				hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 				setLoadBalancerIngressAddress(ctx, services)
 				expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)
@@ -368,7 +368,7 @@ var _ = Describe("HazelcastEndpoint CR", func() {
 			Expect(k8sClient.Create(context.Background(), hz)).Should(Succeed())
 
 			services := expectLenOfHazelcastEndpointServices(ctx, hz, 4)
-			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 5)
+			hzEndpoints := expectLenOfHazelcastEndpoints(ctx, hz, 8)
 
 			setLoadBalancerIngressAddress(ctx, services)
 			expectHazelcastEndpointHasAddress(ctx, hzEndpoints, 10*time.Second)


### PR DESCRIPTION
## Description

We decided to expose default wan port(5710) for Member services like we did for discovery service. With the additional port for Member services, corresponding `hazelcastendpoints` with the type `WAN` are created directly.

### Old version

```yaml
exposeExternally:
  type: Smart
  discoveryServiceType: LoadBalancer
  memberAccess: NodePortExternalIP
```

```sh
$ k get svc
NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                       AGE
hazelcast        LoadBalancer   10.164.15.134   35.226.75.101   5701:31425/TCP,5702:30574/TCP,8081:30858/TCP,5710:31016/TCP   75s
hazelcast-0      NodePort       10.164.5.33     <none>          5701:31001/TCP                                                75s
hazelcast-1      NodePort       10.164.3.158    <none>          5701:30343/TCP                                                75s
hazelcast-2      NodePort       10.164.5.104    <none>          5701:32602/TCP                                                75s
```

```sh
$ k get hazelcastendpoints.hazelcast.com
NAME              TYPE        ADDRESS
hazelcast         Discovery   35.226.75.101:5701
hazelcast-0       Member      34.31.31.174:31001
hazelcast-1       Member      34.31.31.174:30343
hazelcast-2       Member      34.134.146.100:32602
hazelcast-wan     WAN         35.226.75.101:5710
```


### New Version

_Notice additional  `port` for `WAN` on each `Member service` and corresponding `hazelcastEndpoints`._

```yaml
  exposeExternally:
    type: Smart
    discoveryServiceType: LoadBalancer
    memberAccess: NodePortExternalIP
```

```sh
$ k get svc
NAME                             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                       AGE
hazelcast                        LoadBalancer   10.164.15.134   35.226.75.101   5701:31425/TCP,5702:30574/TCP,8081:30858/TCP,5710:31016/TCP   75s
hazelcast-0                      NodePort       10.164.5.33     <none>          5701:31001/TCP,5710:31375/TCP                                 75s
hazelcast-1                      NodePort       10.164.3.158    <none>          5701:30343/TCP,5710:31322/TCP                                 75s
hazelcast-2                      NodePort       10.164.5.104    <none>          5701:32602/TCP,5710:32292/TCP                                 75s
```

```sh
$ k get hazelcastendpoints.hazelcast.com
NAME              TYPE        ADDRESS
hazelcast         Discovery   35.226.75.101:5701
hazelcast-0       Member      34.31.31.174:31001
hazelcast-0-wan   WAN         34.31.31.174:31375
hazelcast-1       Member      34.31.31.174:30343
hazelcast-1-wan   WAN         34.31.31.174:31322
hazelcast-2       Member      34.134.146.100:32602
hazelcast-2-wan   WAN         34.134.146.100:32292
hazelcast-wan     WAN         35.226.75.101:5710
```

## User Impact

Users can now use the default `WAN` port for each member when the Hazelcast cluster is exposed as the type `Smart`. Also users will see the corresponding `hazelcastendpoints` resources for the newly exposed `WAN` port. 
