### PR TITLE
Removed redundant NS creation command

### DIFF
--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -9,6 +9,7 @@ env:
   GAR_REGION: us-east1
   GAR_PROJECT: hazelcast-33
   GAR_REPO: hazelcast-platform-operator
+  NAMESPACE: test-operator-ee
 
 jobs:
   prepare-env:
@@ -65,15 +66,7 @@ jobs:
 
           eksctl create iamserviceaccount \
             --name aws-iam-sa \
-            --namespace test-operator-os \
-            --cluster ${CLUSTER_NAME} \
-            --role-name ${ROLE_NAME}-os \
-            --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess \
-            --approve
-
-          eksctl create iamserviceaccount \
-            --name aws-iam-sa \
-            --namespace test-operator-ee \
+            --namespace ${NAMESPACE} \
             --cluster ${CLUSTER_NAME} \
             --role-name ${ROLE_NAME}-ee \
             --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess \
@@ -89,7 +82,7 @@ jobs:
       gh_run_id: ${{ github.run_id }}
       gh_run_number: ${{ github.run_number }}
       gh_sha: ${{ github.sha }}
-      namespaces: "test-operator-os, test-operator-ee"
+      namespaces: "test-operator-ee"
 
   get-image:
     name: Get Image
@@ -151,13 +144,8 @@ jobs:
     defaults:
       run:
         shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        edition: ["os", "ee"]
     env:
-      NAMESPACE: test-operator-${{ matrix.edition }}
-      RELEASE_NAME: hp-${{ matrix.edition }}-${{ github.run_id }}
+      RELEASE_NAME: hp-ee-${{ github.run_id }}
       IMG: ${{ needs.get-image.outputs.IMG }}
     steps:
       - name: Checkout
@@ -229,13 +217,11 @@ jobs:
       - name: Deploy Operator to EKS
         run: |
           kubectl config set-context --current --namespace=${NAMESPACE}
-
           DEPLOY_NAME=${RELEASE_NAME}-hazelcast-platform-operator
           make install-operator NAMESPACE=${NAMESPACE} IMG=${IMG} RELEASE_NAME=$RELEASE_NAME
           kubectl rollout status deployment $DEPLOY_NAME
 
       - name: Create secrets
-        if: matrix.edition == 'ee'
         run: |
           kubectl create secret generic hazelcast-license-key \
             --namespace ${NAMESPACE} --from-literal=license-key=${{ env.HZ_LICENSE_KEY }}
@@ -248,20 +234,13 @@ jobs:
           kubectl create secret generic br-secret-az --namespace ${NAMESPACE} \
             --from-literal=storage-account=operatortest \
             --from-literal=storage-key=${{ env.AZURE_STORAGE_KEY }}
-
-      - name: Create secret for both OS and EE tests
-        run: |
+          
           kubectl create secret generic br-secret-gcp --namespace ${NAMESPACE} --from-literal=google-credentials-path='${{ env.GKE_SA_KEY }}'
 
       - name: Run Hazelcast E2E tests on EKS
         id: e2e-test
         run: |
-          case ${{ matrix.edition }} in
-            os) GO_TEST_FLAGS=-ee=false;;
-            ee) GO_TEST_FLAGS=-ee=true;;
-            *)  echo Unexpected edition: ${{ matrix.edition }} && exit 1;;
-          esac
-          make test-e2e GO_TEST_FLAGS=${GO_TEST_FLAGS} NAMESPACE=${NAMESPACE} RELEASE_NAME=${RELEASE_NAME} REPORT_SUFFIX=${{ matrix.edition }}_01 WORKFLOW_ID=eks
+          make test-e2e GO_TEST_FLAGS=-ee=true NAMESPACE=${NAMESPACE} RELEASE_NAME=${RELEASE_NAME} REPORT_SUFFIX=ee_01 WORKFLOW_ID=eks
 
       - name: Check if the operator pod has not restarted
         run: |
@@ -326,7 +305,7 @@ jobs:
     with:
       cluster_name: ${{ needs.prepare-env.outputs.CLUSTER_NAME }}
       cluster_type: eks
-      namespaces: "test-operator-os,test-operator-ee,grafana"
+      namespaces: "test-operator-ee,grafana"
 
   delete-cluster:
     name: Delete EKS cluster

--- a/.github/workflows/e2e-eks.yaml
+++ b/.github/workflows/e2e-eks.yaml
@@ -228,7 +228,6 @@ jobs:
 
       - name: Deploy Operator to EKS
         run: |
-          kubectl create namespace ${NAMESPACE}
           kubectl config set-context --current --namespace=${NAMESPACE}
 
           DEPLOY_NAME=${RELEASE_NAME}-hazelcast-platform-operator


### PR DESCRIPTION
## Description
Fix the "Error from server (AlreadyExists): namespaces "test-operator-os" already exists" since "eksctl create iamserviceaccount --namespace test-operator-os" command creates namespace if it doesn't exist.

https://eksctl.io/usage/iamserviceaccounts/#:~:text=If%20the%20namespace%20doesn%27t%20exist%20already%2C%20it%20will%20be%20created.

