### PR TITLE
[CN-1329]: Add cannot be empty validation for env var name

### DIFF
--- a/api/v1alpha1/hazelcast_types.go
+++ b/api/v1alpha1/hazelcast_types.go
@@ -197,6 +197,7 @@ type HazelcastSpec struct {
 	// Env configuration of environment variables
 	// +optional
 	// +kubebuilder:validation:XValidation:message="Environment variables cannot start with 'HZ_'. Use customConfigCmName to configure Hazelcast.",rule="self.all(env, env.name.startsWith('HZ_') == false)"
+	// +kubebuilder:validation:XValidation:message="Environment variable name cannot be empty.",rule="self.all(env, env.name != '')"
 	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 

--- a/config/crd/bases/hazelcast.com_hazelcasts.yaml
+++ b/config/crd/bases/hazelcast.com_hazelcasts.yaml
@@ -371,6 +371,8 @@ spec:
                 - message: Environment variables cannot start with 'HZ_'. Use customConfigCmName
                     to configure Hazelcast.
                   rule: self.all(env, env.name.startsWith('HZ_') == false)
+                - message: Environment variable name cannot be empty.
+                  rule: self.all(env, env.name != '')
               executorServices:
                 description: Java Executor Service configurations, see https://docs.hazelcast.com/hazelcast/latest/computing/executor-service
                 items:

--- a/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
+++ b/helm-charts/hazelcast-platform-operator/charts/hazelcast-platform-operator-crds/templates/all-crds.yaml
@@ -750,6 +750,8 @@ spec:
                 - message: Environment variables cannot start with 'HZ_'. Use customConfigCmName
                     to configure Hazelcast.
                   rule: self.all(env, env.name.startsWith('HZ_') == false)
+                - message: Environment variable name cannot be empty.
+                  rule: self.all(env, env.name != '')
               executorServices:
                 description: Java Executor Service configurations, see https://docs.hazelcast.com/hazelcast/latest/computing/executor-service
                 items:

--- a/test/integration/hazelcast_test.go
+++ b/test/integration/hazelcast_test.go
@@ -1185,6 +1185,25 @@ var _ = Describe("Hazelcast CR", func() {
 				Expect(err.Error()).Should(ContainSubstring("Environment variables cannot start with 'HZ_'. Use customConfigCmName to configure Hazelcast."))
 			})
 		})
+		When("it is configured with empty env var name", func() {
+			It("should give an error", func() {
+				spec := test.HazelcastSpec(defaultHazelcastSpecValues())
+				spec.Env = []corev1.EnvVar{
+					{
+						Name:  "",
+						Value: "VAL",
+					},
+				}
+				hz := &hazelcastv1alpha1.Hazelcast{
+					ObjectMeta: randomObjectMeta(namespace),
+					Spec:       spec,
+				}
+
+				err := k8sClient.Create(context.Background(), hz)
+				Expect(err).ShouldNot(BeNil())
+				Expect(err.Error()).Should(ContainSubstring("Environment variable name cannot be empty"))
+			})
+		})
 	})
 
 	Context("with Resources parameters", func() {


### PR DESCRIPTION
## Description

This PR adds cannot be empty validation to env var name.

## User Impact

Users won't be able to create CR's which has env var name empty in it.